### PR TITLE
Fix WASM object stride and PR Pages deployment

### DIFF
--- a/.github/workflows/plot-pages.yaml
+++ b/.github/workflows/plot-pages.yaml
@@ -4,8 +4,6 @@ name: Deploy static content to Pages
 # GitHub Actions requires this key even though YAML 1.1 treats it as truthy.
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
-    branches: ["main"]
   push:
     branches: ["main"]
   workflow_dispatch:

--- a/src/legoapi/world/world.cpp
+++ b/src/legoapi/world/world.cpp
@@ -613,7 +613,8 @@ after_area:
         goto abort;
 
     // API object system
-    world->api_object_sys = (APIOBJECTSYS_s *)APIObjectSysInit(0x10e4, &world->giz_buffer, &world->unknown_0108);
+    world->api_object_sys =
+        (APIOBJECTSYS_s *)APIObjectSysInit(sizeof(GameObject_s), &world->giz_buffer, &world->unknown_0108);
     if (abort_load != 0)
         goto abort;
 


### PR DESCRIPTION
The API object system allocated each `GameObject_s` with the Android ABI's fixed `0x10e4` stride. The WASM layout is larger, so the second object was read at the wrong address and the Cantina crashed in `GameDrawCharacterModel` with an out-of-bounds memory access.

Use `sizeof(GameObject_s)` for the allocation stride so each build uses its actual layout. The Android target still compiles this to `0x10e4`, leaving matching output unchanged.

The Pages workflow also runs only for pushes to `main` or manual dispatches, preventing Pages deployments from pull-request CI.

Validation:

- `bazel build --config=wasm //src:saga_wasm`
- Loaded a new game into the Cantina and moved in the integrated browser without runtime errors
- `bazel build --config=target //src:saga_target`
- `bazel test //scripts/checks:checks`
- Parsed `.github/workflows/plot-pages.yaml` successfully
