### PR TITLE
Fix Pages launcher isolation setup and premature OBB loading

### DIFF
--- a/scripts/plot_binary_match_map.html
+++ b/scripts/plot_binary_match_map.html
@@ -701,7 +701,8 @@
             setBusy(true);
             setStatus(label);
             try {
-                const [buffer] = await Promise.all([load(), ensureRuntimeLoaded()]);
+                await ensureRuntimeLoaded();
+                const buffer = await load();
                 if (!buffer.byteLength) throw new Error("The selected OBB is empty.");
                 loadedObb = buffer;
                 playButton.disabled = false;
@@ -867,7 +868,15 @@
             return runtimeReady;
         }
 
-        void loadInitialObb();
+        setBusy(true);
+        setStatus("Preparing browser runtime...");
+        window.sagaIsolationReady.then(() => {
+            setBusy(false);
+            return loadInitialObb();
+        }).catch(error => {
+            setBusy(true);
+            setStatus(error instanceof Error ? error.message : String(error), true);
+        });
     </script>
     <script>
         const data = /*__DATA__*/;

--- a/scripts/plot_binary_match_map.py
+++ b/scripts/plot_binary_match_map.py
@@ -150,12 +150,39 @@ COI_SERVICE_WORKER = r"""if (typeof window === "undefined") {
       });
     }));
   });
-} else if (!window.crossOriginIsolated && "serviceWorker" in navigator) {
-  navigator.serviceWorker.register("./coi-serviceworker.js").then(() => {
-    if (!navigator.serviceWorker.controller) {
-      navigator.serviceWorker.addEventListener("controllerchange", () => location.reload(), {once: true});
+} else {
+  window.sagaIsolationReady = new Promise((resolve, reject) => {
+    const reloadKey = "saga-isolation-reload";
+    if (window.crossOriginIsolated) {
+      sessionStorage.removeItem(reloadKey);
+      resolve();
+      return;
     }
+    if (!window.isSecureContext || !("serviceWorker" in navigator)) {
+      reject(new Error("This build needs service workers and a secure browser window. Open the HTTPS site in a normal window; private browsing may disable service workers."));
+      return;
+    }
+    let reloading = false;
+    function reloadWhenControlled() {
+      if (!navigator.serviceWorker.controller || reloading) return;
+      try {
+        if (sessionStorage.getItem(reloadKey)) {
+          reject(new Error("Browser isolation setup failed after reloading. Allow service workers/site storage for this site, then reload in a normal browser window."));
+          return;
+        }
+        reloading = true;
+        sessionStorage.setItem(reloadKey, "1");
+        location.reload();
+      } catch (error) {
+        reject(error);
+      }
+    }
+    navigator.serviceWorker.addEventListener("controllerchange", reloadWhenControlled);
+    navigator.serviceWorker.register("./coi-serviceworker.js").then(reloadWhenControlled, error => {
+      reject(new Error(`Browser isolation setup failed: ${error.message}. Allow service workers/site storage for this site and reload.`));
+    });
   });
+  window.sagaIsolationReady.catch(() => {});
 }
 """
 


### PR DESCRIPTION
The Pages launcher allowed OBB loading before cross-origin isolation was ready, producing an immediate runtime-not-ready error. Service-worker registration also attached its controller-change listener too late and silently skipped reload when the worker already controlled an unisolated document.

Attach the listener before registration, check control again after registration, and guard automatic reloads against loops. Keep asset-loading controls disabled until isolation is ready and display setup/registration failures in the launcher. Initialize the runtime before reading or downloading game data so startup failure does not leave a large transfer running.

Validation: generated Pages output successfully; parsed both generated inline scripts; seven isolated JavaScript checks cover existing isolation, early/late activation, existing control, reload-loop prevention, registration rejection and unavailable service workers. Repository checks pass (3/3). No game code or WASM binary changes. The user's specific browser cause remains unconfirmed; private browsing or blocked service workers still require a browser setting/window change.
