### PR TITLE
Restore door callbacks and resume rendering after exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # _saga_
 
-![Progress](https://img.shields.io/badge/matching-16.18%25-red)
+![Progress](https://img.shields.io/badge/matching-16.19%25-red)
 [![Bazel build](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml/badge.svg)](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml)
 [![Discord](https://img.shields.io/discord/1467775700894224555?color=%235865F2&logo=discord&logoColor=%23FFFFFF)](https://discord.gg/2HJuMtzA7q)
 
@@ -64,15 +64,15 @@ See https://ttdecomp.github.io/saga/
 | `gameframework` | 84.0% | 5.9% |
 | `gamelib` | 6.8% | 4.3% |
 | `java` | 10.5% | 0.0% |
-| `legoapi` | 15.4% | 7.1% |
+| `legoapi` | 15.4% | 7.2% |
 | `legoapi/actions` | 6.6% | 1.3% |
 | `legoapi/ai` | 13.0% | 0.0% |
 | `legoapi/audio` | 7.8% | 5.7% |
 | `legoapi/characters` | 11.3% | 4.0% |
 | `legoapi/core` | 24.9% | 6.6% |
 | `legoapi/cutscenes` | 11.3% | 2.3% |
-| `legoapi/gizmo` | 12.3% | 2.9% |
-| `legoapi/gizmos` | 40.2% | 27.1% |
+| `legoapi/gizmo` | 12.5% | 2.9% |
+| `legoapi/gizmos` | 40.2% | 28.0% |
 | `legoapi/items` | 9.1% | 3.9% |
 | `legoapi/menus` | 15.8% | 6.4% |
 | `legoapi/misc` | 8.9% | 3.5% |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # _saga_
 
-![Progress](https://img.shields.io/badge/matching-16.19%25-red)
+![Progress](https://img.shields.io/badge/matching-16.21%25-red)
 [![Bazel build](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml/badge.svg)](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml)
 [![Discord](https://img.shields.io/discord/1467775700894224555?color=%235865F2&logo=discord&logoColor=%23FFFFFF)](https://discord.gg/2HJuMtzA7q)
 
@@ -77,7 +77,7 @@ See https://ttdecomp.github.io/saga/
 | `legoapi/menus` | 15.8% | 6.4% |
 | `legoapi/misc` | 8.9% | 3.5% |
 | `legoapi/props` | 28.4% | 2.2% |
-| `legoapi/render` | 12.0% | 6.2% |
+| `legoapi/render` | 12.1% | 6.2% |
 | `legoapi/world` | 23.9% | 6.4% |
 | `legogame` | 50.3% | 0.0% |
 | `nu2api` | 33.0% | 14.7% |

--- a/matching.json
+++ b/matching.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "measures": {
-    "fuzzy_match_percent": 16.190672,
+    "fuzzy_match_percent": 16.205053,
     "total_code": "4722419",
     "matched_code": "38296",
     "matched_code_percent": 0.81094027,
@@ -75602,7 +75602,7 @@
           "address": 4769088,
           "offset": 3879120,
           "size": 663,
-          "match_percent": 60.309525
+          "match_percent": 59.531746
         },
         {
           "name": "_Z15GrabStillScreenv",
@@ -75610,7 +75610,7 @@
           "address": 4770896,
           "offset": 3880928,
           "size": 81,
-          "match_percent": 93.611115
+          "match_percent": 99.72222
         },
         {
           "name": "_Z14NeedScreenGrabi",
@@ -75634,7 +75634,7 @@
           "address": 4771600,
           "offset": 3881632,
           "size": 943,
-          "match_percent": 1.981132
+          "match_percent": 74.03302
         }
       ]
     },

--- a/matching.json
+++ b/matching.json
@@ -1,16 +1,16 @@
 {
   "schema_version": 1,
   "measures": {
-    "fuzzy_match_percent": 16.17962,
+    "fuzzy_match_percent": 16.190672,
     "total_code": "4722419",
-    "matched_code": "38126",
-    "matched_code_percent": 0.80734044,
+    "matched_code": "38296",
+    "matched_code_percent": 0.81094027,
     "total_data": "14606528",
     "matched_data": "543696",
     "matched_data_percent": 3.722281,
     "total_functions": 13459,
-    "matched_functions": 965,
-    "matched_functions_percent": 7.1699233,
+    "matched_functions": 970,
+    "matched_functions_percent": 7.207073,
     "total_units": 1
   },
   "text": {
@@ -14347,7 +14347,7 @@
     {
       "name": "MechInputTouch/MechAutoJumpManager.cpp.o",
       "source": "src/MechInputTouch/MechAutoJumpManager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutoJumpManager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutoJumpManager.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechAutoJumpManager.cpp",
@@ -14474,7 +14474,7 @@
     {
       "name": "MechInputTouch/MechAutofireAddon.cpp.o",
       "source": "src/MechInputTouch/MechAutofireAddon.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutofireAddon.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutofireAddon.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechAutofireAddon.cpp",
@@ -14537,7 +14537,7 @@
     {
       "name": "MechInputTouch/MechEdgeStopAddon.cpp.o",
       "source": "src/MechInputTouch/MechEdgeStopAddon.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechEdgeStopAddon.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechEdgeStopAddon.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechEdgeStopAddon.cpp",
@@ -14600,7 +14600,7 @@
     {
       "name": "MechInputTouch/MechInputTouch.cpp.o",
       "source": "src/MechInputTouch/MechInputTouch.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouch.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouch.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouch.cpp",
@@ -14871,7 +14871,7 @@
     {
       "name": "MechInputTouch/MechInputTouchBonusCavalryController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchBonusCavalryController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchBonusCavalryController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchBonusCavalryController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchBonusCavalryController.cpp",
@@ -14966,7 +14966,7 @@
     {
       "name": "MechInputTouch/MechInputTouchButton.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchButton.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchButton.cpp",
@@ -15245,7 +15245,7 @@
     {
       "name": "MechInputTouch/MechInputTouchButton_stubs.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchButton_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton_stubs.o",
       "functions": [
         {
           "name": "_ZNK29MechInputTouchMainDummyButton9IsPressedEv",
@@ -15260,7 +15260,7 @@
     {
       "name": "MechInputTouch/MechInputTouchContextTasks.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchContextTasks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchContextTasks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchContextTasks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchContextTasks.cpp",
@@ -15971,7 +15971,7 @@
     {
       "name": "MechInputTouch/MechInputTouchDeathStarTurretController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchDeathStarTurretController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchDeathStarTurretController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchDeathStarTurretController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchDeathStarTurretController.cpp",
@@ -16074,7 +16074,7 @@
     {
       "name": "MechInputTouch/MechInputTouchGestureBasedController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchGestureBasedController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureBasedController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureBasedController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchGestureBasedController.cpp",
@@ -16281,7 +16281,7 @@
     {
       "name": "MechInputTouch/MechInputTouchGestureTracker.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchGestureTracker.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureTracker.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureTracker.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchGestureTracker.cpp",
@@ -16432,7 +16432,7 @@
     {
       "name": "MechInputTouch/MechInputTouchMainController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchMainController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMainController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMainController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchMainController.cpp",
@@ -16527,7 +16527,7 @@
     {
       "name": "MechInputTouch/MechInputTouchMenuController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchMenuController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMenuController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMenuController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchMenuController.cpp",
@@ -16670,7 +16670,7 @@
     {
       "name": "MechInputTouch/MechInputTouchPodraceController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchPodraceController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchPodraceController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchPodraceController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchPodraceController.cpp",
@@ -16765,7 +16765,7 @@
     {
       "name": "MechInputTouch/MechInputTouchSpeederChaseBikeController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchSpeederChaseBikeController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchSpeederChaseBikeController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchSpeederChaseBikeController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchSpeederChaseBikeController.cpp",
@@ -16916,7 +16916,7 @@
     {
       "name": "MechInputTouch/MechInputTouchVirtualConsoleController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchVirtualConsoleController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchVirtualConsoleController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchVirtualConsoleController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchVirtualConsoleController.cpp",
@@ -17059,7 +17059,7 @@
     {
       "name": "MechInputTouch/MechJumpAutopilotAddon.cpp.o",
       "source": "src/MechInputTouch/MechJumpAutopilotAddon.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechJumpAutopilotAddon.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechJumpAutopilotAddon.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechJumpAutopilotAddon.cpp",
@@ -17194,7 +17194,7 @@
     {
       "name": "MechInputTouch/MechObjectInterface.cpp.o",
       "source": "src/MechInputTouch/MechObjectInterface.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechObjectInterface.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechObjectInterface.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechObjectInterface.cpp",
@@ -17257,7 +17257,7 @@
     {
       "name": "MechInputTouch/MechSystems.cpp.o",
       "source": "src/MechInputTouch/MechSystems.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechSystems.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechSystems.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechSystems.cpp",
@@ -17472,7 +17472,7 @@
     {
       "name": "MechInputTouch/MechTouchUIElements.cpp.o",
       "source": "src/MechInputTouch/MechTouchUIElements.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechTouchUIElements.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechTouchUIElements.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechTouchUIElements.cpp",
@@ -18071,7 +18071,7 @@
     {
       "name": "batman.cpp.o",
       "source": "src/batman.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_root/batman.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_root/batman.o",
       "functions": [
         {
           "name": "_ZL19NuSoundAppTerminatev",
@@ -18094,7 +18094,7 @@
     {
       "name": "editor/aieditor.cpp.o",
       "source": "src/editor/aieditor.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/aieditor.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/aieditor.o",
       "functions": [
         {
           "name": "aieditor_cbDrawAllToggle",
@@ -18349,7 +18349,7 @@
     {
       "name": "editor/area_editor.cpp.o",
       "source": "src/editor/area_editor.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/area_editor.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/area_editor.o",
       "functions": [
         {
           "name": "_ZL31areaEditor_cbAreaCylinderToggleP10eduimenu_sP10eduiitem_sj",
@@ -18412,7 +18412,7 @@
     {
       "name": "editor/creature_editor.cpp.o",
       "source": "src/editor/creature_editor.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/creature_editor.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/creature_editor.o",
       "functions": [
         {
           "name": "_ZL30creatureEditor_cbSetActivationP10eduimenu_sP10eduiitem_sj",
@@ -18787,7 +18787,7 @@
     {
       "name": "editor/edlevelall.cpp.o",
       "source": "src/editor/edlevelall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/edlevelall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edlevelall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_edlevelall.cpp",
@@ -20074,7 +20074,7 @@
     {
       "name": "editor/edlevelall_stubs.cpp.o",
       "source": "src/editor/edlevelall_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/edlevelall_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edlevelall_stubs.o",
       "functions": [
         {
           "name": "_ZN10BaseEditor10InitialiseER9variptr_uS1_i",
@@ -20185,7 +20185,7 @@
     {
       "name": "editor/edpath.cpp.o",
       "source": "src/editor/edpath.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/edpath.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edpath.o",
       "functions": [
         {
           "name": "_ZL18ParseAIPathCnxFlagPc",
@@ -20584,7 +20584,7 @@
     {
       "name": "editor/edtoolsall.cpp.o",
       "source": "src/editor/edtoolsall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/edtoolsall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edtoolsall.o",
       "functions": [
         {
           "name": "_Z21DumpAttributeBindingsv",
@@ -20719,7 +20719,7 @@
     {
       "name": "editor/locator_editor.cpp.o",
       "source": "src/editor/locator_editor.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/locator_editor.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/locator_editor.o",
       "functions": [
         {
           "name": "_ZL14CreateCreatureiP7nuvec_si",
@@ -20958,7 +20958,7 @@
     {
       "name": "gameapi/ai/aisys/aiscript.cpp.o",
       "source": "src/gameapi/ai/aisys/aiscript.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/aiscript.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/aiscript.o",
       "functions": [
         {
           "name": "_ZL27AiParseExpressionNameLoopupPcPfPi",
@@ -21229,7 +21229,7 @@
     {
       "name": "gameapi/ai/aisys/aistate.cpp.o",
       "source": "src/gameapi/ai/aisys/aistate.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/aistate.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/aistate.o",
       "functions": [
         {
           "name": "AIStateFind",
@@ -21244,7 +21244,7 @@
     {
       "name": "gameapi/ai/aisys/aisys.cpp.o",
       "source": "src/gameapi/ai/aisys/aisys.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/aisys.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/aisys.o",
       "functions": [
         {
           "name": "_ZL18Condition_GlynTestP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPcPv",
@@ -23347,7 +23347,7 @@
     {
       "name": "gameapi/ai/aisys/cc.cpp.o",
       "source": "src/gameapi/ai/aisys/cc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/cc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/cc.o",
       "functions": [
         {
           "name": "_ZL10CC_variantP8nufpar_s",
@@ -24978,7 +24978,7 @@
     {
       "name": "gameapi/ai/aisys/gameai_actions.cpp.o",
       "source": "src/gameapi/ai/aisys/gameai_actions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_actions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_actions.o",
       "functions": [
         {
           "name": "_ZL25Condition_PrefersBrawlingP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPcPv",
@@ -27089,7 +27089,7 @@
     {
       "name": "gameapi/ai/gameai_bt.cpp.o",
       "source": "src/gameapi/ai/gameai_bt.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_bt.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_bt.o",
       "functions": [
         {
           "name": "_ZL12BT_nodeflectP8nufpar_s",
@@ -27296,7 +27296,7 @@
     {
       "name": "gameapi/ai/gameai_cs.cpp.o",
       "source": "src/gameapi/ai/gameai_cs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_cs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_cs.o",
       "functions": [
         {
           "name": "_ZL9CS_no_fogP8nufpar_s",
@@ -27639,7 +27639,7 @@
     {
       "name": "gameapi/ai/gameai_d.cpp.o",
       "source": "src/gameapi/ai/gameai_d.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_d.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_d.o",
       "functions": [
         {
           "name": "_ZL19D_cam_lookatplayersP8nufpar_s",
@@ -27758,7 +27758,7 @@
     {
       "name": "gameapi/ai/gameai_grab.cpp.o",
       "source": "src/gameapi/ai/gameai_grab.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_grab.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_grab.o",
       "functions": [
         {
           "name": "_ZL13Grab_invert_xP8nufpar_s",
@@ -27829,7 +27829,7 @@
     {
       "name": "gameapi/ai/gameai_sockpar.cpp.o",
       "source": "src/gameapi/ai/gameai_sockpar.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_sockpar.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_sockpar.o",
       "functions": [
         {
           "name": "_ZL14SockParCircuitP8nufpar_sPv",
@@ -28204,7 +28204,7 @@
     {
       "name": "gameapi/ai/gameai_tel.cpp.o",
       "source": "src/gameapi/ai/gameai_tel.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_tel.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_tel.o",
       "functions": [
         {
           "name": "_ZL9Tel_1_wayP8nufpar_s",
@@ -28291,7 +28291,7 @@
     {
       "name": "gameapi/edtools/edanimall.cpp.o",
       "source": "src/gameapi/edtools/edanimall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edanimall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edanimall.o",
       "functions": [
         {
           "name": "_ZL19edanimcbSetSwitchIdP10eduimenu_sP10eduiitem_sj",
@@ -28506,7 +28506,7 @@
     {
       "name": "gameapi/edtools/edanimcallbacks.cpp.o",
       "source": "src/gameapi/edtools/edanimcallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edanimcallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edanimcallbacks.o",
       "functions": [
         {
           "name": "_ZL26edgizforce_ReadAnimSetDataP13GAMEANIMOBJ_sh",
@@ -28793,7 +28793,7 @@
     {
       "name": "gameapi/edtools/edbriall.cpp.o",
       "source": "src/gameapi/edtools/edbriall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edbriall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edbriall.o",
       "functions": [
         {
           "name": "_ZL20edbricbSetPlankCountP10eduimenu_sP10eduiitem_sj",
@@ -28912,7 +28912,7 @@
     {
       "name": "gameapi/edtools/edbricallbacks.cpp.o",
       "source": "src/gameapi/edtools/edbricallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edbricallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edbricallbacks.o",
       "functions": [
         {
           "name": "_ZL26edbricbSetPostInstanceTypeP10eduimenu_sP10eduiitem_sj",
@@ -29063,7 +29063,7 @@
     {
       "name": "gameapi/edtools/edfile.cpp.o",
       "source": "src/gameapi/edtools/edfile.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edfile.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edfile.o",
       "functions": [
         {
           "name": "EdFileSwapEndianess16",
@@ -29230,7 +29230,7 @@
     {
       "name": "gameapi/edtools/edgraall.cpp.o",
       "source": "src/gameapi/edtools/edgraall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edgraall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edgraall.o",
       "functions": [
         {
           "name": "_ZL22edgracbSetInstanceTypeP10eduimenu_sP10eduiitem_sj",
@@ -29493,7 +29493,7 @@
     {
       "name": "gameapi/edtools/edgracallbacks.cpp.o",
       "source": "src/gameapi/edtools/edgracallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edgracallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edgracallbacks.o",
       "functions": [
         {
           "name": "_ZL26edgracbToggleClumpReactiveP10eduimenu_sP10eduiitem_sj",
@@ -29692,7 +29692,7 @@
     {
       "name": "gameapi/edtools/edlevelall.cpp.o",
       "source": "src/gameapi/edtools/edlevelall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edlevelall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edlevelall.o",
       "functions": [
         {
           "name": "_ZN7EdClass15SerialiseObjectER8EdStreamPv",
@@ -29819,7 +29819,7 @@
     {
       "name": "gameapi/edtools/edmenucallbacks.cpp.o",
       "source": "src/gameapi/edtools/edmenucallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edmenucallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edmenucallbacks.o",
       "functions": [
         {
           "name": "_ZL18cbPtlChangeEmitVelP10eduimenu_sP10eduiitem_sj",
@@ -31338,7 +31338,7 @@
     {
       "name": "gameapi/edtools/edpartall.cpp.o",
       "source": "src/gameapi/edtools/edpartall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edpartall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edpartall.o",
       "functions": [
         {
           "name": "_ZL10edppRenderv",
@@ -31921,7 +31921,7 @@
     {
       "name": "gameapi/edtools/edpartcallbacks.cpp.o",
       "source": "src/gameapi/edtools/edpartcallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edpartcallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edpartcallbacks.o",
       "functions": [
         {
           "name": "_ZL24edptlcbApplyBounceOffsetP10eduimenu_sP10eduiitem_sj",
@@ -32752,7 +32752,7 @@
     {
       "name": "gameapi/edtools/edptlall.cpp.o",
       "source": "src/gameapi/edtools/edptlall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edptlall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edptlall.o",
       "functions": [
         {
           "name": "_ZL21edptlcbChangeDistortXP10eduimenu_sP10eduiitem_sj",
@@ -33111,7 +33111,7 @@
     {
       "name": "gameapi/edtools/edrtlall.cpp.o",
       "source": "src/gameapi/edtools/edrtlall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlall.o",
       "functions": [
         {
           "name": "_ZL13edrtlSaveUndov",
@@ -33342,7 +33342,7 @@
     {
       "name": "gameapi/edtools/edrtlcallbacks.cpp.o",
       "source": "src/gameapi/edtools/edrtlcallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlcallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlcallbacks.o",
       "functions": [
         {
           "name": "_ZL9edrtlUndov",
@@ -33637,7 +33637,7 @@
     {
       "name": "gameapi/edtools/edsplines.cpp.o",
       "source": "src/gameapi/edtools/edsplines.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edsplines.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edsplines.o",
       "functions": [
         {
           "name": "_Z12SplineLengthP11nugspline_si",
@@ -34068,7 +34068,7 @@
     {
       "name": "gameapi/edtools/edstubs.cpp.o",
       "source": "src/gameapi/edtools/edstubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edstubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edstubs.o",
       "functions": [
         {
           "name": "edanimRegisterBaseScene",
@@ -34179,7 +34179,7 @@
     {
       "name": "gameapi/edtools/edtoolsall.cpp.o",
       "source": "src/gameapi/edtools/edtoolsall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall.o",
       "functions": [
         {
           "name": "_Z24edanimPlayerAnimDistancei",
@@ -36522,7 +36522,7 @@
     {
       "name": "gameapi/edtools/edtoolsall_plain.cpp.o",
       "source": "src/gameapi/edtools/edtoolsall_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_plain.o",
       "functions": [
         {
           "name": "edanimParticleDestroy",
@@ -38481,7 +38481,7 @@
     {
       "name": "gameapi/edtools/edtoolsall_stubs.cpp.o",
       "source": "src/gameapi/edtools/edtoolsall_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_stubs.o",
       "functions": [
         {
           "name": "_Z24edpartLookupDebrisEffectPc",
@@ -38568,7 +38568,7 @@
     {
       "name": "gameapi/edtools/edui.c.o",
       "source": "src/gameapi/edtools/edui.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edui.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edui.o",
       "functions": [
         {
           "name": "eduicbInteractSel",
@@ -38975,7 +38975,7 @@
     {
       "name": "gameapi/edtools/edui_fnt.cpp.o",
       "source": "src/gameapi/edtools/edui_fnt.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edui_fnt.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edui_fnt.o",
       "functions": [
         {
           "name": "_ZL14eduiFntPrintExPviiiPcz",
@@ -38998,7 +38998,7 @@
     {
       "name": "gameapi/gui/apimenu.cpp.o",
       "source": "src/gameapi/gui/apimenu.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/apimenu.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/apimenu.o",
       "functions": [
         {
           "name": "_ZL17MenuInitHowToPlayP6MENU_s",
@@ -39293,7 +39293,7 @@
     {
       "name": "gameframework/saveload.cpp.o",
       "source": "src/gameframework/saveload.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameframework/saveload.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameframework/saveload.o",
       "functions": [
         {
           "name": "_Z8slotnamei",
@@ -39412,7 +39412,7 @@
     {
       "name": "gameframework/saveload_checksum.cpp.o",
       "source": "src/gameframework/saveload_checksum.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameframework/saveload_checksum.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameframework/saveload_checksum.o",
       "functions": [
         {
           "name": "ChecksumSaveData",
@@ -39427,7 +39427,7 @@
     {
       "name": "gameframework/saveload_extra.cpp.o",
       "source": "src/gameframework/saveload_extra.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameframework/saveload_extra.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameframework/saveload_extra.o",
       "functions": [
         {
           "name": "TriggerExtraDataSave",
@@ -39450,7 +39450,7 @@
     {
       "name": "gamelib/NewTerrain.cpp.o",
       "source": "src/gamelib/NewTerrain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/NewTerrain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/NewTerrain.o",
       "functions": [
         {
           "name": "_Z18NuVecCheckForSNANsP7nuvec_s",
@@ -39465,7 +39465,7 @@
     {
       "name": "gamelib/crc/crc.cpp.o",
       "source": "src/gamelib/crc/crc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/crc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/crc.o",
       "functions": [
         {
           "name": "CRC_Init",
@@ -39488,7 +39488,7 @@
     {
       "name": "gamelib/nuwind/nuwind.cpp.o",
       "source": "src/gamelib/nuwind/nuwind.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/nuwind.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/nuwind.o",
       "functions": [
         {
           "name": "NuWindInitialise",
@@ -39503,7 +39503,7 @@
     {
       "name": "gamelib/util/AndroidOBBUtils.cpp.o",
       "source": "src/gamelib/util/AndroidOBBUtils.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/AndroidOBBUtils.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/AndroidOBBUtils.o",
       "functions": [
         {
           "name": "_ZN15AndroidOBBUtils17LookupPackagePathEPcN26NuFileDeviceAndroidOBBType1TE",
@@ -39534,7 +39534,7 @@
     {
       "name": "gamelib/util/CRC16.cpp.o",
       "source": "src/gamelib/util/CRC16.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16.o",
       "functions": [
         {
           "name": "_ZN5CRC16C1Ev",
@@ -39573,7 +39573,7 @@
     {
       "name": "gamelib/util/CRC16_plain.cpp.o",
       "source": "src/gamelib/util/CRC16_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16_plain.o",
       "functions": [
         {
           "name": "CRC_Process",
@@ -39612,7 +39612,7 @@
     {
       "name": "gamelib/util/Ftp.cpp.o",
       "source": "src/gamelib/util/Ftp.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp.o",
       "functions": [
         {
           "name": "_ZN13NetFtpManager7ReceiveE10NetMessagehRK10NetAddress",
@@ -39811,7 +39811,7 @@
     {
       "name": "gamelib/util/Ftp_stubs.cpp.o",
       "source": "src/gamelib/util/Ftp_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp_stubs.o",
       "functions": [
         {
           "name": "_ZN7FtpFile6AcceptEv",
@@ -39826,7 +39826,7 @@
     {
       "name": "gamelib/util/Network.cpp.o",
       "source": "src/gamelib/util/Network.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/Network.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Network.o",
       "functions": [
         {
           "name": "_Z16NetworkSyncPausev",
@@ -40641,7 +40641,7 @@
     {
       "name": "gamelib/util/Network_stubs.cpp.o",
       "source": "src/gamelib/util/Network_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/Network_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Network_stubs.o",
       "functions": [
         {
           "name": "_ZN10NetMessage10RaiseErrorEv",
@@ -40680,7 +40680,7 @@
     {
       "name": "gamelib/util/TouchHacks.cpp.o",
       "source": "src/gamelib/util/TouchHacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/TouchHacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/TouchHacks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_TouchHacks.cpp",
@@ -41047,7 +41047,7 @@
     {
       "name": "gamelib/util/Transporter.cpp.o",
       "source": "src/gamelib/util/Transporter.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/Transporter.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Transporter.o",
       "functions": [
         {
           "name": "_ZN14NetTransporter11AddListenerEP20NetListenerInterfacehPc",
@@ -41174,7 +41174,7 @@
     {
       "name": "gamelib/util/V2SessionManager.cpp.o",
       "source": "src/gamelib/util/V2SessionManager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/V2SessionManager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/V2SessionManager.o",
       "functions": [
         {
           "name": "_ZN16V2SessionManager13VerifyStringsEPPcS1_iS0_",
@@ -41253,7 +41253,7 @@
     {
       "name": "gamelib/util/VirtualStackAllocator.cpp.o",
       "source": "src/gamelib/util/VirtualStackAllocator.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/VirtualStackAllocator.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/VirtualStackAllocator.o",
       "functions": [
         {
           "name": "_ZN21VirtualStackAllocatorC1Ev",
@@ -41348,7 +41348,7 @@
     {
       "name": "gamelib/util/gamelib_util_misc.cpp.o",
       "source": "src/gamelib/util/gamelib_util_misc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/gamelib_util_misc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/gamelib_util_misc.o",
       "functions": [
         {
           "name": "_ZN10TouchHacks9TintStackC1Ev",
@@ -41435,13 +41435,13 @@
     {
       "name": "globals.cpp.o",
       "source": "src/globals.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_root/globals.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_root/globals.o",
       "functions": []
     },
     {
       "name": "java/jni_stub.cpp.o",
       "source": "src/java/jni_stub.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_root/jni_stub.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_root/jni_stub.o",
       "functions": [
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetScreenDimesions",
@@ -41648,7 +41648,7 @@
     {
       "name": "legoapi/actions/character/simpletons.cpp.o",
       "source": "src/legoapi/actions/character/simpletons.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/simpletons.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/simpletons.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_simpletons.cpp",
@@ -41759,7 +41759,7 @@
     {
       "name": "legoapi/actions/character/snake.cpp.o",
       "source": "src/legoapi/actions/character/snake.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/snake.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/snake.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_snake.cpp",
@@ -41838,7 +41838,7 @@
     {
       "name": "legoapi/actions/character/specialmoves.cpp.o",
       "source": "src/legoapi/actions/character/specialmoves.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/specialmoves.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/specialmoves.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_specialmoves.cpp",
@@ -41981,7 +41981,7 @@
     {
       "name": "legoapi/actions/character/speederchase.cpp.o",
       "source": "src/legoapi/actions/character/speederchase.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_speederchase.cpp",
@@ -42204,7 +42204,7 @@
     {
       "name": "legoapi/actions/character/speederchase_stubs.cpp.o",
       "source": "src/legoapi/actions/character/speederchase_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase_stubs.o",
       "functions": [
         {
           "name": "_Z10getPodRolli",
@@ -42219,7 +42219,7 @@
     {
       "name": "legoapi/actions/character/starwars.cpp.o",
       "source": "src/legoapi/actions/character/starwars.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/starwars.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/starwars.o",
       "functions": [
         {
           "name": "_ZL24StarWars_PrepareObstacleP10AIPACKET_sP11APIOBJECT_si",
@@ -42338,7 +42338,7 @@
     {
       "name": "legoapi/actions/character/streaks.cpp.o",
       "source": "src/legoapi/actions/character/streaks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/streaks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/streaks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_streaks.cpp",
@@ -42385,7 +42385,7 @@
     {
       "name": "legoapi/actions/character/suit.cpp.o",
       "source": "src/legoapi/actions/character/suit.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/suit.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/suit.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_suit.cpp",
@@ -42464,7 +42464,7 @@
     {
       "name": "legoapi/actions/character/tagging.cpp.o",
       "source": "src/legoapi/actions/character/tagging.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/tagging.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tagging.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_tagging.cpp",
@@ -42559,7 +42559,7 @@
     {
       "name": "legoapi/actions/character/transform.cpp.o",
       "source": "src/legoapi/actions/character/transform.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/transform.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/transform.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_transform.cpp",
@@ -42646,7 +42646,7 @@
     {
       "name": "legoapi/actions/combat/fighting.cpp.o",
       "source": "src/legoapi/actions/combat/fighting.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/fighting.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/fighting.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_fighting.cpp",
@@ -42773,7 +42773,7 @@
     {
       "name": "legoapi/actions/combat/hits.cpp.o",
       "source": "src/legoapi/actions/combat/hits.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/hits.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hits.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_hits.cpp",
@@ -42964,7 +42964,7 @@
     {
       "name": "legoapi/actions/combat/rope.cpp.o",
       "source": "src/legoapi/actions/combat/rope.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/rope.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/rope.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_rope.cpp",
@@ -42995,7 +42995,7 @@
     {
       "name": "legoapi/actions/combat/shovesys.cpp.o",
       "source": "src/legoapi/actions/combat/shovesys.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shovesys.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shovesys.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shovesys.cpp",
@@ -43034,7 +43034,7 @@
     {
       "name": "legoapi/actions/combat/whip.cpp.o",
       "source": "src/legoapi/actions/combat/whip.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/whip.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/whip.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_whip.cpp",
@@ -43065,7 +43065,7 @@
     {
       "name": "legoapi/actions/movement/carrying.cpp.o",
       "source": "src/legoapi/actions/movement/carrying.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/carrying.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/carrying.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_carrying.cpp",
@@ -43192,7 +43192,7 @@
     {
       "name": "legoapi/actions/movement/climbing.cpp.o",
       "source": "src/legoapi/actions/movement/climbing.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/climbing.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/climbing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_climbing.cpp",
@@ -43287,7 +43287,7 @@
     {
       "name": "legoapi/actions/movement/dropinout.cpp.o",
       "source": "src/legoapi/actions/movement/dropinout.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/dropinout.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/dropinout.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_dropinout.cpp",
@@ -43350,7 +43350,7 @@
     {
       "name": "legoapi/actions/movement/jumping.cpp.o",
       "source": "src/legoapi/actions/movement/jumping.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/jumping.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/jumping.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_jumping.cpp",
@@ -43453,7 +43453,7 @@
     {
       "name": "legoapi/actions/movement/pushblocks.cpp.o",
       "source": "src/legoapi/actions/movement/pushblocks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/pushblocks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/pushblocks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_pushblocks.cpp",
@@ -43556,7 +43556,7 @@
     {
       "name": "legoapi/actions/movement/pushing.cpp.o",
       "source": "src/legoapi/actions/movement/pushing.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/pushing.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/pushing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_pushing.cpp",
@@ -43667,7 +43667,7 @@
     {
       "name": "legoapi/ai/core/ai_sys.cpp.o",
       "source": "src/legoapi/ai/core/ai_sys.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys.o",
       "functions": [
         {
           "name": "_ZL15Collide2ObjectsP11APIOBJECT_sS0_",
@@ -43802,7 +43802,7 @@
     {
       "name": "legoapi/ai/core/ai_sys_stubs.cpp.o",
       "source": "src/legoapi/ai/core/ai_sys_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys_stubs.o",
       "functions": [
         {
           "name": "AiRndrLine3d",
@@ -44417,7 +44417,7 @@
     {
       "name": "legoapi/ai/core/aisysall.cpp.o",
       "source": "src/legoapi/ai/core/aisysall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/aisysall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aisysall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_aisysall.cpp",
@@ -44536,7 +44536,7 @@
     {
       "name": "legoapi/ai/core/gameai.cpp.o",
       "source": "src/legoapi/ai/core/gameai.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameai.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameai.cpp",
@@ -44599,7 +44599,7 @@
     {
       "name": "legoapi/ai/core/legoai.cpp.o",
       "source": "src/legoapi/ai/core/legoai.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/legoai.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_legoai.cpp",
@@ -44622,7 +44622,7 @@
     {
       "name": "legoapi/ai/game/aipathcnxhelper.cpp.o",
       "source": "src/legoapi/ai/game/aipathcnxhelper.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/aipathcnxhelper.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aipathcnxhelper.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_aipathcnxhelper.cpp",
@@ -44741,7 +44741,7 @@
     {
       "name": "legoapi/ai/game/aitrigger.cpp.o",
       "source": "src/legoapi/ai/game/aitrigger.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_aitrigger.cpp",
@@ -44788,7 +44788,7 @@
     {
       "name": "legoapi/ai/game/aitrigger_stubs.cpp.o",
       "source": "src/legoapi/ai/game/aitrigger_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger_stubs.o",
       "functions": [
         {
           "name": "_Z18AITriggerSetCreateP17AITRIGGERSETSYS_sP9FLOWBOX_s",
@@ -44803,7 +44803,7 @@
     {
       "name": "legoapi/ai/game/creature.cpp.o",
       "source": "src/legoapi/ai/game/creature.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/creature.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/creature.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_creature.cpp",
@@ -44898,7 +44898,7 @@
     {
       "name": "legoapi/ai/game/gameantinode.cpp.o",
       "source": "src/legoapi/ai/game/gameantinode.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameantinode.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameantinode.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameantinode.cpp",
@@ -45089,7 +45089,7 @@
     {
       "name": "legoapi/ai/game/lsw_hub_ai.cpp.o",
       "source": "src/legoapi/ai/game/lsw_hub_ai.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_lsw_hub_ai.cpp",
@@ -45176,7 +45176,7 @@
     {
       "name": "legoapi/ai/game/lsw_hub_ai_stubs.cpp.o",
       "source": "src/legoapi/ai/game/lsw_hub_ai_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai_stubs.o",
       "functions": [
         {
           "name": "_Z23Condition_InHubAreaInitP7AISYS_sPcP10AISCRIPT_s",
@@ -45191,7 +45191,7 @@
     {
       "name": "legoapi/ai/game/misc_a_game.cpp.o",
       "source": "src/legoapi/ai/game/misc_a_game.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/misc_a_game.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/misc_a_game.o",
       "functions": [
         {
           "name": "_ZL17CreatePodRaceMineP7nuvec_s",
@@ -45238,7 +45238,7 @@
     {
       "name": "legoapi/ai/game/starwars_gameai.cpp.o",
       "source": "src/legoapi/ai/game/starwars_gameai.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/starwars_gameai.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/starwars_gameai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_starwars_gameai.cpp",
@@ -45293,7 +45293,7 @@
     {
       "name": "legoapi/audio/audio.cpp.o",
       "source": "src/legoapi/audio/audio.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/audio.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/audio.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_audio.cpp",
@@ -45468,7 +45468,7 @@
     {
       "name": "legoapi/audio/gamelib_ogg.cpp.o",
       "source": "src/legoapi/audio/gamelib_ogg.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_ogg.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_ogg.o",
       "functions": [
         {
           "name": "_ZL10RemoveDataP9nuqthdr_sPci",
@@ -45531,7 +45531,7 @@
     {
       "name": "legoapi/audio/radio.cpp.o",
       "source": "src/legoapi/audio/radio.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/radio.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/radio.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_radio.cpp",
@@ -45570,7 +45570,7 @@
     {
       "name": "legoapi/audio/sfx.cpp.o",
       "source": "src/legoapi/audio/sfx.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/sfx.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/sfx.o",
       "functions": [
         {
           "name": "_ZL15CheckMusicOtherv",
@@ -46209,7 +46209,7 @@
     {
       "name": "legoapi/audio/sfx_callbacks.cpp.o",
       "source": "src/legoapi/audio/sfx_callbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/sfx_callbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/sfx_callbacks.o",
       "functions": [
         {
           "name": "SetAPIObjPlaySfxByIdFn",
@@ -46224,7 +46224,7 @@
     {
       "name": "legoapi/audio/specialsfx.cpp.o",
       "source": "src/legoapi/audio/specialsfx.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/specialsfx.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/specialsfx.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_specialsfx.cpp",
@@ -46319,7 +46319,7 @@
     {
       "name": "legoapi/characters/core/character.cpp.o",
       "source": "src/legoapi/characters/core/character.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/character.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/character.o",
       "functions": [
         {
           "name": "_ZL11IsAFallAnimi",
@@ -46646,7 +46646,7 @@
     {
       "name": "legoapi/characters/core/characters.cpp.o",
       "source": "src/legoapi/characters/core/characters.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/characters.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/characters.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_characters.cpp",
@@ -47021,7 +47021,7 @@
     {
       "name": "legoapi/characters/core/charconfig.cpp.o",
       "source": "src/legoapi/characters/core/charconfig.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/charconfig.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charconfig.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charconfig.cpp",
@@ -47108,7 +47108,7 @@
     {
       "name": "legoapi/characters/core/playeritems.cpp.o",
       "source": "src/legoapi/characters/core/playeritems.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/playeritems.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/playeritems.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_playeritems.cpp",
@@ -47251,7 +47251,7 @@
     {
       "name": "legoapi/characters/core/players.cpp.o",
       "source": "src/legoapi/characters/core/players.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/players.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/players.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_players.cpp",
@@ -47834,7 +47834,7 @@
     {
       "name": "legoapi/characters/motion/animation.cpp.o",
       "source": "src/legoapi/characters/motion/animation.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/animation.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/animation.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_animation.cpp",
@@ -47905,7 +47905,7 @@
     {
       "name": "legoapi/characters/motion/camera.cpp.o",
       "source": "src/legoapi/characters/motion/camera.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/camera.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/camera.o",
       "functions": [
         {
           "name": "_Z12KeepOnScreenP12GameObject_s",
@@ -48184,7 +48184,7 @@
     {
       "name": "legoapi/characters/motion/charpivot.cpp.o",
       "source": "src/legoapi/characters/motion/charpivot.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/charpivot.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charpivot.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charpivot.cpp",
@@ -48215,7 +48215,7 @@
     {
       "name": "legoapi/characters/motion/charplatforms.cpp.o",
       "source": "src/legoapi/characters/motion/charplatforms.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/charplatforms.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charplatforms.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charplatforms.cpp",
@@ -48318,7 +48318,7 @@
     {
       "name": "legoapi/characters/motion/charshadows.cpp.o",
       "source": "src/legoapi/characters/motion/charshadows.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/charshadows.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charshadows.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charshadows.cpp",
@@ -48357,7 +48357,7 @@
     {
       "name": "legoapi/characters/motion/chris.cpp.o",
       "source": "src/legoapi/characters/motion/chris.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/chris.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/chris.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_chris.cpp",
@@ -48548,7 +48548,7 @@
     {
       "name": "legoapi/characters/motion/chris_stubs.cpp.o",
       "source": "src/legoapi/characters/motion/chris_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/chris_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/chris_stubs.o",
       "functions": [
         {
           "name": "_Z18ChrisAnakinAUpdateP11WORLDINFO_s",
@@ -48587,7 +48587,7 @@
     {
       "name": "legoapi/characters/motion/gameanim.cpp.o",
       "source": "src/legoapi/characters/motion/gameanim.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameanim.cpp",
@@ -49331,7 +49331,7 @@
           "address": 4885536,
           "offset": 3995568,
           "size": 850,
-          "match_percent": 84.29126
+          "match_percent": 84.02427
         },
         {
           "name": "_Z28GameAnimSet_IsAnimationResetP13GAMEANIMSET_s",
@@ -49522,7 +49522,7 @@
     {
       "name": "legoapi/characters/motion/gameanim_modes.cpp.o",
       "source": "src/legoapi/characters/motion/gameanim_modes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim_modes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim_modes.o",
       "functions": [
         {
           "name": "SetAnimBlendMode",
@@ -49545,7 +49545,7 @@
     {
       "name": "legoapi/characters/motion/move.cpp.o",
       "source": "src/legoapi/characters/motion/move.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/move.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/move.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_move.cpp",
@@ -50376,7 +50376,7 @@
     {
       "name": "legoapi/core/config/cheat.cpp.o",
       "source": "src/legoapi/core/config/cheat.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cheat.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cheat.o",
       "functions": [
         {
           "name": "_Z16Cheat_FindByNamePc",
@@ -50423,7 +50423,7 @@
     {
       "name": "legoapi/core/config/cheats.cpp.o",
       "source": "src/legoapi/core/config/cheats.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cheats.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cheats.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_cheats.cpp",
@@ -50534,7 +50534,7 @@
     {
       "name": "legoapi/core/config/config.cpp.o",
       "source": "src/legoapi/core/config/config.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/config.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/config.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_config.cpp",
@@ -50557,7 +50557,7 @@
     {
       "name": "legoapi/core/config/saveload.cpp.o",
       "source": "src/legoapi/core/config/saveload.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/saveload.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/saveload.o",
       "functions": [
         {
           "name": "_Z26LevelScriptReStoreProgressP11WORLDINFO_sP20LEVELSCRIPTPROCESS_s",
@@ -50988,7 +50988,7 @@
     {
       "name": "legoapi/core/input/gamepads.cpp.o",
       "source": "src/legoapi/core/input/gamepads.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamepads.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamepads.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamepads.cpp",
@@ -51307,7 +51307,7 @@
     {
       "name": "legoapi/core/input/input.cpp.o",
       "source": "src/legoapi/core/input/input.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/input.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/input.o",
       "functions": [
         {
           "name": "_ZN31ClickToPressStartGestureTracker7OnClickER12GameObject_sR11TouchHolder",
@@ -51322,7 +51322,7 @@
     {
       "name": "legoapi/core/input/qrand.cpp.o",
       "source": "src/legoapi/core/input/qrand.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/qrand.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/qrand.o",
       "functions": [
         {
           "name": "_Z5qrandv",
@@ -51337,7 +51337,7 @@
     {
       "name": "legoapi/core/input/timer.cpp.o",
       "source": "src/legoapi/core/input/timer.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/timer.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/timer.o",
       "functions": [
         {
           "name": "_Z10ResetTimerP7TIMER_sf",
@@ -51360,7 +51360,7 @@
     {
       "name": "legoapi/core/input/timing.cpp.o",
       "source": "src/legoapi/core/input/timing.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/timing.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/timing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_timing.cpp",
@@ -51415,7 +51415,7 @@
     {
       "name": "legoapi/core/net/netplay.cpp.o",
       "source": "src/legoapi/core/net/netplay.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/netplay.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/netplay.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_netplay.cpp",
@@ -51478,7 +51478,7 @@
     {
       "name": "legoapi/core/net/network.cpp.o",
       "source": "src/legoapi/core/net/network.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/network.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/network.o",
       "functions": [
         {
           "name": "WithinConnection",
@@ -51661,7 +51661,7 @@
     {
       "name": "legoapi/core/startup/game.cpp.o",
       "source": "src/legoapi/core/startup/game.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/game.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/game.o",
       "functions": [
         {
           "name": "_Z7NewGamev",
@@ -51724,7 +51724,7 @@
     {
       "name": "legoapi/core/startup/main.cpp.o",
       "source": "src/legoapi/core/startup/main.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/main.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/main.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_main.cpp",
@@ -51779,7 +51779,7 @@
     {
       "name": "legoapi/core/startup/startup.cpp.o",
       "source": "src/legoapi/core/startup/startup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/startup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/startup.o",
       "functions": [
         {
           "name": "_Z16ParseCommandLinev",
@@ -51794,7 +51794,7 @@
     {
       "name": "legoapi/core/startup/virtual.cpp.o",
       "source": "src/legoapi/core/startup/virtual.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/virtual.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/virtual.o",
       "functions": [
         {
           "name": "_ZN29VirtualControlDPad_LockButton7ProcessEf",
@@ -51945,7 +51945,7 @@
     {
       "name": "legoapi/cutscenes/cutscene.cpp.o",
       "source": "src/legoapi/cutscenes/cutscene.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene.o",
       "functions": [
         {
           "name": "_ZL21CutScenePlayer_AcceptP18CUTSCENEPLAYERCLIP",
@@ -52200,7 +52200,7 @@
     {
       "name": "legoapi/cutscenes/cutscene_find.cpp.o",
       "source": "src/legoapi/cutscenes/cutscene_find.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_find.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_find.o",
       "functions": [
         {
           "name": "_Z13CutScene_FindP6CUTSYSPc",
@@ -52215,7 +52215,7 @@
     {
       "name": "legoapi/cutscenes/cutscene_stubs.cpp.o",
       "source": "src/legoapi/cutscenes/cutscene_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_stubs.o",
       "functions": [
         {
           "name": "SetForceScenePlayBack",
@@ -52526,7 +52526,7 @@
     {
       "name": "legoapi/cutscenes/cutscenes.cpp.o",
       "source": "src/legoapi/cutscenes/cutscenes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cutscenes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscenes.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_cutscenes.cpp",
@@ -52805,7 +52805,7 @@
     {
       "name": "legoapi/cutscenes/gcutscn.cpp.o",
       "source": "src/legoapi/cutscenes/gcutscn.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gcutscn.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gcutscn.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gcutscn.cpp",
@@ -52964,7 +52964,7 @@
     {
       "name": "legoapi/cutscenes/minicamcut.cpp.o",
       "source": "src/legoapi/cutscenes/minicamcut.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/minicamcut.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/minicamcut.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_minicamcut.cpp",
@@ -53051,7 +53051,7 @@
     {
       "name": "legoapi/gizmo/base/gizactions.cpp.o",
       "source": "src/legoapi/gizmo/base/gizactions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizactions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizactions.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizactions.cpp",
@@ -53098,7 +53098,7 @@
     {
       "name": "legoapi/gizmo/base/gizflow.cpp.o",
       "source": "src/legoapi/gizmo/base/gizflow.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizflow.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizflow.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizflow.cpp",
@@ -53217,7 +53217,7 @@
     {
       "name": "legoapi/gizmo/base/gizmessage.cpp.o",
       "source": "src/legoapi/gizmo/base/gizmessage.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmessage.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmessage.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmessage.cpp",
@@ -53296,7 +53296,7 @@
     {
       "name": "legoapi/gizmo/base/gizmo.cpp.o",
       "source": "src/legoapi/gizmo/base/gizmo.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmo.cpp",
@@ -54351,7 +54351,7 @@
     {
       "name": "legoapi/gizmo/base/gizmo_sys.cpp.o",
       "source": "src/legoapi/gizmo/base/gizmo_sys.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo_sys.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo_sys.o",
       "functions": [
         {
           "name": "_Z24Hub_LoadAndFixUpMiniKitsP11WORLDINFO_sP9variptr_uS2_",
@@ -54478,7 +54478,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizactions.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizactions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizactions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizactions.o",
       "functions": [
         {
           "name": "_Z23Action_GameFollowPlayerP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPPciif",
@@ -54885,7 +54885,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizbuildits.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizbuildits.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizbuildits.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizbuildits.o",
       "functions": [
         {
           "name": "_ZL34GizBuildIt_CanStartBuildingFn_GameP12GIZBUILDIT_sP12GameObject_s",
@@ -55068,7 +55068,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizforce.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizforce.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizforce.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizforce.o",
       "functions": [
         {
           "name": "_ZL21GizForceSFX_returnsfxP8nufpar_s",
@@ -55243,7 +55243,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizmopickups.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizmopickups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizmopickups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizmopickups.o",
       "functions": [
         {
           "name": "_ZL22GizmoPickups_Collide2DP12GameObject_s",
@@ -55410,7 +55410,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizobstacles.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizobstacles.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizobstacles.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizobstacles.o",
       "functions": [
         {
           "name": "_Z31GizObstacle_SetDefaultSFXFn_LSWPvP13GIZOBSTACLE_s",
@@ -55458,7 +55458,7 @@
           "address": 4896400,
           "offset": 4006432,
           "size": 41,
-          "match_percent": 32.307693
+          "match_percent": 99.92308
         },
         {
           "name": "_Z24GizObstacle_PlayForwardsP13GIZOBSTACLE_s",
@@ -55466,7 +55466,7 @@
           "address": 4896448,
           "offset": 4006480,
           "size": 155,
-          "match_percent": 10.769231
+          "match_percent": 99.97436
         },
         {
           "name": "_Z25GizObstacle_PlayBackwardsP13GIZOBSTACLE_s",
@@ -55474,7 +55474,7 @@
           "address": 4898176,
           "offset": 4008208,
           "size": 168,
-          "match_percent": 8.936171
+          "match_percent": 99.95744
         },
         {
           "name": "_ZL27GizObstacleUpdate_ProximityP13GIZOBSTACLE_s",
@@ -55546,7 +55546,7 @@
           "address": 4902032,
           "offset": 4012064,
           "size": 45,
-          "match_percent": 28.0
+          "match_percent": 99.933334
         },
         {
           "name": "_Z21GizObstacle_JumpToEndP13GIZOBSTACLE_s",
@@ -55554,7 +55554,7 @@
           "address": 4902080,
           "offset": 4012112,
           "size": 45,
-          "match_percent": 28.0
+          "match_percent": 99.933334
         },
         {
           "name": "_Z16GizObstacles_HitPvP13GIZOBSTACLE_sP7nuvec_sii",
@@ -55593,7 +55593,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizpanel.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizpanel.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizpanel.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizpanel.o",
       "functions": [
         {
           "name": "_ZL22GizPanel_CreateTerrainP10GIZPANEL_s",
@@ -55720,7 +55720,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizturrets.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizturrets.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizturrets.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizturrets.o",
       "functions": [
         {
           "name": "_Z16GizTurret_GetTgtP11GIZTURRET_sP7numtx_s",
@@ -55815,7 +55815,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_grabber.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_grabber.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grabber.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grabber.o",
       "functions": [
         {
           "name": "_Z18Grabber_GetGrabPosP9GRABBER_sP7numtx_s",
@@ -55870,7 +55870,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_grapples.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_grapples.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grapples.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grapples.o",
       "functions": [
         {
           "name": "_Z16Grapple_OccupiedP9GRAPPLE_sP12GameObject_sP11AIPATHCNX_s",
@@ -55981,7 +55981,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_hatmachine.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_hatmachine.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_hatmachine.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_hatmachine.o",
       "functions": [
         {
           "name": "_Z23HatMachines_InitTerrainP11WORLDINFO_s",
@@ -56036,7 +56036,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_lever.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_lever.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_lever.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_lever.o",
       "functions": [
         {
           "name": "_Z18Levers_InitTerrainP11WORLDINFO_s",
@@ -56107,7 +56107,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_newblowup.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_newblowup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_newblowup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_newblowup.o",
       "functions": [
         {
           "name": "_ZL20GizmoBlowUp_NoTargetP11WORLDINFO_sP12GameObject_s",
@@ -56202,7 +56202,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_spinner.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_spinner.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_spinner.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_spinner.o",
       "functions": [
         {
           "name": "_Z23GizSpinners_InitTerrainP11WORLDINFO_s",
@@ -56305,7 +56305,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_teleport.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_teleport.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_teleport.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_teleport.o",
       "functions": [
         {
           "name": "_ZN10TELEPORT_s22GetMechObjectInterfaceEv",
@@ -56384,7 +56384,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_tubes.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_tubes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_tubes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_tubes.o",
       "functions": [
         {
           "name": "_Z21Torpedo_UpdateJobbiesP12GameObject_s",
@@ -56519,7 +56519,7 @@
     {
       "name": "legoapi/gizmo/object/gizbombgen.cpp.o",
       "source": "src/legoapi/gizmo/object/gizbombgen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizbombgen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizbombgen.o",
       "functions": [
         {
           "name": "_Z9Mine_KillP6PART_si",
@@ -56542,7 +56542,7 @@
     {
       "name": "legoapi/gizmo/object/gizbuildit.cpp.o",
       "source": "src/legoapi/gizmo/object/gizbuildit.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildit.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildit.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizbuildit.cpp",
@@ -56621,7 +56621,7 @@
     {
       "name": "legoapi/gizmo/object/gizforce.cpp.o",
       "source": "src/legoapi/gizmo/object/gizforce.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizforce.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizforce.o",
       "functions": [
         {
           "name": "_Z8EndForceP12GameObject_si",
@@ -56692,7 +56692,7 @@
     {
       "name": "legoapi/gizmo/object/gizminicut.cpp.o",
       "source": "src/legoapi/gizmo/object/gizminicut.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizminicut.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizminicut.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizminicut.cpp",
@@ -56715,7 +56715,7 @@
     {
       "name": "legoapi/gizmo/object/gizmoblowups.cpp.o",
       "source": "src/legoapi/gizmo/object/gizmoblowups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmoblowups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmoblowups.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmoblowups.cpp",
@@ -57018,7 +57018,7 @@
     {
       "name": "legoapi/gizmo/object/gizmopickup.cpp.o",
       "source": "src/legoapi/gizmo/object/gizmopickup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmopickup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmopickup.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmopickup.cpp",
@@ -57113,7 +57113,7 @@
     {
       "name": "legoapi/gizmo/object/gizmopickups.cpp.o",
       "source": "src/legoapi/gizmo/object/gizmopickups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizmopickups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizmopickups.o",
       "functions": [
         {
           "name": "_Z17InDoubleScoreZoneP12GameObject_s",
@@ -57168,7 +57168,7 @@
     {
       "name": "legoapi/gizmo/object/gizobstacle.cpp.o",
       "source": "src/legoapi/gizmo/object/gizobstacle.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacle.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacle.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizobstacle.cpp",
@@ -57199,7 +57199,7 @@
     {
       "name": "legoapi/gizmo/object/gizpanel.cpp.o",
       "source": "src/legoapi/gizmo/object/gizpanel.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizpanel.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizpanel.o",
       "functions": [
         {
           "name": "_Z14SetPanelLightsf",
@@ -57214,7 +57214,7 @@
     {
       "name": "legoapi/gizmo/object/gizportal.cpp.o",
       "source": "src/legoapi/gizmo/object/gizportal.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizportal.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizportal.o",
       "functions": [
         {
           "name": "_Z16PortalGameObjectP12GameObject_siisP8nugscn_s",
@@ -57237,7 +57237,7 @@
     {
       "name": "legoapi/gizmo/object/gizrandom.cpp.o",
       "source": "src/legoapi/gizmo/object/gizrandom.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizrandom.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizrandom.o",
       "functions": [
         {
           "name": "_Z10randyfloatv",
@@ -57268,7 +57268,7 @@
     {
       "name": "legoapi/gizmo/object/gizspecial.cpp.o",
       "source": "src/legoapi/gizmo/object/gizspecial.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizspecial.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizspecial.o",
       "functions": [
         {
           "name": "_Z19ReleaseAllTakeOversv",
@@ -57323,7 +57323,7 @@
     {
       "name": "legoapi/gizmo/object/giztimers.cpp.o",
       "source": "src/legoapi/gizmo/object/giztimers.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/giztimers.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztimers.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_giztimers.cpp",
@@ -57346,7 +57346,7 @@
     {
       "name": "legoapi/gizmo/object/giztorpedo.cpp.o",
       "source": "src/legoapi/gizmo/object/giztorpedo.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpedo.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpedo.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_giztorpedo.cpp",
@@ -57377,7 +57377,7 @@
     {
       "name": "legoapi/gizmos/door/door.cpp.o",
       "source": "src/legoapi/gizmos/door/door.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/door.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/door.o",
       "functions": [
         {
           "name": "_ZL17Door_GetMaxGizmosPv",
@@ -57448,7 +57448,7 @@
     {
       "name": "legoapi/gizmos/door/plugs.cpp.o",
       "source": "src/legoapi/gizmos/door/plugs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/plugs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/plugs.o",
       "functions": [
         {
           "name": "_ZL13Plug_ActivateP7GIZMO_si",
@@ -57599,7 +57599,7 @@
     {
       "name": "legoapi/gizmos/door/push.cpp.o",
       "source": "src/legoapi/gizmos/door/push.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/push.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/push.o",
       "functions": [
         {
           "name": "_ZL29PushBlocks_ReserveBufferSpacePv",
@@ -57742,7 +57742,7 @@
     {
       "name": "legoapi/gizmos/door/securitydoors.cpp.o",
       "source": "src/legoapi/gizmos/door/securitydoors.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoors.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoors.o",
       "functions": [
         {
           "name": "_ZL32SecurityDoors_ReserveBufferSpacePv",
@@ -57893,7 +57893,7 @@
     {
       "name": "legoapi/gizmos/door/spinner.cpp.o",
       "source": "src/legoapi/gizmos/door/spinner.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/spinner.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/spinner.o",
       "functions": [
         {
           "name": "_ZL20GizSpinner_PanelDrawPvS_f",
@@ -58084,7 +58084,7 @@
     {
       "name": "legoapi/gizmos/door/zipups.cpp.o",
       "source": "src/legoapi/gizmos/door/zipups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/zipups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/zipups.o",
       "functions": [
         {
           "name": "_ZL17ZipUp_ActivateRevP7GIZMO_sii",
@@ -58235,7 +58235,7 @@
     {
       "name": "legoapi/gizmos/fx/edgizshadowmachine.cpp.o",
       "source": "src/legoapi/gizmos/fx/edgizshadowmachine.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/edgizshadowmachine.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/edgizshadowmachine.o",
       "functions": [
         {
           "name": "_ZL24edGizShadow_GetMaxGizmosPv",
@@ -58314,7 +58314,7 @@
     {
       "name": "legoapi/gizmos/fx/gizmopickups.cpp.o",
       "source": "src/legoapi/gizmos/fx/gizmopickups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizmopickups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizmopickups.o",
       "functions": [
         {
           "name": "_ZL25GizmoPickups_GetMaxGizmosPv",
@@ -58473,7 +58473,7 @@
     {
       "name": "legoapi/gizmos/fx/guidelines.cpp.o",
       "source": "src/legoapi/gizmos/fx/guidelines.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/guidelines.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/guidelines.o",
       "functions": [
         {
           "name": "_ZL29GuideLines_ReserveBufferSpacePv",
@@ -58608,7 +58608,7 @@
     {
       "name": "legoapi/gizmos/object/gizbuildits.cpp.o",
       "source": "src/legoapi/gizmos/object/gizbuildits.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildits.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildits.o",
       "functions": [
         {
           "name": "_ZL19GizmoBuildit_GetPosP7GIZMO_s",
@@ -58775,7 +58775,7 @@
     {
       "name": "legoapi/gizmos/object/gizobstacles.cpp.o",
       "source": "src/legoapi/gizmos/object/gizobstacles.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacles.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacles.o",
       "functions": [
         {
           "name": "_ZL20GizmoObstacle_GetPosP7GIZMO_s",
@@ -58982,7 +58982,7 @@
     {
       "name": "legoapi/gizmos/object/gizpanel.cpp.o",
       "source": "src/legoapi/gizmos/object/gizpanel.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizpanel.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizpanel.o",
       "functions": [
         {
           "name": "_ZL21GizPanel_GetMaxGizmosPv",
@@ -59125,7 +59125,7 @@
     {
       "name": "legoapi/gizmos/object/hatmachine.cpp.o",
       "source": "src/legoapi/gizmos/object/hatmachine.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/hatmachine.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/hatmachine.o",
       "functions": [
         {
           "name": "_ZL23HatMachine_GetMaxGizmosPv",
@@ -59276,7 +59276,7 @@
     {
       "name": "legoapi/gizmos/object/lever.cpp.o",
       "source": "src/legoapi/gizmos/object/lever.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/lever.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/lever.o",
       "functions": [
         {
           "name": "_ZL25Levers_ReserveBufferSpacePv",
@@ -59435,7 +59435,7 @@
     {
       "name": "legoapi/gizmos/object/newblowup.cpp.o",
       "source": "src/legoapi/gizmos/object/newblowup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/newblowup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/newblowup.o",
       "functions": [
         {
           "name": "_ZL19Blowup_GetMaxGizmosPv",
@@ -59602,7 +59602,7 @@
     {
       "name": "legoapi/gizmos/object/technos.cpp.o",
       "source": "src/legoapi/gizmos/object/technos.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/technos.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/technos.o",
       "functions": [
         {
           "name": "_ZL26Technos_ReserveBufferSpacePv",
@@ -59761,7 +59761,7 @@
     {
       "name": "legoapi/gizmos/transport/gizportal.cpp.o",
       "source": "src/legoapi/gizmos/transport/gizportal.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizportal.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizportal.o",
       "functions": [
         {
           "name": "_Z17PortalDoors_ResetP11WORLDINFO_s",
@@ -59880,7 +59880,7 @@
     {
       "name": "legoapi/gizmos/transport/grapples.cpp.o",
       "source": "src/legoapi/gizmos/transport/grapples.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/grapples.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/grapples.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_grapples.cpp",
@@ -60039,7 +60039,7 @@
     {
       "name": "legoapi/gizmos/transport/ledges.cpp.o",
       "source": "src/legoapi/gizmos/transport/ledges.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ledges.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ledges.o",
       "functions": [
         {
           "name": "_ZL25Ledges_ReserveBufferSpacePv",
@@ -60174,7 +60174,7 @@
     {
       "name": "legoapi/gizmos/transport/teleport.cpp.o",
       "source": "src/legoapi/gizmos/transport/teleport.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/teleport.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/teleport.o",
       "functions": [
         {
           "name": "_ZL20Teleport_ActivateRevP7GIZMO_sii",
@@ -60182,7 +60182,7 @@
           "address": 1235040,
           "offset": 345072,
           "size": 83,
-          "match_percent": 15.714286
+          "match_percent": 100.0
         },
         {
           "name": "_ZL17Teleport_ActivateP7GIZMO_si",
@@ -60190,7 +60190,7 @@
           "address": 1235136,
           "offset": 345168,
           "size": 29,
-          "match_percent": 42.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZL21Teleport_GetMaxGizmosPv",
@@ -60206,7 +60206,7 @@
           "address": 1235200,
           "offset": 345232,
           "size": 19,
-          "match_percent": null
+          "match_percent": 100.0
         },
         {
           "name": "_ZL18Teleport_GetOutputP7GIZMO_sii",
@@ -60214,7 +60214,7 @@
           "address": 1235232,
           "offset": 345264,
           "size": 27,
-          "match_percent": null
+          "match_percent": 100.0
         },
         {
           "name": "_Z22Teleport_GetOutputNameP7GIZMO_si",
@@ -60222,7 +60222,7 @@
           "address": 1235264,
           "offset": 345296,
           "size": 22,
-          "match_percent": 77.5
+          "match_percent": 99.75
         },
         {
           "name": "_ZL22Teleport_GetNumOutputsP7GIZMO_s",
@@ -60230,7 +60230,7 @@
           "address": 1235296,
           "offset": 345328,
           "size": 12,
-          "match_percent": 92.5
+          "match_percent": 100.0
         },
         {
           "name": "_ZL18Teleport_AddGizmosP10GIZMOSYS_siPvS1_",
@@ -60238,7 +60238,7 @@
           "address": 1235312,
           "offset": 345344,
           "size": 117,
-          "match_percent": 97.64103
+          "match_percent": 99.589745
         },
         {
           "name": "_Z22Teleport_RegisterGizmoi",
@@ -60253,7 +60253,7 @@
     {
       "name": "legoapi/gizmos/transport/tightropes.cpp.o",
       "source": "src/legoapi/gizmos/transport/tightropes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/tightropes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tightropes.o",
       "functions": [
         {
           "name": "_ZL29TightRopes_ReserveBufferSpacePv",
@@ -60388,7 +60388,7 @@
     {
       "name": "legoapi/gizmos/transport/tubes.cpp.o",
       "source": "src/legoapi/gizmos/transport/tubes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/tubes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/tubes.o",
       "functions": [
         {
           "name": "_ZL24Tubes_ReserveBufferSpacePv",
@@ -60547,7 +60547,7 @@
     {
       "name": "legoapi/gizmos/traps/attractos.cpp.o",
       "source": "src/legoapi/gizmos/traps/attractos.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/attractos.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/attractos.o",
       "functions": [
         {
           "name": "_ZL28Attractos_ReserveBufferSpacePv",
@@ -60698,7 +60698,7 @@
     {
       "name": "legoapi/gizmos/traps/gizbombgen.cpp.o",
       "source": "src/legoapi/gizmos/traps/gizbombgen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizbombgen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizbombgen.o",
       "functions": [
         {
           "name": "_ZL21GizmoBombGen_ActivateP7GIZMO_si",
@@ -60841,7 +60841,7 @@
     {
       "name": "legoapi/gizmos/traps/gizforce.cpp.o",
       "source": "src/legoapi/gizmos/traps/gizforce.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizforce.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizforce.o",
       "functions": [
         {
           "name": "_ZL17GizmoForce_GetPosP7GIZMO_s",
@@ -61040,7 +61040,7 @@
     {
       "name": "legoapi/gizmos/traps/giztorpmachine.cpp.o",
       "source": "src/legoapi/gizmos/traps/giztorpmachine.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpmachine.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpmachine.o",
       "functions": [
         {
           "name": "_ZL21GizTorp_SetVisibilityP7GIZMO_si",
@@ -61159,7 +61159,7 @@
     {
       "name": "legoapi/gizmos/traps/gizturrets.cpp.o",
       "source": "src/legoapi/gizmos/traps/gizturrets.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizturrets.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizturrets.o",
       "functions": [
         {
           "name": "_ZL20GizmoTurret_ActivateP7GIZMO_si",
@@ -61358,7 +61358,7 @@
     {
       "name": "legoapi/gizmos/traps/shards.cpp.o",
       "source": "src/legoapi/gizmos/traps/shards.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shards.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shards.o",
       "functions": [
         {
           "name": "_ZL25Shards_ReserveBufferSpacePv",
@@ -61509,7 +61509,7 @@
     {
       "name": "legoapi/gizmos/trigger/ai.cpp.o",
       "source": "src/legoapi/gizmos/trigger/ai.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ai.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ai.o",
       "functions": [
         {
           "name": "_ZL15AI_GetMaxGizmosPv",
@@ -61580,7 +61580,7 @@
     {
       "name": "legoapi/gizmos/trigger/gizaimessage.cpp.o",
       "source": "src/legoapi/gizmos/trigger/gizaimessage.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizaimessage.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizaimessage.o",
       "functions": [
         {
           "name": "_ZL25GizAIMessage_GetMaxGizmosPv",
@@ -61643,7 +61643,7 @@
     {
       "name": "legoapi/gizmos/trigger/gizrandom.cpp.o",
       "source": "src/legoapi/gizmos/trigger/gizrandom.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizrandom.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizrandom.o",
       "functions": [
         {
           "name": "_Z22GizRandom_GetMaxGizmosPv",
@@ -61722,7 +61722,7 @@
     {
       "name": "legoapi/gizmos/trigger/gizspecial.cpp.o",
       "source": "src/legoapi/gizmos/trigger/gizspecial.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizspecial.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizspecial.o",
       "functions": [
         {
           "name": "_ZL23GizSpecial_GetMaxGizmosPv",
@@ -61865,7 +61865,7 @@
     {
       "name": "legoapi/gizmos/trigger/giztimer.cpp.o",
       "source": "src/legoapi/gizmos/trigger/giztimer.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/giztimer.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztimer.o",
       "functions": [
         {
           "name": "_Z21GizTimer_GetMaxGizmosPv",
@@ -61960,7 +61960,7 @@
     {
       "name": "legoapi/gizmos/trigger/minicut.cpp.o",
       "source": "src/legoapi/gizmos/trigger/minicut.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/minicut.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/minicut.o",
       "functions": [
         {
           "name": "_ZL23GizMiniCut_GetGizmoNameP7GIZMO_s",
@@ -62071,7 +62071,7 @@
     {
       "name": "legoapi/gizmos/trigger/signals.cpp.o",
       "source": "src/legoapi/gizmos/trigger/signals.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/signals.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/signals.o",
       "functions": [
         {
           "name": "_ZL26Signals_ReserveBufferSpacePv",
@@ -62230,7 +62230,7 @@
     {
       "name": "legoapi/items/base/apiobject.cpp.o",
       "source": "src/legoapi/items/base/apiobject.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/apiobject.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/apiobject.o",
       "functions": [
         {
           "name": "WindShear",
@@ -62349,7 +62349,7 @@
     {
       "name": "legoapi/items/base/collection.cpp.o",
       "source": "src/legoapi/items/base/collection.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/collection.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/collection.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_collection.cpp",
@@ -62556,7 +62556,7 @@
     {
       "name": "legoapi/items/base/game_object.cpp.o",
       "source": "src/legoapi/items/base/game_object.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/game_object.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/game_object.o",
       "functions": [
         {
           "name": "_ZL27Tag_FindGameObject_TRANSFERP12GameObject_s",
@@ -62819,7 +62819,7 @@
     {
       "name": "legoapi/items/base/scene.cpp.o",
       "source": "src/legoapi/items/base/scene.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/scene.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/scene.o",
       "functions": [
         {
           "name": "_ZNK13SceneInstance13GetVisibilityEv",
@@ -62930,7 +62930,7 @@
     {
       "name": "legoapi/items/base/sceneobject.cpp.o",
       "source": "src/legoapi/items/base/sceneobject.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/sceneobject.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/sceneobject.o",
       "functions": [
         {
           "name": "_ZN17SceneObjectHelper10ClearLevelEi",
@@ -63089,7 +63089,7 @@
     {
       "name": "legoapi/items/collect/attracto.cpp.o",
       "source": "src/legoapi/items/collect/attracto.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/attracto.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/attracto.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_attracto.cpp",
@@ -63144,7 +63144,7 @@
     {
       "name": "legoapi/items/collect/batarang.cpp.o",
       "source": "src/legoapi/items/collect/batarang.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/batarang.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/batarang.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_batarang.cpp",
@@ -63271,7 +63271,7 @@
     {
       "name": "legoapi/items/collect/bolt.cpp.o",
       "source": "src/legoapi/items/collect/bolt.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/bolt.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/bolt.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_bolt.cpp",
@@ -63382,7 +63382,7 @@
     {
       "name": "legoapi/items/collect/bolts.cpp.o",
       "source": "src/legoapi/items/collect/bolts.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/bolts.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/bolts.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_bolts.cpp",
@@ -63749,7 +63749,7 @@
     {
       "name": "legoapi/items/collect/bolts_stubs.cpp.o",
       "source": "src/legoapi/items/collect/bolts_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/bolts_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/bolts_stubs.o",
       "functions": [
         {
           "name": "_Z15Bolt_PlayHitSfxP6BOLT_s",
@@ -63764,7 +63764,7 @@
     {
       "name": "legoapi/items/collect/detonator.cpp.o",
       "source": "src/legoapi/items/collect/detonator.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/detonator.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/detonator.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_detonator.cpp",
@@ -63827,7 +63827,7 @@
     {
       "name": "legoapi/items/collect/minikits.cpp.o",
       "source": "src/legoapi/items/collect/minikits.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/minikits.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/minikits.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_minikits.cpp",
@@ -64042,7 +64042,7 @@
     {
       "name": "legoapi/items/collect/shard.cpp.o",
       "source": "src/legoapi/items/collect/shard.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shard.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shard.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shard.cpp",
@@ -64081,7 +64081,7 @@
     {
       "name": "legoapi/items/collect/thermaldetonators.cpp.o",
       "source": "src/legoapi/items/collect/thermaldetonators.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/thermaldetonators.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/thermaldetonators.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_thermaldetonators.cpp",
@@ -64160,7 +64160,7 @@
     {
       "name": "legoapi/items/collect/torpedo.cpp.o",
       "source": "src/legoapi/items/collect/torpedo.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/torpedo.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/torpedo.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_torpedo.cpp",
@@ -64255,7 +64255,7 @@
     {
       "name": "legoapi/items/fx/explosions.cpp.o",
       "source": "src/legoapi/items/fx/explosions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/explosions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/explosions.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_explosions.cpp",
@@ -64310,7 +64310,7 @@
     {
       "name": "legoapi/items/fx/pulses.cpp.o",
       "source": "src/legoapi/items/fx/pulses.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/pulses.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/pulses.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_pulses.cpp",
@@ -64357,7 +64357,7 @@
     {
       "name": "legoapi/items/fx/ripples.cpp.o",
       "source": "src/legoapi/items/fx/ripples.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ripples.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ripples.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_ripples.cpp",
@@ -64460,7 +64460,7 @@
     {
       "name": "legoapi/items/objects/cable.cpp.o",
       "source": "src/legoapi/items/objects/cable.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cable.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cable.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_cable.cpp",
@@ -64531,7 +64531,7 @@
     {
       "name": "legoapi/items/objects/gameobjects.cpp.o",
       "source": "src/legoapi/items/objects/gameobjects.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameobjects.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameobjects.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameobjects.cpp",
@@ -66258,7 +66258,7 @@
     {
       "name": "legoapi/items/objects/grabber.cpp.o",
       "source": "src/legoapi/items/objects/grabber.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/grabber.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/grabber.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_grabber.cpp",
@@ -66289,7 +66289,7 @@
     {
       "name": "legoapi/items/objects/objectsall.cpp.o",
       "source": "src/legoapi/items/objects/objectsall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/objectsall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/objectsall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_objectsall.cpp",
@@ -66424,7 +66424,7 @@
     {
       "name": "legoapi/items/objects/placeable.cpp.o",
       "source": "src/legoapi/items/objects/placeable.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/placeable.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/placeable.o",
       "functions": [
         {
           "name": "_ZNK9Placeable18GetInitialPositionEv",
@@ -66639,7 +66639,7 @@
     {
       "name": "legoapi/items/objects/plugs.cpp.o",
       "source": "src/legoapi/items/objects/plugs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/plugs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/plugs.o",
       "functions": [
         {
           "name": "_Z16Plug_FindNearestP9PLUGSYS_sP7nuvec_sPfi",
@@ -66662,7 +66662,7 @@
     {
       "name": "legoapi/items/objects/things.cpp.o",
       "source": "src/legoapi/items/objects/things.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/things.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/things.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_things.cpp",
@@ -66701,7 +66701,7 @@
     {
       "name": "legoapi/items/objects/traffic.cpp.o",
       "source": "src/legoapi/items/objects/traffic.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/traffic.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/traffic.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_traffic.cpp",
@@ -66748,7 +66748,7 @@
     {
       "name": "legoapi/menus/core/gamehint.cpp.o",
       "source": "src/legoapi/menus/core/gamehint.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamehint.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamehint.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamehint.cpp",
@@ -67003,7 +67003,7 @@
     {
       "name": "legoapi/menus/core/gamemessages.cpp.o",
       "source": "src/legoapi/menus/core/gamemessages.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamemessages.cpp",
@@ -67098,7 +67098,7 @@
     {
       "name": "legoapi/menus/core/gamemessages_stubs.cpp.o",
       "source": "src/legoapi/menus/core/gamemessages_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages_stubs.o",
       "functions": [
         {
           "name": "_Z9numeminitv",
@@ -67121,7 +67121,7 @@
     {
       "name": "legoapi/menus/core/hint.cpp.o",
       "source": "src/legoapi/menus/core/hint.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/hint.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hint.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_hint.cpp",
@@ -67272,7 +67272,7 @@
     {
       "name": "legoapi/menus/core/hud.cpp.o",
       "source": "src/legoapi/menus/core/hud.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/hud.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hud.o",
       "functions": [
         {
           "name": "_ZL13DrawCoinTotalii",
@@ -67367,7 +67367,7 @@
     {
       "name": "legoapi/menus/core/panel.cpp.o",
       "source": "src/legoapi/menus/core/panel.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/panel.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/panel.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_panel.cpp",
@@ -67422,7 +67422,7 @@
     {
       "name": "legoapi/menus/core/text.cpp.o",
       "source": "src/legoapi/menus/core/text.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/text.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/text.o",
       "functions": [
         {
           "name": "_Z18Text_DecodeButtonsPcS_",
@@ -67933,7 +67933,7 @@
     {
       "name": "legoapi/menus/screens/arcade.cpp.o",
       "source": "src/legoapi/menus/screens/arcade.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/arcade.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/arcade.o",
       "functions": [
         {
           "name": "_Z24Arcade_BothPlayersActivev",
@@ -68036,7 +68036,7 @@
     {
       "name": "legoapi/menus/screens/credits.cpp.o",
       "source": "src/legoapi/menus/screens/credits.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/credits.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/credits.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_credits.cpp",
@@ -68091,7 +68091,7 @@
     {
       "name": "legoapi/menus/screens/customise.cpp.o",
       "source": "src/legoapi/menus/screens/customise.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/customise.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/customise.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_customise.cpp",
@@ -68378,7 +68378,7 @@
     {
       "name": "legoapi/menus/screens/gamemenuall.cpp.o",
       "source": "src/legoapi/menus/screens/gamemenuall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamemenuall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamemenuall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamemenuall.cpp",
@@ -69857,7 +69857,7 @@
     {
       "name": "legoapi/menus/screens/gamestatus_lsw.cpp.o",
       "source": "src/legoapi/menus/screens/gamestatus_lsw.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamestatus_lsw.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamestatus_lsw.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamestatus_lsw.cpp",
@@ -70288,7 +70288,7 @@
     {
       "name": "legoapi/menus/screens/menus.cpp.o",
       "source": "src/legoapi/menus/screens/menus.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/menus.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/menus.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_menus.cpp",
@@ -70375,7 +70375,7 @@
     {
       "name": "legoapi/menus/screens/movies.cpp.o",
       "source": "src/legoapi/menus/screens/movies.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/movies.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/movies.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_movies.cpp",
@@ -70414,7 +70414,7 @@
     {
       "name": "legoapi/menus/screens/shop.cpp.o",
       "source": "src/legoapi/menus/screens/shop.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shop.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shop.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shop.cpp",
@@ -70517,7 +70517,7 @@
     {
       "name": "legoapi/menus/screens/store.cpp.o",
       "source": "src/legoapi/menus/screens/store.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/store.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/store.o",
       "functions": [
         {
           "name": "_Z24StoreProgressAICharacterP16LEVEL_PROGRESS_s",
@@ -70716,7 +70716,7 @@
     {
       "name": "legoapi/misc/androidbatman.cpp.o",
       "source": "src/legoapi/misc/androidbatman.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/androidbatman.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/androidbatman.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_androidbatman.cpp",
@@ -70811,7 +70811,7 @@
     {
       "name": "legoapi/misc/buffers.cpp.o",
       "source": "src/legoapi/misc/buffers.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/buffers.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/buffers.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_buffers.cpp",
@@ -70842,7 +70842,7 @@
     {
       "name": "legoapi/misc/gamelib_utilities.cpp.o",
       "source": "src/legoapi/misc/gamelib_utilities.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_utilities.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_utilities.o",
       "functions": [
         {
           "name": "VuQuatSlerpFast",
@@ -70961,13 +70961,13 @@
     {
       "name": "legoapi/misc/legoapi_helpers.cpp.o",
       "source": "src/legoapi/misc/legoapi_helpers.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_helpers.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_helpers.o",
       "functions": []
     },
     {
       "name": "legoapi/misc/legoapi_misc.cpp.o",
       "source": "src/legoapi/misc/legoapi_misc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc.o",
       "functions": [
         {
           "name": "_Z21ClearLastSafeTakeOverP12GameObject_s",
@@ -71118,7 +71118,7 @@
     {
       "name": "legoapi/misc/legoapi_misc_c.c.o",
       "source": "src/legoapi/misc/legoapi_misc_c.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc_c.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc_c.o",
       "functions": [
         {
           "name": "tpentPropOnEnter",
@@ -71141,7 +71141,7 @@
     {
       "name": "legoapi/misc/legoapi_status.cpp.o",
       "source": "src/legoapi/misc/legoapi_status.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_status.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_status.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_legoapi_status.cpp",
@@ -71188,7 +71188,7 @@
     {
       "name": "legoapi/misc/memory.cpp.o",
       "source": "src/legoapi/misc/memory.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/memory.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/memory.o",
       "functions": [
         {
           "name": "DebAlloc",
@@ -71275,7 +71275,7 @@
     {
       "name": "legoapi/misc/stream.cpp.o",
       "source": "src/legoapi/misc/stream.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/stream.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/stream.o",
       "functions": [
         {
           "name": "StreamRead",
@@ -71314,7 +71314,7 @@
     {
       "name": "legoapi/misc/supportall.cpp.o",
       "source": "src/legoapi/misc/supportall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/supportall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/supportall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_supportall.cpp",
@@ -71753,7 +71753,7 @@
     {
       "name": "legoapi/misc/supportall_stubs.cpp.o",
       "source": "src/legoapi/misc/supportall_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/supportall_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/supportall_stubs.o",
       "functions": [
         {
           "name": "_Z14bgprocIsFrozenv",
@@ -71816,7 +71816,7 @@
     {
       "name": "legoapi/misc/tm.cpp.o",
       "source": "src/legoapi/misc/tm.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/tm.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tm.o",
       "functions": [
         {
           "name": "_ZN8TMClient11AllocHandleEv",
@@ -71935,7 +71935,7 @@
     {
       "name": "legoapi/misc/utilities.cpp.o",
       "source": "src/legoapi/misc/utilities.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/utilities.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/utilities.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_utilities.cpp",
@@ -72406,7 +72406,7 @@
     {
       "name": "legoapi/props/doors/door.cpp.o",
       "source": "src/legoapi/props/doors/door.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/door.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/door.o",
       "functions": [
         {
           "name": "_ZL23GoThroughDoor_ExtraCodeP11WORLDINFO_sP6DOOR_s",
@@ -72445,7 +72445,7 @@
     {
       "name": "legoapi/props/doors/doors.cpp.o",
       "source": "src/legoapi/props/doors/doors.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/doors.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/doors.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_doors.cpp",
@@ -72524,7 +72524,7 @@
     {
       "name": "legoapi/props/doors/securitydoor.cpp.o",
       "source": "src/legoapi/props/doors/securitydoor.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoor.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoor.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_securitydoor.cpp",
@@ -72563,7 +72563,7 @@
     {
       "name": "legoapi/props/objects/guidelines.cpp.o",
       "source": "src/legoapi/props/objects/guidelines.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/guidelines.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/guidelines.o",
       "functions": [
         {
           "name": "_Z21GuideLine_FindNearestP7nuvec_sP11WORLDINFO_sPiPf",
@@ -72578,7 +72578,7 @@
     {
       "name": "legoapi/props/objects/hatmachine.cpp.o",
       "source": "src/legoapi/props/objects/hatmachine.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/hatmachine.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/hatmachine.o",
       "functions": [
         {
           "name": "_Z19Hat_GetAbsTargetPosP12HATMACHINE_sP7nuvec_s",
@@ -72593,7 +72593,7 @@
     {
       "name": "legoapi/props/objects/ledge.cpp.o",
       "source": "src/legoapi/props/objects/ledge.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ledge.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ledge.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_ledge.cpp",
@@ -72640,7 +72640,7 @@
     {
       "name": "legoapi/props/objects/lever.cpp.o",
       "source": "src/legoapi/props/objects/lever.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/lever.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/lever.o",
       "functions": [
         {
           "name": "_Z12ReleaseLeverP12GameObject_s",
@@ -72663,7 +72663,7 @@
     {
       "name": "legoapi/props/objects/signal.cpp.o",
       "source": "src/legoapi/props/objects/signal.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/signal.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/signal.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_signal.cpp",
@@ -72710,7 +72710,7 @@
     {
       "name": "legoapi/props/objects/techno.cpp.o",
       "source": "src/legoapi/props/objects/techno.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/techno.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/techno.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_techno.cpp",
@@ -72797,7 +72797,7 @@
     {
       "name": "legoapi/props/objects/teleport.cpp.o",
       "source": "src/legoapi/props/objects/teleport.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/teleport.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/teleport.o",
       "functions": [
         {
           "name": "_Z19Teleports_ConfigureP11WORLDINFO_sPc",
@@ -72820,7 +72820,7 @@
     {
       "name": "legoapi/props/objects/tightrope.cpp.o",
       "source": "src/legoapi/props/objects/tightrope.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/tightrope.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tightrope.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_tightrope.cpp",
@@ -72875,7 +72875,7 @@
     {
       "name": "legoapi/props/objects/tubes.cpp.o",
       "source": "src/legoapi/props/objects/tubes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/tubes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/tubes.o",
       "functions": [
         {
           "name": "_Z15TractorBeamCodeP12GameObject_s",
@@ -72898,7 +72898,7 @@
     {
       "name": "legoapi/props/objects/zipup.cpp.o",
       "source": "src/legoapi/props/objects/zipup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/zipup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/zipup.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_zipup.cpp",
@@ -72945,7 +72945,7 @@
     {
       "name": "legoapi/props/system/socksysall.cpp.o",
       "source": "src/legoapi/props/system/socksysall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall.o",
       "functions": [
         {
           "name": "_Z28GoingForwardsAlongNarrowSockP12GameObject_s",
@@ -73216,7 +73216,7 @@
     {
       "name": "legoapi/props/system/socksysall_stubs.cpp.o",
       "source": "src/legoapi/props/system/socksysall_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall_stubs.o",
       "functions": [
         {
           "name": "_Z21TurnOffAllSocksExceptP7SOCKSYSi",
@@ -73239,7 +73239,7 @@
     {
       "name": "legoapi/render/core/gameliball.cpp.o",
       "source": "src/legoapi/render/core/gameliball.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameliball.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameliball.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameliball.cpp",
@@ -73278,7 +73278,7 @@
     {
       "name": "legoapi/render/core/nugraph.cpp.o",
       "source": "src/legoapi/render/core/nugraph.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/nugraph.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/nugraph.o",
       "functions": [
         {
           "name": "nugraphInit",
@@ -73421,7 +73421,7 @@
     {
       "name": "legoapi/render/core/render.cpp.o",
       "source": "src/legoapi/render/core/render.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/render.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/render.o",
       "functions": [
         {
           "name": "_Z22DrawGameObjectsProcessv",
@@ -74492,7 +74492,7 @@
     {
       "name": "legoapi/render/core/render_stubs.cpp.o",
       "source": "src/legoapi/render/core/render_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/render_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/render_stubs.o",
       "functions": [
         {
           "name": "BoundingBoxToLine",
@@ -74979,7 +74979,7 @@
     {
       "name": "legoapi/render/core/rtl.cpp.o",
       "source": "src/legoapi/render/core/rtl.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/rtl.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/rtl.o",
       "functions": [
         {
           "name": "_ZL10ElOverlapsP9nuqtdim_sS0_",
@@ -75466,7 +75466,7 @@
     {
       "name": "legoapi/render/core/screen.cpp.o",
       "source": "src/legoapi/render/core/screen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/screen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/screen.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_screen.cpp",
@@ -75641,7 +75641,7 @@
     {
       "name": "legoapi/render/core/shader.cpp.o",
       "source": "src/legoapi/render/core/shader.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shader.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shader.o",
       "functions": [
         {
           "name": "_ZN19ShaderMtlDescFilter12internalInitEPK17nushadermtldesc_sPK7numtl_sii",
@@ -75784,7 +75784,7 @@
     {
       "name": "legoapi/render/core/terrain.cpp.o",
       "source": "src/legoapi/render/core/terrain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/terrain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/terrain.o",
       "functions": [
         {
           "name": "_Z13TerrainPlayerP12GameObject_s",
@@ -76087,7 +76087,7 @@
     {
       "name": "legoapi/render/core/terrain_runtime.cpp.o",
       "source": "src/legoapi/render/core/terrain_runtime.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_runtime.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_runtime.o",
       "functions": [
         {
           "name": "DebrisSetTimeIncrement",
@@ -76110,7 +76110,7 @@
     {
       "name": "legoapi/render/core/terrain_stubs.cpp.o",
       "source": "src/legoapi/render/core/terrain_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_stubs.o",
       "functions": [
         {
           "name": "CreateDmaParticleSet",
@@ -77413,7 +77413,7 @@
     {
       "name": "legoapi/render/fx/edsplines.cpp.o",
       "source": "src/legoapi/render/fx/edsplines.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/edsplines.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/edsplines.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_edsplines.cpp",
@@ -77660,7 +77660,7 @@
     {
       "name": "legoapi/render/fx/game_deb.cpp.o",
       "source": "src/legoapi/render/fx/game_deb.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/game_deb.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/game_deb.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_game_deb.cpp",
@@ -77859,7 +77859,7 @@
     {
       "name": "legoapi/render/fx/inflate.cpp.o",
       "source": "src/legoapi/render/fx/inflate.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/inflate.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/inflate.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_inflate.cpp",
@@ -78018,7 +78018,7 @@
     {
       "name": "legoapi/render/fx/particles.cpp.o",
       "source": "src/legoapi/render/fx/particles.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/particles.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/particles.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_particles.cpp",
@@ -78105,7 +78105,7 @@
     {
       "name": "legoapi/render/fx/parts.cpp.o",
       "source": "src/legoapi/render/fx/parts.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/parts.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/parts.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_parts.cpp",
@@ -79088,7 +79088,7 @@
     {
       "name": "legoapi/render/fx/parts_control.cpp.o",
       "source": "src/legoapi/render/fx/parts_control.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/parts_control.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/parts_control.o",
       "functions": [
         {
           "name": "_Z11Parts_StartP11WORLDINFO_s",
@@ -79111,7 +79111,7 @@
     {
       "name": "legoapi/render/fx/parts_stubs.cpp.o",
       "source": "src/legoapi/render/fx/parts_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/parts_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/parts_stubs.o",
       "functions": [
         {
           "name": "ParticlesPerFrame",
@@ -79158,7 +79158,7 @@
     {
       "name": "legoapi/render/light/fade.cpp.o",
       "source": "src/legoapi/render/light/fade.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/fade.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/fade.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_fade.cpp",
@@ -79541,7 +79541,7 @@
     {
       "name": "legoapi/render/light/faders.cpp.o",
       "source": "src/legoapi/render/light/faders.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/faders.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/faders.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_faders.cpp",
@@ -79580,7 +79580,7 @@
     {
       "name": "legoapi/render/light/lighting.cpp.o",
       "source": "src/legoapi/render/light/lighting.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/lighting.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lighting.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_lighting.cpp",
@@ -79723,7 +79723,7 @@
     {
       "name": "legoapi/render/light/occlusion.cpp.o",
       "source": "src/legoapi/render/light/occlusion.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/occlusion.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/occlusion.o",
       "functions": [
         {
           "name": "_ZN11OccluderSet11SortByDepthEPKvS1_",
@@ -79970,7 +79970,7 @@
     {
       "name": "legoapi/render/light/shadow.cpp.o",
       "source": "src/legoapi/render/light/shadow.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shadow.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shadow.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shadow.cpp",
@@ -80081,7 +80081,7 @@
     {
       "name": "legoapi/render/light/surfaces.cpp.o",
       "source": "src/legoapi/render/light/surfaces.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/surfaces.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/surfaces.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_surfaces.cpp",
@@ -80208,7 +80208,7 @@
     {
       "name": "legoapi/world/area.cpp.o",
       "source": "src/legoapi/world/area.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/area.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/area.o",
       "functions": [
         {
           "name": "_ZL12LoadAreaDataP12bgprocinfo_s",
@@ -80287,7 +80287,7 @@
     {
       "name": "legoapi/world/areas.cpp.o",
       "source": "src/legoapi/world/areas.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/areas.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/areas.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_areas.cpp",
@@ -80358,7 +80358,7 @@
     {
       "name": "legoapi/world/boss.cpp.o",
       "source": "src/legoapi/world/boss.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/boss.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/boss.o",
       "functions": [
         {
           "name": "_Z8KillBossiif",
@@ -80397,7 +80397,7 @@
     {
       "name": "legoapi/world/level.cpp.o",
       "source": "src/legoapi/world/level.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/level.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/level.o",
       "functions": [
         {
           "name": "_Z18ClearLevelProgressiP11WORLDINFO_s",
@@ -80564,7 +80564,7 @@
     {
       "name": "legoapi/world/levelconfig.cpp.o",
       "source": "src/legoapi/world/levelconfig.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/levelconfig.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levelconfig.o",
       "functions": [
         {
           "name": "_ZL15LC_BL_wind_sizeP8nufpar_s",
@@ -81411,7 +81411,7 @@
     {
       "name": "legoapi/world/leveldata.cpp.o",
       "source": "src/legoapi/world/leveldata.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/leveldata.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/leveldata.o",
       "functions": [
         {
           "name": "_Z12ClearLevDatav",
@@ -81442,7 +81442,7 @@
     {
       "name": "legoapi/world/levelobjects.cpp.o",
       "source": "src/legoapi/world/levelobjects.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/levelobjects.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levelobjects.o",
       "functions": [
         {
           "name": "_Z24LevelObjects_InitForGameP11LEVELOBJECTP9variptr_uS2_ii",
@@ -81473,7 +81473,7 @@
     {
       "name": "legoapi/world/levels.cpp.o",
       "source": "src/legoapi/world/levels.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/levels.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levels.o",
       "functions": [
         {
           "name": "_Z15getSpawnLocatorfPc",
@@ -81520,7 +81520,7 @@
     {
       "name": "legoapi/world/levels/episode.cpp.o",
       "source": "src/legoapi/world/levels/episode.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episode.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episode.o",
       "functions": [
         {
           "name": "_Z32Episodes_CompleteAllSuperStoriesv",
@@ -81711,7 +81711,7 @@
     {
       "name": "legoapi/world/levels/episodeI.cpp.o",
       "source": "src/legoapi/world/levels/episodeI.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeI.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeI.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeI.cpp",
@@ -82222,7 +82222,7 @@
     {
       "name": "legoapi/world/levels/episodeII.cpp.o",
       "source": "src/legoapi/world/levels/episodeII.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeII.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeII.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeII.cpp",
@@ -82677,7 +82677,7 @@
     {
       "name": "legoapi/world/levels/episodeIII.cpp.o",
       "source": "src/legoapi/world/levels/episodeIII.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIII.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIII.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeIII.cpp",
@@ -83068,7 +83068,7 @@
     {
       "name": "legoapi/world/levels/episodeIV.cpp.o",
       "source": "src/legoapi/world/levels/episodeIV.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIV.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIV.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeIV.cpp",
@@ -83419,7 +83419,7 @@
     {
       "name": "legoapi/world/levels/episodeV.cpp.o",
       "source": "src/legoapi/world/levels/episodeV.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeV.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeV.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeV.cpp",
@@ -84010,7 +84010,7 @@
     {
       "name": "legoapi/world/levels/episodeVI.cpp.o",
       "source": "src/legoapi/world/levels/episodeVI.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeVI.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeVI.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeVI.cpp",
@@ -84321,7 +84321,7 @@
     {
       "name": "legoapi/world/levels/hub.cpp.o",
       "source": "src/legoapi/world/levels/hub.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/hub.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hub.o",
       "functions": [
         {
           "name": "_ZL21Hub_DrawBonusModeMenuif",
@@ -84616,7 +84616,7 @@
     {
       "name": "legoapi/world/levels/lego_city.cpp.o",
       "source": "src/legoapi/world/levels/lego_city.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/lego_city.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lego_city.o",
       "functions": [
         {
           "name": "_Z13LegoCity_InitP11WORLDINFO_s",
@@ -84647,7 +84647,7 @@
     {
       "name": "legoapi/world/levels/new_town.cpp.o",
       "source": "src/legoapi/world/levels/new_town.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/new_town.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/new_town.o",
       "functions": [
         {
           "name": "_Z12NewTown_InitP11WORLDINFO_s",
@@ -84678,7 +84678,7 @@
     {
       "name": "legoapi/world/levels/senate.cpp.o",
       "source": "src/legoapi/world/levels/senate.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/senate.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/senate.o",
       "functions": [
         {
           "name": "_Z12SenateA_InitP11WORLDINFO_s",
@@ -84693,7 +84693,7 @@
     {
       "name": "legoapi/world/levelstreaming.cpp.o",
       "source": "src/legoapi/world/levelstreaming.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/levelstreaming.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levelstreaming.o",
       "functions": [
         {
           "name": "_Z32LevelProgress_ReserveBufferSpaceP9variptr_uS_",
@@ -84724,7 +84724,7 @@
     {
       "name": "legoapi/world/mission.cpp.o",
       "source": "src/legoapi/world/mission.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/mission.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/mission.o",
       "functions": [
         {
           "name": "_Z18Missions_ConfigurePcP9variptr_uS1_P13MISSIONSAVE_s",
@@ -84739,7 +84739,7 @@
     {
       "name": "legoapi/world/missions.cpp.o",
       "source": "src/legoapi/world/missions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/missions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/missions.o",
       "functions": [
         {
           "name": "_Z13InitChallengei",
@@ -84842,7 +84842,7 @@
     {
       "name": "legoapi/world/world.cpp.o",
       "source": "src/legoapi/world/world.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/world.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/world.o",
       "functions": [
         {
           "name": "_Z21MakeFreePlayModelListiiiii",
@@ -85017,7 +85017,7 @@
     {
       "name": "legogame/game.cpp.o",
       "source": "src/legogame/game.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legogame/game.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legogame/game.o",
       "functions": [
         {
           "name": "_Z12MakeSaveHashv",
@@ -85096,7 +85096,7 @@
     {
       "name": "legogame/startup.cpp.o",
       "source": "src/legogame/startup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legogame/startup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legogame/startup.o",
       "functions": [
         {
           "name": "_ZL12LoadPermDataP12bgprocinfo_s",
@@ -85135,7 +85135,7 @@
     {
       "name": "legogame/target_android.cpp.o",
       "source": "src/legogame/target_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legogame/target_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legogame/target_android.o",
       "functions": [
         {
           "name": "_ZL29SystemDidBecomeActiveCallbackPK20NuPhoneOSMessageData",
@@ -85174,7 +85174,7 @@
     {
       "name": "nu2api/nu3d/NuRenderDevice.cpp.o",
       "source": "src/nu2api/nu3d/NuRenderDevice.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuRenderDevice.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuRenderDevice.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_NuRenderDevice.cpp",
@@ -85453,7 +85453,7 @@
     {
       "name": "nu2api/nu3d/android/nugscn_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nugscn_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn_android.o",
       "functions": [
         {
           "name": "_ZL5NuMaxii",
@@ -85476,7 +85476,7 @@
     {
       "name": "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
       "source": "src/nu2api/nu3d/android/nuiosdl_gl.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuiosdl_gl.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuiosdl_gl.o",
       "functions": [
         {
           "name": "_Z21NuIOSDLGeom2DCallbackPv",
@@ -85619,7 +85619,7 @@
     {
       "name": "nu2api/nu3d/android/numtl_android.cpp.o",
       "source": "src/nu2api/nu3d/android/numtl_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numtl_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numtl_android.o",
       "functions": [
         {
           "name": "_Z13NuMtlCreatePSP7numtl_si",
@@ -85650,7 +85650,7 @@
     {
       "name": "nu2api/nu3d/android/nuposteffect_plain.cpp.o",
       "source": "src/nu2api/nu3d/android/nuposteffect_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuposteffect_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuposteffect_plain.o",
       "functions": [
         {
           "name": "NuFramebufferSwapBuffers",
@@ -85713,7 +85713,7 @@
     {
       "name": "nu2api/nu3d/android/nuptl_flush.cpp.o",
       "source": "src/nu2api/nu3d/android/nuptl_flush.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuptl_flush.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuptl_flush.o",
       "functions": [
         {
           "name": "NuInitDebrisRenderer",
@@ -85744,7 +85744,7 @@
     {
       "name": "nu2api/nu3d/android/nuqfnt_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nuqfnt_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt_android.o",
       "functions": [
         {
           "name": "NuQFntSetMtxRS",
@@ -85767,7 +85767,7 @@
     {
       "name": "nu2api/nu3d/android/nurenderthread.cpp.o",
       "source": "src/nu2api/nu3d/android/nurenderthread.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurenderthread.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurenderthread.o",
       "functions": [
         {
           "name": "NuRenderThreadCreate",
@@ -85846,7 +85846,7 @@
     {
       "name": "nu2api/nu3d/android/nurndr_android.c.o",
       "source": "src/nu2api/nu3d/android/nurndr_android.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_android.o",
       "functions": [
         {
           "name": "FaceYDirStream",
@@ -85877,7 +85877,7 @@
     {
       "name": "nu2api/nu3d/android/nutex_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nutex_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_android.o",
       "functions": [
         {
           "name": "_Z13NuTexCreatePSP13nunativetex_sb",
@@ -85996,7 +85996,7 @@
     {
       "name": "nu2api/nu3d/android/nutex_ios_ex.cpp.o",
       "source": "src/nu2api/nu3d/android/nutex_ios_ex.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_ios_ex.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_ios_ex.o",
       "functions": [
         {
           "name": "_Z20GetTextureFormatInfo11NUTEXFORMATRjS0_",
@@ -86123,7 +86123,7 @@
     {
       "name": "nu2api/nu3d/android/nutimebar_plain.cpp.o",
       "source": "src/nu2api/nu3d/android/nutimebar_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutimebar_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutimebar_plain.o",
       "functions": [
         {
           "name": "NuTimeBarCreateSetEx",
@@ -86186,7 +86186,7 @@
     {
       "name": "nu2api/nu3d/android/nuvertexformat_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nuvertexformat_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvertexformat_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvertexformat_android.o",
       "functions": [
         {
           "name": "NuGetVertexDeclaration",
@@ -86201,7 +86201,7 @@
     {
       "name": "nu2api/nu3d/generic/nucamera_gen.cpp.o",
       "source": "src/nu2api/nu3d/generic/nucamera_gen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera_gen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera_gen.o",
       "functions": [
         {
           "name": "NuCameraCreate",
@@ -86368,7 +86368,7 @@
     {
       "name": "nu2api/nu3d/nucamera.cpp.o",
       "source": "src/nu2api/nu3d/nucamera.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera.o",
       "functions": [
         {
           "name": "NuCameraClipTestExtents",
@@ -86391,7 +86391,7 @@
     {
       "name": "nu2api/nu3d/nucamvu0.c.o",
       "source": "src/nu2api/nu3d/nucamvu0.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucamvu0.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucamvu0.o",
       "functions": [
         {
           "name": "NuCameraInitClipTestVU0",
@@ -86406,7 +86406,7 @@
     {
       "name": "nu2api/nu3d/nudlist.cpp.o",
       "source": "src/nu2api/nu3d/nudlist.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist.o",
       "functions": [
         {
           "name": "NuDisplayListDrawItems",
@@ -86533,7 +86533,7 @@
     {
       "name": "nu2api/nu3d/nudlist_stubs.cpp.o",
       "source": "src/nu2api/nu3d/nudlist_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist_stubs.o",
       "functions": [
         {
           "name": "NuDisplayListCheckBuffer",
@@ -86612,7 +86612,7 @@
     {
       "name": "nu2api/nu3d/nufogstate.cpp.o",
       "source": "src/nu2api/nu3d/nufogstate.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufogstate.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufogstate.o",
       "functions": [
         {
           "name": "NuRndrStateSetFogEnabled",
@@ -86635,7 +86635,7 @@
     {
       "name": "nu2api/nu3d/nugscn.cpp.o",
       "source": "src/nu2api/nu3d/nugscn.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn.o",
       "functions": [
         {
           "name": "_Z18NuGScnMtlLayerMaskP8nugscn_sh",
@@ -86730,7 +86730,7 @@
     {
       "name": "nu2api/nu3d/numtl.cpp.o",
       "source": "src/nu2api/nu3d/numtl.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numtl.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numtl.o",
       "functions": [
         {
           "name": "_Z13NuMtlUpdatePSP7numtl_s",
@@ -86833,7 +86833,7 @@
     {
       "name": "nu2api/nu3d/nuocclusion.cpp.o",
       "source": "src/nu2api/nu3d/nuocclusion.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuocclusion.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuocclusion.o",
       "functions": [
         {
           "name": "NuOcclusionManagerBeginFrame",
@@ -86848,7 +86848,7 @@
     {
       "name": "nu2api/nu3d/nuportal.cpp.o",
       "source": "src/nu2api/nu3d/nuportal.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuportal.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuportal.o",
       "functions": [
         {
           "name": "_ZL19transposeClipPlanesP10NUFRUSTRUM",
@@ -86911,7 +86911,7 @@
     {
       "name": "nu2api/nu3d/nuprim.cpp.o",
       "source": "src/nu2api/nu3d/nuprim.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuprim.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuprim.o",
       "functions": [
         {
           "name": "NuPrimPushCoordSystem",
@@ -86950,7 +86950,7 @@
     {
       "name": "nu2api/nu3d/nuqfnt.cpp.o",
       "source": "src/nu2api/nu3d/nuqfnt.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt.o",
       "functions": [
         {
           "name": "NuQFntPushPrintMode",
@@ -87213,7 +87213,7 @@
     {
       "name": "nu2api/nu3d/nurndr.cpp.o",
       "source": "src/nu2api/nu3d/nurndr.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr.o",
       "functions": [
         {
           "name": "_Z33NuRndrCreateBlendShapeDWAPointersi",
@@ -87396,7 +87396,7 @@
     {
       "name": "nu2api/nu3d/nurndr_grad.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_grad.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_grad.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_grad.o",
       "functions": [
         {
           "name": "NuRndrGradClear",
@@ -87411,7 +87411,7 @@
     {
       "name": "nu2api/nu3d/nurndr_noops.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_noops.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_noops.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_noops.o",
       "functions": [
         {
           "name": "NuRndrShadowOnOff",
@@ -87434,7 +87434,7 @@
     {
       "name": "nu2api/nu3d/nurndr_plain.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_plain.o",
       "functions": [
         {
           "name": "NuRndrPspDraw",
@@ -88465,7 +88465,7 @@
     {
       "name": "nu2api/nu3d/nurndr_shadow.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_shadow.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_shadow.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_shadow.o",
       "functions": [
         {
           "name": "NuRndrAddShadow",
@@ -88480,7 +88480,7 @@
     {
       "name": "nu2api/nu3d/nuscreen.cpp.o",
       "source": "src/nu2api/nu3d/nuscreen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuscreen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuscreen.o",
       "functions": [
         {
           "name": "_ZN8NuScreen6CreateEv",
@@ -88551,7 +88551,7 @@
     {
       "name": "nu2api/nu3d/nushader.cpp.o",
       "source": "src/nu2api/nu3d/nushader.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nushader.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nushader.o",
       "functions": [
         {
           "name": "NuShaderProgramSetVertexParamfv",
@@ -88782,7 +88782,7 @@
     {
       "name": "nu2api/nu3d/nushadermanager_plain.cpp.o",
       "source": "src/nu2api/nu3d/nushadermanager_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nushadermanager_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nushadermanager_plain.o",
       "functions": [
         {
           "name": "NuShaderManagerInit",
@@ -88869,7 +88869,7 @@
     {
       "name": "nu2api/nu3d/nuspecial.cpp.o",
       "source": "src/nu2api/nu3d/nuspecial.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuspecial.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuspecial.o",
       "functions": [
         {
           "name": "NuSpecialGetName",
@@ -88964,7 +88964,7 @@
     {
       "name": "nu2api/nu3d/nuspline.c.o",
       "source": "src/nu2api/nu3d/nuspline.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuspline.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuspline.o",
       "functions": [
         {
           "name": "NuSplineFind",
@@ -88979,7 +88979,7 @@
     {
       "name": "nu2api/nu3d/nutex.cpp.o",
       "source": "src/nu2api/nu3d/nutex.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutex.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutex.o",
       "functions": [
         {
           "name": "_Z15NuTexReadBitmapPc",
@@ -89202,13 +89202,13 @@
     {
       "name": "nu2api/nu3d/nutexanm.c.o",
       "source": "src/nu2api/nu3d/nutexanm.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanm.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanm.o",
       "functions": []
     },
     {
       "name": "nu2api/nu3d/nuvport.cpp.o",
       "source": "src/nu2api/nu3d/nuvport.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport.o",
       "functions": [
         {
           "name": "_Z16NuPs2GetViewportP12nuviewport_s",
@@ -89311,13 +89311,13 @@
     {
       "name": "nu2api/nu3d/nuvport_ps2.cpp.o",
       "source": "src/nu2api/nu3d/nuvport_ps2.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport_ps2.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport_ps2.o",
       "functions": []
     },
     {
       "name": "nu2api/nu3d/nuwater.cpp.o",
       "source": "src/nu2api/nu3d/nuwater.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater.o",
       "functions": [
         {
           "name": "NuWaterReset",
@@ -89332,7 +89332,7 @@
     {
       "name": "nu2api/nu3d/nuwater_speed.cpp.o",
       "source": "src/nu2api/nu3d/nuwater_speed.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater_speed.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater_speed.o",
       "functions": [
         {
           "name": "NuWaterSpeed",
@@ -89347,7 +89347,7 @@
     {
       "name": "nu2api/nuandroid/ios_graphics.cpp.o",
       "source": "src/nu2api/nuandroid/ios_graphics.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/ios_graphics.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/ios_graphics.o",
       "functions": [
         {
           "name": "NuIOS_ShouldUseMSAA",
@@ -89474,7 +89474,7 @@
     {
       "name": "nu2api/nuandroid/nuphoneos.cpp.o",
       "source": "src/nu2api/nuandroid/nuphoneos.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuphoneos.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuphoneos.o",
       "functions": [
         {
           "name": "NuPhoneOSRegisterEventCallback",
@@ -89489,7 +89489,7 @@
     {
       "name": "nu2api/nucore/NuInputDevice.cpp.o",
       "source": "src/nu2api/nucore/NuInputDevice.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice.o",
       "functions": [
         {
           "name": "_ZN13NuInputDevice15SetDisconnectedEv",
@@ -89600,7 +89600,7 @@
     {
       "name": "nu2api/nucore/NuInputManager.cpp.o",
       "source": "src/nu2api/nucore/NuInputManager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputManager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputManager.o",
       "functions": [
         {
           "name": "_ZN14NuInputManagerD1Ev",
@@ -89671,7 +89671,7 @@
     {
       "name": "nu2api/nucore/NuMemoryManager.cpp.o",
       "source": "src/nu2api/nucore/NuMemoryManager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryManager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryManager.o",
       "functions": [
         {
           "name": "_ZN15NuMemoryManager13IErrorHandler11HandleErrorEPS_NS_9ErrorCodeEPKc",
@@ -90022,7 +90022,7 @@
     {
       "name": "nu2api/nucore/NuMemoryPool.cpp.o",
       "source": "src/nu2api/nucore/NuMemoryPool.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryPool.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryPool.o",
       "functions": [
         {
           "name": "_ZN12NuMemoryPool14InterlockedAddEPVjj",
@@ -90053,7 +90053,7 @@
     {
       "name": "nu2api/nucore/NuThreadManager.cpp.o",
       "source": "src/nu2api/nucore/NuThreadManager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuThreadManager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuThreadManager.o",
       "functions": [
         {
           "name": "_ZN15NuThreadManagerC1Ev",
@@ -90124,7 +90124,7 @@
     {
       "name": "nu2api/nucore/NuVirtualTouchDevice.cpp.o",
       "source": "src/nu2api/nucore/NuVirtualTouchDevice.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuVirtualTouchDevice.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuVirtualTouchDevice.o",
       "functions": [
         {
           "name": "_ZN20NuVirtualTouchDeviceC1Ej",
@@ -90187,7 +90187,7 @@
     {
       "name": "nu2api/nucore/android/NuInputDevice_android.cpp.o",
       "source": "src/nu2api/nucore/android/NuInputDevice_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice_android.o",
       "functions": [
         {
           "name": "_ZN15NuInputDevicePS11ClassInitPSEv",
@@ -90354,7 +90354,7 @@
     {
       "name": "nu2api/nucore/android/NuThread_android.cpp.o",
       "source": "src/nu2api/nucore/android/NuThread_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuThread_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuThread_android.o",
       "functions": [
         {
           "name": "_ZN8NuThreadD1Ev",
@@ -90553,7 +90553,7 @@
     {
       "name": "nu2api/nucore/android/bgproc_android.cpp.o",
       "source": "src/nu2api/nucore/android/bgproc_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/bgproc_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/bgproc_android.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_bgproc_android.cpp",
@@ -90608,7 +90608,7 @@
     {
       "name": "nu2api/nucore/android/nuapi_android.cpp.o",
       "source": "src/nu2api/nucore/android/nuapi_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuapi_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuapi_android.o",
       "functions": [
         {
           "name": "NudxFw_D3DBeginCriticalSection",
@@ -90655,7 +90655,7 @@
     {
       "name": "nu2api/nucore/android/numemory_android.cpp.o",
       "source": "src/nu2api/nucore/android/numemory_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numemory_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numemory_android.o",
       "functions": [
         {
           "name": "_ZN10NuMemoryPS16Mem2EventHandler12AllocatePageEP15NuMemoryManagerjj",
@@ -90726,7 +90726,7 @@
     {
       "name": "nu2api/nucore/android/nupad_android.cpp.o",
       "source": "src/nu2api/nucore/android/nupad_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_android.o",
       "functions": [
         {
           "name": "_Z11NuPadOpenPSP7nupad_s",
@@ -90765,7 +90765,7 @@
     {
       "name": "nu2api/nucore/android/nutime_android.cpp.o",
       "source": "src/nu2api/nucore/android/nutime_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutime_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutime_android.o",
       "functions": [
         {
           "name": "_Z29NuGetCurrentTimeMilisecondsPSv",
@@ -90804,7 +90804,7 @@
     {
       "name": "nu2api/nucore/android/nuvideo_android.cpp.o",
       "source": "src/nu2api/nucore/android/nuvideo_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo_android.o",
       "functions": [
         {
           "name": "_Z20NuVideoSetSwapModePS16NUVIDEO_SWAPMODE",
@@ -90835,7 +90835,7 @@
     {
       "name": "nu2api/nucore/deflate.cpp.o",
       "source": "src/nu2api/nucore/deflate.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/deflate.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/deflate.o",
       "functions": [
         {
           "name": "_Z16BuildHuffmanTreeP10DEFHUFFMANPhi",
@@ -90906,7 +90906,7 @@
     {
       "name": "nu2api/nucore/implode.cpp.o",
       "source": "src/nu2api/nucore/implode.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/implode.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/implode.o",
       "functions": [
         {
           "name": "_ZL7__sputciP7__sFILE",
@@ -91073,7 +91073,7 @@
     {
       "name": "nu2api/nucore/nu2api_nucore_misc.cpp.o",
       "source": "src/nu2api/nucore/nu2api_nucore_misc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc.o",
       "functions": [
         {
           "name": "_Z30NuIOS_CateInAppPurchaseManagerv",
@@ -92104,7 +92104,7 @@
     {
       "name": "nu2api/nucore/nu2api_nucore_misc_stubs.cpp.o",
       "source": "src/nu2api/nucore/nu2api_nucore_misc_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc_stubs.o",
       "functions": [
         {
           "name": "_Z19NuTerminateHardwarev",
@@ -92175,7 +92175,7 @@
     {
       "name": "nu2api/nucore/nuanim.cpp.o",
       "source": "src/nu2api/nucore/nuanim.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuanim.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuanim.o",
       "functions": [
         {
           "name": "NuAnimEndFrame",
@@ -92198,7 +92198,7 @@
     {
       "name": "nu2api/nucore/nuapi.c.o",
       "source": "src/nu2api/nucore/nuapi.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/0/nuapi.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nuapi.o",
       "functions": [
         {
           "name": "NuPrimReset",
@@ -92221,7 +92221,7 @@
     {
       "name": "nu2api/nucore/nuapi.cpp.o",
       "source": "src/nu2api/nucore/nuapi.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/1/nuapi.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nuapi.o",
       "functions": [
         {
           "name": "_Z9NuAPIInitv",
@@ -92260,7 +92260,7 @@
     {
       "name": "nu2api/nucore/nucore.cpp.o",
       "source": "src/nu2api/nucore/nucore.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucore.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucore.o",
       "functions": [
         {
           "name": "_ZN6NuCore19GetApplicationStateEv",
@@ -93355,7 +93355,7 @@
     {
       "name": "nu2api/nucore/nucore_plain.cpp.o",
       "source": "src/nu2api/nucore/nucore_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucore_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucore_plain.o",
       "functions": [
         {
           "name": "NuIOS_DeallocateSystemRenderbuffer",
@@ -99866,7 +99866,7 @@
     {
       "name": "nu2api/nucore/nuhgobj.cpp.o",
       "source": "src/nu2api/nucore/nuhgobj.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuhgobj.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuhgobj.o",
       "functions": [
         {
           "name": "NuHGobjGetLayerIndex",
@@ -99881,7 +99881,7 @@
     {
       "name": "nu2api/nucore/nuios_metrics.cpp.o",
       "source": "src/nu2api/nucore/nuios_metrics.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuios_metrics.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuios_metrics.o",
       "functions": [
         {
           "name": "NuIOS_GetAspectRatio",
@@ -99904,7 +99904,7 @@
     {
       "name": "nu2api/nucore/nukeyboard.cpp.o",
       "source": "src/nu2api/nucore/nukeyboard.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nukeyboard.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nukeyboard.o",
       "functions": [
         {
           "name": "NuKeyboardRead",
@@ -99919,7 +99919,7 @@
     {
       "name": "nu2api/nucore/nulanguage.cpp.o",
       "source": "src/nu2api/nucore/nulanguage.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nulanguage.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nulanguage.o",
       "functions": [
         {
           "name": "NuLanguageGet",
@@ -99942,7 +99942,7 @@
     {
       "name": "nu2api/nucore/nulist.cpp.o",
       "source": "src/nu2api/nucore/nulist.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nulist.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nulist.o",
       "functions": [
         {
           "name": "NuLinkedListAppend",
@@ -100005,7 +100005,7 @@
     {
       "name": "nu2api/nucore/nulst.cpp.o",
       "source": "src/nu2api/nucore/nulst.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nulst.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nulst.o",
       "functions": [
         {
           "name": "NuLstCreate",
@@ -100068,7 +100068,7 @@
     {
       "name": "nu2api/nucore/numem.c.o",
       "source": "src/nu2api/nucore/numem.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numem.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numem.o",
       "functions": [
         {
           "name": "NuMemSet128",
@@ -100083,7 +100083,7 @@
     {
       "name": "nu2api/nucore/numemory.cpp.o",
       "source": "src/nu2api/nucore/numemory.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numemory.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numemory.o",
       "functions": [
         {
           "name": "_ZN8NuMemory21FixedPoolEventHandler12AllocatePageEP12NuMemoryPooljjPKc",
@@ -100842,7 +100842,7 @@
     {
       "name": "nu2api/nucore/numouse.cpp.o",
       "source": "src/nu2api/nucore/numouse.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numouse.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numouse.o",
       "functions": [
         {
           "name": "NuMouseRead",
@@ -100857,7 +100857,7 @@
     {
       "name": "nu2api/nucore/nunew.cpp.o",
       "source": "src/nu2api/nucore/nunew.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nunew.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nunew.o",
       "functions": [
         {
           "name": "_Znwj",
@@ -100960,7 +100960,7 @@
     {
       "name": "nu2api/nucore/nupad.cpp.o",
       "source": "src/nu2api/nucore/nupad.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nupad.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nupad.o",
       "functions": [
         {
           "name": "_ZL21DeadZoneValueXYProperPiS_i",
@@ -101095,7 +101095,7 @@
     {
       "name": "nu2api/nucore/nupad_interface.cpp.o",
       "source": "src/nu2api/nucore/nupad_interface.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_interface.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_interface.o",
       "functions": [
         {
           "name": "_ZN15NuInputDevicePS15GetIdentifierPSEj",
@@ -101710,7 +101710,7 @@
     {
       "name": "nu2api/nucore/nuptrblock.cpp.o",
       "source": "src/nu2api/nucore/nuptrblock.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuptrblock.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuptrblock.o",
       "functions": [
         {
           "name": "NuPtrBlockFix",
@@ -101725,7 +101725,7 @@
     {
       "name": "nu2api/nucore/nurdpf.cpp.o",
       "source": "src/nu2api/nucore/nurdpf.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpf.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpf.o",
       "functions": [
         {
           "name": "_ZL10isnumordotc",
@@ -101788,7 +101788,7 @@
     {
       "name": "nu2api/nucore/nurdpi.cpp.o",
       "source": "src/nu2api/nucore/nurdpi.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpi.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpi.o",
       "functions": [
         {
           "name": "_ZL5isnumc",
@@ -101867,7 +101867,7 @@
     {
       "name": "nu2api/nucore/nustring.cpp.o",
       "source": "src/nu2api/nucore/nustring.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nustring.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nustring.o",
       "functions": [
         {
           "name": "_ZL17NuStringCharEquivtt",
@@ -101922,7 +101922,7 @@
     {
       "name": "nu2api/nucore/nustring_c.cpp.o",
       "source": "src/nu2api/nucore/nustring_c.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nustring_c.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nustring_c.o",
       "functions": [
         {
           "name": "NuStrCat",
@@ -102193,7 +102193,7 @@
     {
       "name": "nu2api/nucore/nutexanim.cpp.o",
       "source": "src/nu2api/nucore/nutexanim.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanim.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanim.o",
       "functions": [
         {
           "name": "NuTexAnimSetSignals",
@@ -102216,7 +102216,7 @@
     {
       "name": "nu2api/nucore/nuthread.cpp.o",
       "source": "src/nu2api/nucore/nuthread.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuthread.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuthread.o",
       "functions": [
         {
           "name": "_ZN8NuThread12SetDebugNameEPKc",
@@ -102311,7 +102311,7 @@
     {
       "name": "nu2api/nucore/nutime.cpp.o",
       "source": "src/nu2api/nucore/nutime.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutime.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutime.o",
       "functions": [
         {
           "name": "NuTimeGetFrameTime",
@@ -102366,7 +102366,7 @@
     {
       "name": "nu2api/nucore/nuvideo.cpp.o",
       "source": "src/nu2api/nucore/nuvideo.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo.o",
       "functions": [
         {
           "name": "NuVideoGetMode",
@@ -102437,7 +102437,7 @@
     {
       "name": "nu2api/nucore/pending_stubs.cpp.o",
       "source": "src/nu2api/nucore/pending_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/pending_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/pending_stubs.o",
       "functions": [
         {
           "name": "NuTexAnimProgSysInit",
@@ -102780,7 +102780,7 @@
     {
       "name": "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
       "source": "src/nu2api/nufile/NuFileDeviceAndroidAPK.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileDeviceAndroidAPK.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileDeviceAndroidAPK.o",
       "functions": [
         {
           "name": "_ZN22NuFileDeviceAndroidAPKD1Ev",
@@ -102835,13 +102835,13 @@
     {
       "name": "nu2api/nufile/android/NuFileAndroidDeviceAPK.cpp.o",
       "source": "src/nu2api/nufile/android/NuFileAndroidDeviceAPK.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileAndroidDeviceAPK.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileAndroidDeviceAPK.o",
       "functions": []
     },
     {
       "name": "nu2api/nufile/android/nufile_android.cpp.o",
       "source": "src/nu2api/nufile/android/nufile_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile_android.o",
       "functions": [
         {
           "name": "_ZN16NuFileAndroidAPK11GetFileSizeEi",
@@ -103024,7 +103024,7 @@
     {
       "name": "nu2api/nufile/nudatfile.cpp.o",
       "source": "src/nu2api/nufile/nudatfile.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nudatfile.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudatfile.o",
       "functions": [
         {
           "name": "_Z12NuDatCalcPosP10nudathdr_si",
@@ -103071,7 +103071,7 @@
     {
       "name": "nu2api/nufile/nufile.c.o",
       "source": "src/nu2api/nufile/nufile.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile.o",
       "functions": [
         {
           "name": "DEVHOST_Interrogate",
@@ -103110,7 +103110,7 @@
     {
       "name": "nu2api/nufile/nufile.cpp.o",
       "source": "src/nu2api/nufile/nufile.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile.o",
       "functions": [
         {
           "name": "_ZL19NuDatFileDecodeInitv",
@@ -103613,7 +103613,7 @@
     {
       "name": "nu2api/nufile/nufile_android.cpp.o",
       "source": "src/nu2api/nufile/nufile_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile_android.o",
       "functions": [
         {
           "name": "_ZN16NuFileAndroidAPK4InitEv",
@@ -103652,7 +103652,7 @@
     {
       "name": "nu2api/nufile/nufile_plain.cpp.o",
       "source": "src/nu2api/nufile/nufile_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufile_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufile_plain.o",
       "functions": [
         {
           "name": "NuFileSwapEndianOnWrite",
@@ -104171,7 +104171,7 @@
     {
       "name": "nu2api/nufile/nufilebase.cpp.o",
       "source": "src/nu2api/nufile/nufilebase.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufilebase.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufilebase.o",
       "functions": [
         {
           "name": "_ZN10NuFileBaseD1Ev",
@@ -104370,7 +104370,7 @@
     {
       "name": "nu2api/nufile/nufiledevice.cpp.o",
       "source": "src/nu2api/nufile/nufiledevice.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufiledevice.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufiledevice.o",
       "functions": [
         {
           "name": "_ZN12NuFileDeviceD1Ev",
@@ -104553,7 +104553,7 @@
     {
       "name": "nu2api/nufile/nufilepak.cpp.o",
       "source": "src/nu2api/nufile/nufilepak.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufilepak.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufilepak.o",
       "functions": [
         {
           "name": "_ZL8GetItemsP16nufilepakhdrv2_s",
@@ -104632,7 +104632,7 @@
     {
       "name": "nu2api/nufile/nufpar.cpp.o",
       "source": "src/nu2api/nufile/nufpar.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufpar.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufpar.o",
       "functions": [
         {
           "name": "_ZL15Traffic_tfactorP8nufpar_s",
@@ -105447,7 +105447,7 @@
     {
       "name": "nu2api/nufile/numc.cpp.o",
       "source": "src/nu2api/nufile/numc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numc.o",
       "functions": [
         {
           "name": "_Z16NuMcFileOpenSizei",
@@ -105510,7 +105510,7 @@
     {
       "name": "nu2api/nufile/tmclient.cpp.o",
       "source": "src/nu2api/nufile/tmclient.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/tmclient.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/tmclient.o",
       "functions": [
         {
           "name": "_ZN8TMClientC1EiPc",
@@ -105533,7 +105533,7 @@
     {
       "name": "nu2api/numath/nufloat.c.o",
       "source": "src/nu2api/numath/nufloat.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufloat.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufloat.o",
       "functions": [
         {
           "name": "NuFsel",
@@ -105644,7 +105644,7 @@
     {
       "name": "nu2api/numath/numaths.cpp.o",
       "source": "src/nu2api/numath/numaths.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numaths.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numaths.o",
       "functions": [
         {
           "name": "_Z21NuVecClipTestPointVU0P7nuvec_sP7numtx_s",
@@ -105675,7 +105675,7 @@
     {
       "name": "nu2api/numath/numaths_plain.cpp.o",
       "source": "src/nu2api/numath/numaths_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numaths_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numaths_plain.o",
       "functions": [
         {
           "name": "NuVecMtxRotateValX",
@@ -105978,7 +105978,7 @@
     {
       "name": "nu2api/numath/numtx.cpp.o",
       "source": "src/nu2api/numath/numtx.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numtx.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numtx.o",
       "functions": [
         {
           "name": "NuMtxSetZero",
@@ -106681,7 +106681,7 @@
     {
       "name": "nu2api/numath/nuplane.cpp.o",
       "source": "src/nu2api/numath/nuplane.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuplane.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuplane.o",
       "functions": [
         {
           "name": "NuPlnEqn",
@@ -106776,7 +106776,7 @@
     {
       "name": "nu2api/numath/nuquat.cpp.o",
       "source": "src/nu2api/numath/nuquat.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuquat.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuquat.o",
       "functions": [
         {
           "name": "_ZL16NuQTUnfixAddressP9nuqthdr_s",
@@ -106967,7 +106967,7 @@
     {
       "name": "nu2api/numath/nurand.cpp.o",
       "source": "src/nu2api/numath/nurand.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurand.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurand.o",
       "functions": [
         {
           "name": "NuRandSeed",
@@ -107046,7 +107046,7 @@
     {
       "name": "nu2api/numath/nutrig.c.o",
       "source": "src/nu2api/numath/nutrig.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/0/nutrig.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nutrig.o",
       "functions": [
         {
           "name": "NuASin",
@@ -107141,7 +107141,7 @@
     {
       "name": "nu2api/numath/nutrig.cpp.o",
       "source": "src/nu2api/numath/nutrig.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/1/nutrig.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nutrig.o",
       "functions": [
         {
           "name": "_ZL12NuSinApprox3i",
@@ -107212,7 +107212,7 @@
     {
       "name": "nu2api/numath/nutrig_gen.cpp.o",
       "source": "src/nu2api/numath/nutrig_gen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutrig_gen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutrig_gen.o",
       "functions": [
         {
           "name": "NuTrigInit",
@@ -107227,7 +107227,7 @@
     {
       "name": "nu2api/numath/nuvec.cpp.o",
       "source": "src/nu2api/numath/nuvec.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec.o",
       "functions": [
         {
           "name": "NuVecMtxTransform",
@@ -107522,7 +107522,7 @@
     {
       "name": "nu2api/numath/nuvec4.c.o",
       "source": "src/nu2api/numath/nuvec4.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec4.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec4.o",
       "functions": [
         {
           "name": "NuVec4Add",
@@ -107569,7 +107569,7 @@
     {
       "name": "nu2api/numath/vumath.c.o",
       "source": "src/nu2api/numath/vumath.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/vumath.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/vumath.o",
       "functions": [
         {
           "name": "VuQuatBlend",
@@ -107632,7 +107632,7 @@
     {
       "name": "nu2api/numusic/numusic.cpp.o",
       "source": "src/nu2api/numusic/numusic.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numusic.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numusic.o",
       "functions": [
         {
           "name": "_ZN7NuMusic18GlobalParseErrorFnEP8nufpar_s",
@@ -108407,7 +108407,7 @@
     {
       "name": "nu2api/numusic/sfx.cpp.o",
       "source": "src/nu2api/numusic/sfx.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/sfx.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/sfx.o",
       "functions": [
         {
           "name": "_ZL12fnAudioAudioP8nufpar_s",
@@ -108470,7 +108470,7 @@
     {
       "name": "nu2api/nuplatform/nudevicespecs.cpp.o",
       "source": "src/nu2api/nuplatform/nudevicespecs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nudevicespecs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudevicespecs.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nudevicespecs.cpp",
@@ -108509,7 +108509,7 @@
     {
       "name": "nu2api/nuplatform/nuplatform.cpp.o",
       "source": "src/nu2api/nuplatform/nuplatform.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuplatform.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuplatform.o",
       "functions": [
         {
           "name": "_ZN10NuPlatform6CreateEv",
@@ -108532,7 +108532,7 @@
     {
       "name": "nu2api/nusound/nu2api_nusound_misc.cpp.o",
       "source": "src/nu2api/nusound/nu2api_nusound_misc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_misc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_misc.o",
       "functions": [
         {
           "name": "_ZN13NuSoundSystem22GetNearestRealListenerERK7NuEListI15NuSoundListener12DefaultElistERK5VuVec",
@@ -108587,7 +108587,7 @@
     {
       "name": "nu2api/nusound/nu2api_nusound_plain.cpp.o",
       "source": "src/nu2api/nusound/nu2api_nusound_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_plain.o",
       "functions": [
         {
           "name": "PrepareSounds",
@@ -108690,19 +108690,19 @@
     {
       "name": "nu2api/nusound/nu2api_nusound_types.cpp.o",
       "source": "src/nu2api/nusound/nu2api_nusound_types.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_types.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_types.o",
       "functions": []
     },
     {
       "name": "nu2api/nusound/nusound.cpp.o",
       "source": "src/nu2api/nusound/nusound.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound.o",
       "functions": []
     },
     {
       "name": "nu2api/nusound/nusound3_include.cpp.o",
       "source": "src/nu2api/nusound/nusound3_include.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound3_include.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound3_include.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound3_include.cpp",
@@ -108917,7 +108917,7 @@
     {
       "name": "nu2api/nusound/nusound_android.cpp.o",
       "source": "src/nu2api/nusound/nusound_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_android.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_android.cpp",
@@ -109044,7 +109044,7 @@
     {
       "name": "nu2api/nusound/nusound_buffer.cpp.o",
       "source": "src/nu2api/nusound/nusound_buffer.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_buffer.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_buffer.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_buffer.cpp",
@@ -109211,7 +109211,7 @@
     {
       "name": "nu2api/nusound/nusound_bus.cpp.o",
       "source": "src/nu2api/nusound/nusound_bus.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_bus.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_bus.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_bus.cpp",
@@ -109346,7 +109346,7 @@
     {
       "name": "nu2api/nusound/nusound_clock.cpp.o",
       "source": "src/nu2api/nusound/nusound_clock.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_clock.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_clock.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_clock.cpp",
@@ -109433,7 +109433,7 @@
     {
       "name": "nu2api/nusound/nusound_decoder.cpp.o",
       "source": "src/nu2api/nusound/nusound_decoder.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_decoder.cpp",
@@ -109664,7 +109664,7 @@
     {
       "name": "nu2api/nusound/nusound_decoder_ogg.cpp.o",
       "source": "src/nu2api/nusound/nusound_decoder_ogg.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder_ogg.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder_ogg.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_decoder_ogg.cpp",
@@ -109831,7 +109831,7 @@
     {
       "name": "nu2api/nusound/nusound_effect.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect.cpp",
@@ -109878,7 +109878,7 @@
     {
       "name": "nu2api/nusound/nusound_effect_doppler.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect_doppler.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_doppler.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_doppler.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect_doppler.cpp",
@@ -109949,7 +109949,7 @@
     {
       "name": "nu2api/nusound/nusound_effect_fader.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect_fader.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_fader.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_fader.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect_fader.cpp",
@@ -110076,7 +110076,7 @@
     {
       "name": "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect_pitchramp.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_pitchramp.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_pitchramp.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect_pitchramp.cpp",
@@ -110163,7 +110163,7 @@
     {
       "name": "nu2api/nusound/nusound_handle.cpp.o",
       "source": "src/nu2api/nusound/nusound_handle.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_handle.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_handle.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_handle.cpp",
@@ -110522,7 +110522,7 @@
     {
       "name": "nu2api/nusound/nusound_listener.cpp.o",
       "source": "src/nu2api/nusound/nusound_listener.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_listener.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_listener.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_listener.cpp",
@@ -110737,7 +110737,7 @@
     {
       "name": "nu2api/nusound/nusound_loader.cpp.o",
       "source": "src/nu2api/nusound/nusound_loader.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_loader.cpp",
@@ -110888,7 +110888,7 @@
     {
       "name": "nu2api/nusound/nusound_loader_ogg.cpp.o",
       "source": "src/nu2api/nusound/nusound_loader_ogg.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_ogg.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_ogg.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_loader_ogg.cpp",
@@ -111231,7 +111231,7 @@
     {
       "name": "nu2api/nusound/nusound_loader_wav.cpp.o",
       "source": "src/nu2api/nusound/nusound_loader_wav.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_wav.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_wav.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_loader_wav.cpp",
@@ -111462,7 +111462,7 @@
     {
       "name": "nu2api/nusound/nusound_memorymanager.cpp.o",
       "source": "src/nu2api/nusound/nusound_memorymanager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_memorymanager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_memorymanager.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_memorymanager.cpp",
@@ -111885,7 +111885,7 @@
     {
       "name": "nu2api/nusound/nusound_mixer.cpp.o",
       "source": "src/nu2api/nusound/nusound_mixer.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_mixer.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_mixer.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_mixer.cpp",
@@ -111948,7 +111948,7 @@
     {
       "name": "nu2api/nusound/nusound_plain.cpp.o",
       "source": "src/nu2api/nusound/nusound_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_plain.o",
       "functions": [
         {
           "name": "NuSound3InitEx",
@@ -112571,7 +112571,7 @@
     {
       "name": "nu2api/nusound/nusound_routing.cpp.o",
       "source": "src/nu2api/nusound/nusound_routing.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_routing.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_routing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_routing.cpp",
@@ -112658,7 +112658,7 @@
     {
       "name": "nu2api/nusound/nusound_sample.cpp.o",
       "source": "src/nu2api/nusound/nusound_sample.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_sample.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_sample.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_sample.cpp",
@@ -112857,7 +112857,7 @@
     {
       "name": "nu2api/nusound/nusound_source.cpp.o",
       "source": "src/nu2api/nusound/nusound_source.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_source.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_source.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_source.cpp",
@@ -112952,7 +112952,7 @@
     {
       "name": "nu2api/nusound/nusound_streamer.cpp.o",
       "source": "src/nu2api/nusound/nusound_streamer.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_streamer.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_streamer.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_streamer.cpp",
@@ -113167,7 +113167,7 @@
     {
       "name": "nu2api/nusound/nusound_system.cpp.o",
       "source": "src/nu2api/nusound/nusound_system.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_system.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_system.o",
       "functions": [
         {
           "name": "_Z19NuSound3ExitThreadsv",
@@ -113846,7 +113846,7 @@
     {
       "name": "nu2api/nusound/nusound_voice.cpp.o",
       "source": "src/nu2api/nusound/nusound_voice.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_voice.cpp",
@@ -114493,7 +114493,7 @@
     {
       "name": "nu2api/nusound/nusound_voice_android.cpp.o",
       "source": "src/nu2api/nusound/nusound_voice_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice_android.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_voice_android.cpp",
@@ -114724,7 +114724,7 @@
     {
       "name": "nu2api/nusound/nusound_weakptr.cpp.o",
       "source": "src/nu2api/nusound/nusound_weakptr.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_weakptr.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_weakptr.o",
       "functions": [
         {
           "name": "_ZN17NuCriticalSectionC1EPKc",

--- a/src/legoapi/gizmo/gizmos/gizmos_gizobstacles.cpp
+++ b/src/legoapi/gizmo/gizmos/gizmos_gizobstacles.cpp
@@ -58,13 +58,19 @@ static i32 GizObstacle_PosWithinBox(GIZOBSTACLE_s *obstacle, NUVEC *position) {
            local_position.z <= obstacle->trigger_box_half_extents.z;
 }
 
-void GizObstacle_Stop(GIZOBSTACLE_s *) {
+void GizObstacle_Stop(GIZOBSTACLE_s *obstacle) {
+    if (obstacle != NULL) {
+        GameAnimSet_Stop(obstacle->anim_set);
+    }
 }
 
 void GizObstacles_Hit(void *, GIZOBSTACLE_s *, nuvec_s *, i32, i32) {
 }
 
-void GizObstacle_JumpToEnd(GIZOBSTACLE_s *) {
+void GizObstacle_JumpToEnd(GIZOBSTACLE_s *obstacle) {
+    if (obstacle != NULL && obstacle->anim_set != NULL) {
+        GameAnimSet_JumpToEnd(obstacle->anim_set);
+    }
 }
 
 GIZOBSTACLE_s *GizObstacle_FindByName(GIZOBSTACLESYS_s *system, char *name) {
@@ -85,7 +91,10 @@ GIZOBSTACLE_s *GizObstacle_FindByName(GIZOBSTACLESYS_s *system, char *name) {
 void GizObstacle_FindNearest(GIZOBSTACLESYS_s *, nuvec_s *, GameObject_s *, float *, i32) {
 }
 
-void GizObstacle_JumpToStart(GIZOBSTACLE_s *) {
+void GizObstacle_JumpToStart(GIZOBSTACLE_s *obstacle) {
+    if (obstacle != NULL && obstacle->anim_set != NULL) {
+        GameAnimSet_JumpToStart(obstacle->anim_set);
+    }
 }
 
 void GizObstacles_AddTrigger(nuvec_s *position) {
@@ -103,10 +112,26 @@ void GizObstacles_AddTrigger(nuvec_s *position) {
 void GizObstacles_TotalScore(void *) {
 }
 
-void GizObstacle_PlayForwards(GIZOBSTACLE_s *) {
+void GizObstacle_PlayForwards(GIZOBSTACLE_s *obstacle) {
+    if (obstacle != NULL) {
+        GameAnimSet_SetRepeating(obstacle->anim_set, obstacle->state == 2);
+        if (obstacle->animation_speed < 0.0f) {
+            GameAnimSet_Play(obstacle->anim_set, obstacle->animation_speed * obstacle->field_0x50, 0);
+        } else {
+            GameAnimSet_Play(obstacle->anim_set, obstacle->animation_speed * obstacle->field_0x4c, 0);
+        }
+    }
 }
 
-void GizObstacle_PlayBackwards(GIZOBSTACLE_s *) {
+void GizObstacle_PlayBackwards(GIZOBSTACLE_s *obstacle) {
+    if (obstacle != NULL) {
+        GameAnimSet_SetRepeating(obstacle->anim_set, obstacle->state == 2);
+        if (obstacle->animation_speed < 0.0f) {
+            GameAnimSet_Play(obstacle->anim_set, -obstacle->animation_speed * obstacle->field_0x4c, 0);
+        } else {
+            GameAnimSet_Play(obstacle->anim_set, -obstacle->animation_speed * obstacle->field_0x50, 0);
+        }
+    }
 }
 
 void GizObstacle_SetPushControlled(GIZOBSTACLE_s *, GameObject_s *, float) {

--- a/src/legoapi/gizmos/transport/teleport.cpp
+++ b/src/legoapi/gizmos/transport/teleport.cpp
@@ -1,6 +1,7 @@
 #include "legoapi/gizmos/transport/teleport.h"
 
 #include "decomp.h"
+#include "legoapi/legoapi_types.h"
 #include "legoapi/world/level.h"
 #include "legoapi/world/world.h"
 
@@ -13,42 +14,56 @@ static i32 Teleport_GetMaxGizmos(void *world_ptr) {
 
 static void Teleport_AddGizmos(GIZMOSYS *gizmo_sys, i32 type_id, void *world_ptr, void *) {
     WORLDINFO *world = static_cast<WORLDINFO *>(world_ptr);
-    if (world == NULL || world->teleports == NULL || world->teleport_count <= 0) {
-        return;
-    }
-
-    for (i32 index = 0; index < world->teleport_count; ++index) {
-        AddGizmo(gizmo_sys, type_id, NULL, &world->teleports[index]);
+    if (world != NULL && world->teleports != NULL) {
+        for (i32 index = 0; index < world->teleport_count; ++index) {
+            AddGizmo(gizmo_sys, type_id, NULL, &world->teleports[index]);
+        }
     }
 }
 
 static char *Teleport_GetGizmoName(GIZMO *gizmo) {
-    UNIMPLEMENTED();
-    return {};
+    return gizmo != NULL ? static_cast<char *>(gizmo->object) : NULL;
 }
 
 static i32 Teleport_GetOutput(GIZMO *gizmo, i32, i32) {
-    UNIMPLEMENTED();
-    return {};
+    if (gizmo != NULL && gizmo->object != NULL) {
+        return static_cast<TELEPORT_s *>(gizmo->object)->active;
+    }
+    return 0;
 }
 
-char *Teleport_GetOutputName(GIZMO *gizmo, i32 output_index) {
-    UNIMPLEMENTED();
-    return {};
+char *Teleport_GetOutputName(GIZMO *, i32) {
+    return const_cast<char *>("Occupied");
 }
 
-static i32 Teleport_GetNumOutputs(GIZMO *gizmo) {
-    UNIMPLEMENTED();
-    return {};
+static i32 Teleport_GetNumOutputs(GIZMO *) {
+    return 1;
 }
 
-static void Teleport_Activate(GIZMO *gizmo, i32) {
-    UNIMPLEMENTED();
+static void Teleport_Activate(GIZMO *gizmo, i32 activate) {
+    TELEPORT_s *teleport = static_cast<TELEPORT_s *>(gizmo->object);
+    if (activate != 0) {
+        teleport->active = 0;
+        teleport->enabled = 1;
+    } else {
+        teleport->enabled = 0;
+    }
 }
 
-static i32 Teleport_ActivateRev(GIZMO *gizmo, i32, i32) {
-    UNIMPLEMENTED();
-    return {};
+static i32 Teleport_ActivateRev(GIZMO *gizmo, i32 activate, i32 flags) {
+    if (gizmo == NULL || gizmo->object == NULL) {
+        return 0;
+    }
+    TELEPORT_s *teleport = static_cast<TELEPORT_s *>(gizmo->object);
+    if ((flags & 1) != 0 && teleport->enabled != activate) {
+        return 0;
+    }
+    if (activate != 0) {
+        teleport->enabled = 0;
+    } else if (teleport->enabled == 0) {
+        teleport->enabled = 1;
+    }
+    return 1;
 }
 
 ADDGIZMOTYPE *Teleport_RegisterGizmo(i32 type_id) {

--- a/src/legoapi/render/core/screen.cpp
+++ b/src/legoapi/render/core/screen.cpp
@@ -3,6 +3,10 @@
 #include "legoapi/legoapi_types.h"
 #include "legoapi/characters/motion.h"
 #include "legoapi/menus/core/text.h"
+#include "gameapi/gui/apimenu.h"
+#include "legoapi/world/area.h"
+#include "legoapi/world/level.h"
+#include "legoapi/world/world.h"
 #include "legoapi/menus/screens/shop.h"
 #include "nu2api/nu3d/nucamera.h"
 #include "nu2api/nu3d/numtl.h"
@@ -59,14 +63,33 @@ f32 GetAspectRatio() {
 }
 
 static u8 ScreenGrabNeeded;
-i32 pause_rt;
+static i32 pause_rt;
 NUMTL *pause_rndr_mtl;
 extern i32 pause_rndr_on;
 extern i32 pause_fade;
+static i32 old_pause_state;
+i32 (*PauseRenderOffFn)(void);
+i32 cut_waiting_for_new_level;
+
+extern FadeSystem FadeSys;
+extern i32 Paused;
+extern i32 waiting_for_level;
+extern i32 GAMEDEMO;
+extern "C" {
+    extern f32 MainRenderTime;
+    extern i32 back_rgba[2];
+    extern i32 clear_screen_onstill;
+    extern i32 gone_through_door_to_new_level;
+    extern i32 screendump;
+}
+void BackDrop_Draw(f32, i32);
+void DrawStillScreen(i32);
 
 extern "C" i32 NuRndrBeginScene(i32);
 extern "C" void NuRndrEndScene(void);
 extern "C" void NuBackbufferCopy(i32);
+extern "C" void NuRndrClear(i32, i32, f32);
+extern "C" void NuRndrGradClear(i32, i32, i32, f32);
 
 void NeedScreenGrab(i32 needed) {
     ScreenGrabNeeded = needed != 0;
@@ -154,6 +177,61 @@ void UpdateCutBorders() {
 }
 
 void HandleStillRender() {
+    GetMenuID();
+    if (pause_rndr_on != 0 && FadeSys.pending_type == FADE_TYPE_NONE) {
+        NuRndrBeginScene(-1);
+        if (MainRenderTime < 1.0f) {
+            if (back_rgba[0] == back_rgba[1]) {
+                NuRndrClear(0xf00, back_rgba[0], 1.0f);
+            } else {
+                NuRndrGradClear(0xf00, back_rgba[0], back_rgba[1], 1.0f);
+            }
+            BackDrop_Draw(1.0f - MainRenderTime, 0);
+        } else {
+            NuRndrClear(0x300, 0, 1.0f);
+        }
+        NuRndrEndScene();
+    }
+
+    if (grab_screen_image != 2 && pause_rndr_on != 0 && pause_rt != 0 &&
+        FadeSys.pending_type == FADE_TYPE_NONE) {
+        DrawStillScreen(clear_screen_onstill);
+    }
+
+    if (Paused != 0) {
+        if (old_pause_state == 0 && FadeSys.pending_type == FADE_TYPE_NONE) {
+            NeedScreenGrab(1);
+        }
+    }
+    if (Paused == 0 && old_pause_state != 0) {
+        pause_rndr_on = 0;
+    }
+    old_pause_state = Paused;
+
+    if ((waiting_for_level == -1 ||
+         (gone_through_door_to_new_level == 0 && cut_waiting_for_new_level == 0 && waiting_for_new_level == 0)) &&
+        (NewLData != CREDITS_LDATA || LastLData != STATUS_LDATA) &&
+        (NewLData != STATUS_LDATA ||
+         ((WORLD->level_sub_id == -1 || (WORLD->area[WORLD->level_sub_id].flags & 2) == 0) && GAMEDEMO == 0)) &&
+        NewLData != CREDITS_LDATA &&
+        (NewLData != HUB_LDATA || WORLD->level_sub_id == -1 || (WORLD->area[WORLD->level_sub_id].flags & 2) == 0) &&
+        !(MainRenderTime > 0.0f && MainRenderTime < 1.0f)) {
+        if (Paused == 0 || IsGrabbingScreen() != 0) {
+            pause_rndr_on = static_cast<u32>(grab_screen_image) > 1;
+        } else if (PauseRenderOffFn != NULL && PauseRenderOffFn() != 0) {
+            pause_rndr_on = 0;
+        } else {
+            pause_rndr_on = 1;
+        }
+    } else {
+        pause_rndr_on = 1;
+    }
+
+    if (screendump != 0) {
+        pause_rndr_on = 0;
+    }
+    clear_screen_onstill = 1;
+    grab_screen_image = 0;
 }
 
 void LinkShaderProgram(u32) {


### PR DESCRIPTION
Restores obstacle animation controls used by doors and the teleport gizmo name, occupancy, and activation callbacks. Refines the teleport registration loop added on main to match the original target more closely. Implements HandleStillRender so completed door/level transitions can clear pause_rndr_on and resume live rendering instead of leaving the screen black.

Includes the door-related callbacks and the still-render transition handling they need. Excludes spline/collision experiments, BuildIt work, and player-position initialization.

Based on main at 2af7939. Uses ordinary C++ without volatile, branch prediction hints, inline assembly, or added attributes.

Target matching against the original Android x86 binary:

| Functions | Match |
| --- | --- |
| Teleport_Activate, Teleport_ActivateRev, Teleport_GetGizmoName, Teleport_GetOutput, Teleport_GetNumOutputs | 100% |
| Teleport_AddGizmos | 99.590% |
| Teleport_GetOutputName | 99.750% |
| Five obstacle animation controls | 99.923-99.974% |
| HandleStillRender | 74.033% |

Regenerated matching.json and the README progress table with the documented ttdecomp/objdiff fork. Whole-binary fuzzy match increases from 16.179620% to 16.205053%, with five additional fully matched functions. HandleStillRender preserves the reference control flow but does not yet fully match its instruction layout.

Validation: Android target and WASM builds passed, all three source checks passed, symbol verification reported zero missing symbols, and git diff --check passed. The restored still-render function passed 200,000 state/callback comparisons against a reference logic model under ASan/UBSan. The updated WASM is served locally for exit testing; full browser gameplay verification remains pending.
