### PR TITLE
Restore bitfield layouts and add 22 exact function matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # _saga_
 
-![Progress](https://img.shields.io/badge/matching-17.54%25-red)
+![Progress](https://img.shields.io/badge/matching-17.55%25-red)
 [![Bazel build](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml/badge.svg)](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml)
 [![Discord](https://img.shields.io/discord/1467775700894224555?color=%235865F2&logo=discord&logoColor=%23FFFFFF)](https://discord.gg/2HJuMtzA7q)
 [![status & wasm build](https://img.shields.io/badge/status%20%26%20wasm%20build-click%20here-orange?style=flat)](https://ttdecomp.github.io/saga/)
@@ -65,23 +65,23 @@ See https://ttdecomp.github.io/saga/
 | `gameframework` | 84.0% | 5.9% |
 | `gamelib` | 8.2% | 5.1% |
 | `java` | 10.5% | 0.0% |
-| `legoapi` | 16.7% | 7.4% |
+| `legoapi` | 16.8% | 7.7% |
 | `legoapi/actions` | 8.0% | 1.3% |
 | `legoapi/ai` | 13.1% | 0.0% |
 | `legoapi/audio` | 8.2% | 5.7% |
 | `legoapi/characters` | 15.6% | 4.9% |
 | `legoapi/core` | 25.7% | 6.6% |
-| `legoapi/cutscenes` | 11.3% | 2.3% |
+| `legoapi/cutscenes` | 11.4% | 3.0% |
 | `legoapi/gizmo` | 15.5% | 3.9% |
-| `legoapi/gizmos` | 40.3% | 28.0% |
-| `legoapi/items` | 10.1% | 3.9% |
+| `legoapi/gizmos` | 40.5% | 30.9% |
+| `legoapi/items` | 10.1% | 4.1% |
 | `legoapi/menus` | 16.0% | 6.4% |
 | `legoapi/misc` | 9.7% | 4.0% |
 | `legoapi/props` | 28.4% | 2.2% |
 | `legoapi/render` | 13.0% | 6.2% |
 | `legoapi/world` | 24.1% | 6.4% |
 | `legogame` | 52.0% | 14.3% |
-| `nu2api` | 33.9% | 14.8% |
+| `nu2api` | 33.9% | 14.9% |
 
 <!-- matching-table-end -->
 

--- a/matching.json
+++ b/matching.json
@@ -1,16 +1,16 @@
 {
   "schema_version": 1,
   "measures": {
-    "fuzzy_match_percent": 17.535992,
+    "fuzzy_match_percent": 17.545746,
     "total_code": "4722419",
-    "matched_code": "39843",
-    "matched_code_percent": 0.843699,
+    "matched_code": "40744",
+    "matched_code_percent": 0.8627782,
     "total_data": "14606528",
     "matched_data": "543696",
     "matched_data_percent": 3.722281,
     "total_functions": 13459,
-    "matched_functions": 998,
-    "matched_functions_percent": 7.415113,
+    "matched_functions": 1020,
+    "matched_functions_percent": 7.578572,
     "total_units": 1
   },
   "text": {
@@ -52185,7 +52185,7 @@
           "address": 4411584,
           "offset": 3521616,
           "size": 34,
-          "match_percent": 66.111115
+          "match_percent": 100.0
         },
         {
           "name": "_ZL22instNuGCutCamSysUpdateP17instNUGCUTSCENE_sf",
@@ -57624,7 +57624,7 @@
           "address": 5241728,
           "offset": 4351760,
           "size": 34,
-          "match_percent": 97.5
+          "match_percent": 100.0
         },
         {
           "name": "_ZL18Plug_SetVisibilityP7GIZMO_si",
@@ -57632,7 +57632,7 @@
           "address": 5241776,
           "offset": 4351808,
           "size": 36,
-          "match_percent": 92.333336
+          "match_percent": 100.0
         },
         {
           "name": "_ZL11Plugs_ResetPvS_S_",
@@ -57736,7 +57736,7 @@
           "address": 5242480,
           "offset": 4352512,
           "size": 146,
-          "match_percent": 86.22449
+          "match_percent": 86.53061
         },
         {
           "name": "_ZL10Plugs_LoadPvS_",
@@ -57744,7 +57744,7 @@
           "address": 5242640,
           "offset": 4352672,
           "size": 299,
-          "match_percent": 81.655914
+          "match_percent": 81.97849
         },
         {
           "name": "_ZL19Plugs_StoreProgressPvS_S_",
@@ -58276,7 +58276,7 @@
           "address": 1906160,
           "offset": 1016192,
           "size": 45,
-          "match_percent": 58.266666
+          "match_percent": 100.0
         },
         {
           "name": "_ZL19ZipUp_SetVisibilityP7GIZMO_si",
@@ -58284,7 +58284,7 @@
           "address": 1906208,
           "offset": 1016240,
           "size": 37,
-          "match_percent": 93.333336
+          "match_percent": 100.0
         },
         {
           "name": "_ZL19ZipUps_GetMaxGizmosPv",
@@ -58530,7 +58530,7 @@
           "address": 4976192,
           "offset": 4086224,
           "size": 37,
-          "match_percent": 44.666668
+          "match_percent": 100.0
         },
         {
           "name": "_ZL18GizmoPickup_GetPosP7GIZMO_s",
@@ -59174,7 +59174,7 @@
           "address": 1995360,
           "offset": 1105392,
           "size": 32,
-          "match_percent": 85.35714
+          "match_percent": 100.0
         },
         {
           "name": "_ZL22GizPanel_GetOutputNameP7GIZMO_si",
@@ -59198,7 +59198,7 @@
           "address": 1995440,
           "offset": 1105472,
           "size": 587,
-          "match_percent": 65.19075
+          "match_percent": 67.42197
         },
         {
           "name": "_ZL28GizPanels_ReserveBufferSpacePv",
@@ -59254,7 +59254,7 @@
           "address": 2000080,
           "offset": 1110112,
           "size": 163,
-          "match_percent": 49.0
+          "match_percent": 54.80357
         },
         {
           "name": "_ZL13GizPanel_DrawPvS_f",
@@ -59270,7 +59270,7 @@
           "address": 2004432,
           "offset": 1114464,
           "size": 197,
-          "match_percent": 69.393936
+          "match_percent": 98.92424
         },
         {
           "name": "_ZL17GizPanel_ActivateP7GIZMO_si",
@@ -59460,7 +59460,7 @@
           "address": 1897840,
           "offset": 1007872,
           "size": 86,
-          "match_percent": 14.642858
+          "match_percent": 100.0
         },
         {
           "name": "_ZL19Levers_GetMaxGizmosPv",
@@ -59476,7 +59476,7 @@
           "address": 1897968,
           "offset": 1008000,
           "size": 19,
-          "match_percent": 71.111115
+          "match_percent": 100.0
         },
         {
           "name": "_ZL19Lever_GetOutputNameP7GIZMO_si",
@@ -59548,7 +59548,7 @@
           "address": 1899600,
           "offset": 1009632,
           "size": 231,
-          "match_percent": 66.56061
+          "match_percent": 83.51515
         },
         {
           "name": "_ZL11Lever_ResetP7LEVER_s",
@@ -59564,7 +59564,7 @@
           "address": 1900832,
           "offset": 1010864,
           "size": 215,
-          "match_percent": 41.555557
+          "match_percent": 42.27778
         },
         {
           "name": "_ZL14Lever_ActivateP7GIZMO_si",
@@ -59627,7 +59627,7 @@
           "address": 4945280,
           "offset": 4055312,
           "size": 71,
-          "match_percent": 59.791668
+          "match_percent": 100.0
         },
         {
           "name": "_ZL20Blowup_GetOutputNameP7GIZMO_si",
@@ -59786,7 +59786,7 @@
           "address": 1943792,
           "offset": 1053824,
           "size": 36,
-          "match_percent": 93.333336
+          "match_percent": 100.0
         },
         {
           "name": "_ZL15Techno_ActivateP7GIZMO_si",
@@ -59794,7 +59794,7 @@
           "address": 1943840,
           "offset": 1053872,
           "size": 34,
-          "match_percent": 96.42857
+          "match_percent": 98.92857
         },
         {
           "name": "_ZL19Technos_EarlyUpdatePvS_f",
@@ -60072,7 +60072,7 @@
           "address": 5057248,
           "offset": 4167280,
           "size": 45,
-          "match_percent": 97.64706
+          "match_percent": 100.0
         },
         {
           "name": "_ZL21Grapple_SetVisibilityP7GIZMO_si",
@@ -60080,7 +60080,7 @@
           "address": 5057296,
           "offset": 4167328,
           "size": 36,
-          "match_percent": 92.333336
+          "match_percent": 100.0
         },
         {
           "name": "_ZL21Grapples_GetMaxGizmosPv",
@@ -60152,7 +60152,7 @@
           "address": 5058464,
           "offset": 4168496,
           "size": 1461,
-          "match_percent": 32.293335
+          "match_percent": 32.77667
         },
         {
           "name": "_ZL22Grapples_StoreProgressPvS_S_",
@@ -60572,7 +60572,7 @@
           "address": 5135968,
           "offset": 4246000,
           "size": 34,
-          "match_percent": 97.5
+          "match_percent": 100.0
         },
         {
           "name": "_ZL16Tube_ActivateRevP7GIZMO_sii",
@@ -60588,7 +60588,7 @@
           "address": 5136112,
           "offset": 4246144,
           "size": 36,
-          "match_percent": 93.333336
+          "match_percent": 100.0
         },
         {
           "name": "_ZL11Tubes_ResetPvS_S_",
@@ -60874,7 +60874,7 @@
           "address": 2301152,
           "offset": 1411184,
           "size": 34,
-          "match_percent": 97.5
+          "match_percent": 100.0
         },
         {
           "name": "_ZL19GizmoBombGen_GetPosP7GIZMO_s",
@@ -60970,7 +60970,7 @@
           "address": 2302080,
           "offset": 1412112,
           "size": 96,
-          "match_percent": 96.51724
+          "match_percent": 99.965515
         },
         {
           "name": "_ZL21GizBombGens_AddGizmosP10GIZMOSYS_siPvS1_",
@@ -61216,7 +61216,7 @@
           "address": 2072272,
           "offset": 1182304,
           "size": 36,
-          "match_percent": 93.333336
+          "match_percent": 100.0
         },
         {
           "name": "_ZL16GizTorp_ActivateP7GIZMO_si",
@@ -61224,7 +61224,7 @@
           "address": 2072320,
           "offset": 1182352,
           "size": 34,
-          "match_percent": 96.42857
+          "match_percent": 100.0
         },
         {
           "name": "_ZL14GizTorps_ResetPvS_S_",
@@ -62445,7 +62445,7 @@
           "address": 3959387,
           "offset": 3069419,
           "size": 66,
-          "match_percent": 55.894737
+          "match_percent": 100.0
         },
         {
           "name": "APIObjectCreate",
@@ -86842,7 +86842,7 @@
           "address": 2990928,
           "offset": 2100960,
           "size": 38,
-          "match_percent": 65.333336
+          "match_percent": 65.75
         },
         {
           "name": "_Z16NuGScnRestoreTIDP8nugscn_si",
@@ -111717,7 +111717,7 @@
           "address": 3281232,
           "offset": 2391264,
           "size": 46,
-          "match_percent": 63.8125
+          "match_percent": 100.0
         },
         {
           "name": "_ZN19NuSoundMemoryBuffer7GetSizeEv",
@@ -111725,7 +111725,7 @@
           "address": 3281280,
           "offset": 2391312,
           "size": 39,
-          "match_percent": 65.61539
+          "match_percent": 100.0
         },
         {
           "name": "_ZN19NuSoundMemoryBuffer10SetAddressEPv",
@@ -111749,7 +111749,7 @@
           "address": 3281360,
           "offset": 2391392,
           "size": 28,
-          "match_percent": 88.888885
+          "match_percent": 100.0
         },
         {
           "name": "_ZN19NuSoundMemoryBuffer9IsAllocedEv",
@@ -111813,7 +111813,7 @@
           "address": 3281568,
           "offset": 2391600,
           "size": 98,
-          "match_percent": 25.851852
+          "match_percent": 99.96296
         },
         {
           "name": "_ZN19NuSoundMemoryBuffer6UnlockEv",
@@ -111821,7 +111821,7 @@
           "address": 3281680,
           "offset": 2391712,
           "size": 54,
-          "match_percent": 84.0
+          "match_percent": 99.92308
         },
         {
           "name": "_ZN19NuSoundMemoryBuffer8IsLockedEv",

--- a/src/legoapi/cutscenes/cutscene.cpp
+++ b/src/legoapi/cutscenes/cutscene.cpp
@@ -488,7 +488,7 @@ extern "C" {
     }
 
     void instNuGCutScenePause(instNUGCUTSCENE_s *instance, u8 paused) {
-        instance->flags_88 = (instance->flags_88 & 0xfb) | ((paused & 1) << 2);
+        instance->paused = paused;
     }
 } // extern "C"
 

--- a/src/legoapi/gizmos/door/plugs.cpp
+++ b/src/legoapi/gizmos/door/plugs.cpp
@@ -65,8 +65,7 @@ static void Plug_Activate(GIZMO *gizmo, i32 active) {
         return;
     }
     PLUG *plug = static_cast<PLUG *>(gizmo->object);
-    const u8 active_flag = active != 0;
-    plug->flags = static_cast<u8>((plug->flags & ~PLUG_FLAG_ACTIVE) | active_flag);
+    plug->active = active != 0;
 }
 
 static void Plug_SetVisibility(GIZMO *gizmo, i32 visible) {
@@ -74,8 +73,7 @@ static void Plug_SetVisibility(GIZMO *gizmo, i32 visible) {
         return;
     }
     PLUG *plug = static_cast<PLUG *>(gizmo->object);
-    const u8 visible_flag = visible != 0;
-    plug->flags = static_cast<u8>((plug->flags & ~PLUG_FLAG_VISIBLE) | (visible_flag << 1));
+    plug->visible = visible != 0;
 }
 
 static NUVEC *Plug_GetPos(GIZMO *gizmo) {

--- a/src/legoapi/gizmos/door/plugs.h
+++ b/src/legoapi/gizmos/door/plugs.h
@@ -21,7 +21,14 @@ typedef struct PLUG_s {
     u16 y_rotation;
     u16 target_id;
     u8 enabled;
-    u8 flags;
+    union {
+        u8 flags;
+        struct {
+            u8 active : 1;
+            u8 visible : 1;
+            u8 reserved_flags : 6;
+        };
+    };
     u8 reserved[0x10];
 } PLUG;
 

--- a/src/legoapi/gizmos/door/zipups.cpp
+++ b/src/legoapi/gizmos/door/zipups.cpp
@@ -228,7 +228,7 @@ static void ZipUp_Activate(GIZMO *gizmo, i32 active) {
         zipup->direction = 0;
         active_flag = 1;
     }
-    zipup->flags = static_cast<u8>((zipup->flags & ~ZIPUP_FLAG_ACTIVE) | (active_flag << 6));
+    zipup->active = active_flag;
 }
 
 static i32 ZipUp_ActivateRev(GIZMO *gizmo, i32 active, i32 query) {
@@ -253,8 +253,7 @@ static i32 ZipUp_ActivateRev(GIZMO *gizmo, i32 active, i32 query) {
 static void ZipUp_SetVisibility(GIZMO *gizmo, i32 visible) {
     if (gizmo != NULL) {
         ZIPUP *zipup = static_cast<ZIPUP *>(gizmo->object);
-        const u8 visible_flag = visible != 0;
-        zipup->flags = static_cast<u8>((zipup->flags & ~ZIPUP_FLAG_VISIBLE) | (visible_flag << 7));
+        zipup->visible = visible != 0;
     }
 }
 

--- a/src/legoapi/gizmos/door/zipups.h
+++ b/src/legoapi/gizmos/door/zipups.h
@@ -38,7 +38,14 @@ typedef struct ZIPUP_s {
     u16 direction;               // 0x62
     u16 facing_angle;            // 0x64
     u8 reserved_0x66[2];         // 0x66 .. 0x68
-    u8 flags;                    // 0x68
+    union {
+        u8 flags;
+        struct {
+            u8 configuration_flags : 6;
+            u8 active : 1;
+            u8 visible : 1;
+        };
+    };
     u8 runtime_flags;            // 0x69
     u8 reserved_0x6a[2];         // 0x6a .. 0x6c
     f32 lower_ground_height;     // 0x6c

--- a/src/legoapi/gizmos/fx/gizmopickups.cpp
+++ b/src/legoapi/gizmos/fx/gizmopickups.cpp
@@ -402,7 +402,7 @@ static void GizmoPickup_SetVisibility(GIZMO *gizmo, i32 visible) {
         return;
     }
     GIZMOPICKUP_s *pickup = static_cast<GIZMOPICKUP_s *>(gizmo->object);
-    pickup->state_flags = static_cast<u8>((pickup->state_flags & ~GIZMOPICKUP_STATE_VISIBLE) | ((visible != 0) << 2));
+    pickup->state_visible = visible != 0;
 }
 
 static NUVEC *GizmoPickup_GetPos(GIZMO *gizmo) {

--- a/src/legoapi/gizmos/object/gizpanel.cpp
+++ b/src/legoapi/gizmos/object/gizpanel.cpp
@@ -377,13 +377,13 @@ static char *GizPanel_GetGizmoName(GIZMO *gizmo) {
 }
 
 static i32 GizPanel_GetOutput(GIZMO *gizmo, i32, i32) {
-    u8 flags = static_cast<GIZPANEL *>(gizmo->object)->flags;
+    GIZPANEL *panel = static_cast<GIZPANEL *>(gizmo->object);
+    u8 flags = panel->flags;
     if ((flags & (GIZPANEL_FLAG_VISIBLE | GIZPANEL_FLAG_TRACK_PLAYER)) !=
         (GIZPANEL_FLAG_VISIBLE | GIZPANEL_FLAG_TRACK_PLAYER)) {
         return 0;
     }
-    flags >>= 1;
-    return flags & 1;
+    return panel->state;
 }
 
 static char *GizPanel_GetOutputName(GIZMO *, i32 output_index) {
@@ -488,16 +488,11 @@ static void GizPanels_Reset(void *world_ptr, void *, void *progress_ptr) {
             GizPanel_Reset(panel);
             if (index < 32 && progress != NULL) {
                 const u32 bit = 1u << index;
-                u8 flags = panel->flags;
                 if ((progress->state & bit) != 0) {
-                    flags |= GIZPANEL_FLAG_STATE;
-                    panel->flags = static_cast<GIZPANEL_FLAGS>(flags);
+                    panel->state = 1;
                 }
-                const u8 visible = ((progress->baddie_state & bit) != 0) << 2;
-                panel->flags = static_cast<GIZPANEL_FLAGS>((flags & ~GIZPANEL_FLAG_VISIBLE) | visible);
-                panel->flags =
-                    static_cast<GIZPANEL_FLAGS>((flags & ~(GIZPANEL_FLAG_TRACK_PLAYER | GIZPANEL_FLAG_VISIBLE)) |
-                                                visible | (((progress->goodie_state & bit) != 0) << 3));
+                panel->visible = (progress->baddie_state & bit) != 0;
+                panel->track_player = (progress->goodie_state & bit) != 0;
             }
             ++index;
             if (panel_sys->count <= index) {

--- a/src/legoapi/gizmos/object/hatmachine.cpp
+++ b/src/legoapi/gizmos/object/hatmachine.cpp
@@ -355,11 +355,11 @@ static void HatMachine_Activate(GIZMO *gizmo, i32 enabled) {
     }
 
     HATMACHINE *machine = static_cast<HATMACHINE *>(gizmo->object);
-    if (enabled != 0) {
-        machine->flags = static_cast<HATMACHINE_FLAGS>(machine->flags | HATMACHINE_FLAG_ENABLED);
+    if (enabled) {
+        machine->progress_state0 = 1;
         HatMachine_Reset(machine);
     } else {
-        machine->flags = static_cast<HATMACHINE_FLAGS>(machine->flags & ~HATMACHINE_FLAG_ENABLED);
+        machine->progress_state0 = 0;
     }
 }
 

--- a/src/legoapi/gizmos/object/lever.cpp
+++ b/src/legoapi/gizmos/object/lever.cpp
@@ -34,9 +34,9 @@ f32 GameShadow(GameObject_s *object, NUVEC *position, f32 probe_height, i32 plat
 void FindAnglesZX(NUVEC *normal, u16 *x_rotation, u16 *z_rotation);
 
 struct LEVERPROGRESS {
-    u32 pulled_down;
-    u32 enabled;
-    u32 visible;
+    u32 pulled_down[1];
+    u32 enabled[1];
+    u32 visible[1];
 };
 
 DECOMP_ASSERT(sizeof(LEVERPROGRESS) == 0xc, "LEVER progress ABI");
@@ -274,7 +274,7 @@ static void Levers_Draw(void *world_ptr, void *, float) {
 }
 
 static char *Lever_GetGizmoName(GIZMO *gizmo) {
-    if (gizmo == NULL || gizmo->object == NULL) {
+    if (gizmo == NULL) {
         return NULL;
     }
     return static_cast<LEVER_s *>(gizmo->object)->name;
@@ -343,18 +343,14 @@ static i32 Lever_ActivateRev(GIZMO *gizmo, i32 value, i32 query) {
     }
 
     LEVER_s *lever = static_cast<LEVER_s *>(gizmo->object);
-    if ((query & 1) == 0) {
-        if (value == 0) {
-            lever->flags |= LEVER_FLAG_ENABLED;
-        } else {
-            lever->flags &= ~LEVER_FLAG_ENABLED;
+    if ((query & 1) != 0) {
+        if (!lever->enabled) {
+            return value == 0;
         }
-        return 1;
+        return value;
     }
-    if ((lever->flags & LEVER_FLAG_ENABLED) == 0) {
-        return value == 0;
-    }
-    return value;
+    lever->enabled = value == 0;
+    return 1;
 }
 
 static void Lever_SetVisibility(GIZMO *gizmo, i32 visible) {
@@ -388,9 +384,9 @@ static void Levers_ClearProgress(void *, void *progress_data) {
         return;
     }
 
-    progress->pulled_down = 0;
-    progress->enabled = 0xffffffff;
-    progress->visible = 0xffffffff;
+    progress->pulled_down[0] = 0;
+    progress->enabled[0] = 0xffffffff;
+    progress->visible[0] = 0xffffffff;
 }
 
 static void Levers_StoreProgress(void *world_ptr, void *, void *progress_ptr) {
@@ -405,18 +401,22 @@ static void Levers_StoreProgress(void *world_ptr, void *, void *progress_ptr) {
         return;
     }
 
-    const i32 count = world->nlevers < 32 ? world->nlevers : 32;
-    for (i32 index = 0; index < count; ++index) {
-        const LEVER_s &lever = world->levers[index];
+    const i32 count = world->nlevers;
+    const LEVER_s *lever = world->levers;
+    for (i32 index = 0; index < count; ++index, ++lever) {
+        if (index == 32) {
+            break;
+        }
+        const i32 word = index >> 5;
         const u32 bit = 1u << index;
-        if ((lever.flags & LEVER_FLAG_BEING_PULLED) != 0 && lever.pull_progress >= 1.0f) {
-            progress->pulled_down |= bit;
+        if (lever->being_pulled && lever->pull_progress >= 1.0f) {
+            progress->pulled_down[word] |= bit;
         }
-        if ((lever.flags & LEVER_FLAG_VISIBLE) == 0) {
-            progress->visible &= ~bit;
+        if (!lever->visible) {
+            progress->visible[word] &= ~bit;
         }
-        if ((lever.flags & LEVER_FLAG_ENABLED) == 0) {
-            progress->enabled &= ~bit;
+        if (!lever->enabled) {
+            progress->enabled[word] &= ~bit;
         }
     }
 }
@@ -436,17 +436,17 @@ static void Levers_Reset(void *world_ptr, void *, void *progress_ptr) {
         }
 
         const u32 bit = 1u << index;
-        if ((progress->pulled_down & bit) != 0) {
+        if ((progress->pulled_down[0] & bit) != 0) {
             lever.pull_progress = 1.0f;
             lever.flags |= LEVER_FLAG_BEING_PULLED;
             lever.animation_frame = 0x8000;
         }
-        if ((progress->visible & bit) != 0) {
+        if ((progress->visible[0] & bit) != 0) {
             lever.flags |= LEVER_FLAG_VISIBLE;
         } else {
             lever.flags &= ~LEVER_FLAG_VISIBLE;
         }
-        if ((progress->enabled & bit) != 0) {
+        if ((progress->enabled[0] & bit) != 0) {
             lever.flags |= LEVER_FLAG_ENABLED;
         } else {
             lever.flags &= ~LEVER_FLAG_ENABLED;

--- a/src/legoapi/gizmos/object/newblowup.cpp
+++ b/src/legoapi/gizmos/object/newblowup.cpp
@@ -370,14 +370,24 @@ static i32 Blowup_GetOutput(GIZMO *gizmo, i32 output_index, i32) {
     GIZMOBLOWUP_s *blowup = static_cast<GIZMOBLOWUP_s *>(gizmo->object);
     switch (output_index) {
         case 0:
-            return (blowup->output_flags & GIZMOBLOWUP_OUTPUT_BLOWN_UP) != 0;
+            if ((blowup->output_flags & GIZMOBLOWUP_OUTPUT_BLOWN_UP) != 0) {
+                return 1;
+            }
+            break;
         case 1:
-            return (blowup->output_flags & GIZMOBLOWUP_OUTPUT_PUNCHED) != 0;
+            if ((blowup->output_flags & GIZMOBLOWUP_OUTPUT_PUNCHED) != 0) {
+                return 1;
+            }
+            break;
         case 2:
-            return (blowup->field_0x9f & 0x10) != 0;
+            if ((blowup->field_0x9f & 0x10) != 0) {
+                return 1;
+            }
+            break;
         default:
             return 0;
     }
+    return 0;
 }
 
 static char *Blowup_GetOutputName(GIZMO *gizmo, i32 output_index) {

--- a/src/legoapi/gizmos/object/technos.cpp
+++ b/src/legoapi/gizmos/object/technos.cpp
@@ -193,7 +193,7 @@ static void Techno_Activate(GIZMO *gizmo, i32 active) {
         return;
     }
     TECHNO *techno = static_cast<TECHNO *>(gizmo->object);
-    techno->flags = static_cast<u8>((techno->flags & ~TECHNO_FLAG_ACTIVE) | (active != 0 ? TECHNO_FLAG_ACTIVE : 0));
+    techno->active = active != 0;
 }
 
 static void Techno_SetVisibility(GIZMO *gizmo, i32 visible) {
@@ -201,8 +201,7 @@ static void Techno_SetVisibility(GIZMO *gizmo, i32 visible) {
         return;
     }
     TECHNO *techno = static_cast<TECHNO *>(gizmo->object);
-    const u8 visible_flag = visible != 0;
-    techno->flags = static_cast<u8>((techno->flags & ~TECHNO_FLAG_VISIBLE) | (visible_flag << 1));
+    techno->visible = visible != 0;
 }
 
 static NUVEC *Techno_GetPos(GIZMO *gizmo) {

--- a/src/legoapi/gizmos/object/technos.h
+++ b/src/legoapi/gizmos/object/technos.h
@@ -40,7 +40,14 @@ typedef struct TECHNO_s {
     u8 enabled;
     u8 target_mode;
     i32 output;
-    u8 flags;
+    union {
+        u8 flags;
+        struct {
+            u8 active : 1;
+            u8 visible : 1;
+            u8 reserved_flags : 6;
+        };
+    };
     char target_name[16];
     char target_object_name[31];
     void *controlled_object;

--- a/src/legoapi/gizmos/transport/grapples.cpp
+++ b/src/legoapi/gizmos/transport/grapples.cpp
@@ -377,7 +377,7 @@ static i32 Grapple_GetNumOutputs(GIZMO *) {
 static void Grapple_Activate(GIZMO *gizmo, i32 active) {
     if (gizmo != NULL) {
         GRAPPLE *grapple = static_cast<GRAPPLE *>(gizmo->object);
-        grapple->flags = (grapple->flags & ~GRAPPLE_FLAG_ACTIVE) | (active != 0 ? GRAPPLE_FLAG_ACTIVE : 0);
+        grapple->active = active != 0;
         if ((grapple->flags & GRAPPLE_FLAG_ACTIVE) != 0) {
             grapple->activation_progress = 1.0f;
         }
@@ -387,8 +387,7 @@ static void Grapple_Activate(GIZMO *gizmo, i32 active) {
 static void Grapple_SetVisibility(GIZMO *gizmo, i32 visible) {
     if (gizmo != NULL) {
         GRAPPLE *grapple = static_cast<GRAPPLE *>(gizmo->object);
-        const u8 visible_flag = visible != 0;
-        grapple->flags = static_cast<u8>((grapple->flags & ~GRAPPLE_FLAG_VISIBLE) | (visible_flag << 1));
+        grapple->visible = visible != 0;
     }
 }
 

--- a/src/legoapi/gizmos/transport/grapples.h
+++ b/src/legoapi/gizmos/transport/grapples.h
@@ -19,7 +19,14 @@ typedef struct GRAPPLE_s {
     NUVEC position;          // 0x10
     u8 has_terrain_platform; // 0x1c
     u8 retain_attachment;    // 0x1d
-    u8 flags;                // 0x1e
+    union {
+        u8 flags;
+        struct {
+            u8 active : 1;
+            u8 visible : 1;
+            u8 reserved_flags : 6;
+        };
+    };
     u8 field_0x1f;
     u16 y_rotation;              // 0x20
     u16 x_rotation;              // 0x22

--- a/src/legoapi/gizmos/transport/tubes.cpp
+++ b/src/legoapi/gizmos/transport/tubes.cpp
@@ -131,7 +131,7 @@ static i32 Tube_GetNumOutputs(GIZMO *) {
 static void Tube_Activate(GIZMO *gizmo, i32 active) {
     if (gizmo != NULL) {
         TUBE *tube = static_cast<TUBE *>(gizmo->object);
-        tube->flags = (tube->flags & ~TUBE_FLAG_ACTIVE) | (active != 0 ? TUBE_FLAG_ACTIVE : 0);
+        tube->active = active != 0;
     }
 }
 
@@ -156,8 +156,7 @@ static i32 Tube_ActivateRev(GIZMO *gizmo, i32 reverse, i32 check_only) {
 static void Tube_SetVisibility(GIZMO *gizmo, i32 visible) {
     if (gizmo != NULL) {
         TUBE *tube = static_cast<TUBE *>(gizmo->object);
-        const u8 visible_flag = visible != 0;
-        tube->flags = static_cast<u8>((tube->flags & ~TUBE_FLAG_VISIBLE) | (visible_flag << 1));
+        tube->visible = visible != 0;
     }
 }
 

--- a/src/legoapi/gizmos/transport/tubes.h
+++ b/src/legoapi/gizmos/transport/tubes.h
@@ -24,7 +24,14 @@ typedef struct TUBE_s {
     f32 top;            // 0x28
     f32 radius_squared; // 0x2c
     f32 audio_cooldown; // 0x30
-    u8 flags;           // 0x34
+    union {
+        u8 flags;
+        struct {
+            u8 active : 1;
+            u8 visible : 1;
+            u8 reserved_flags : 6;
+        };
+    };
     u8 reserved_0x35[3];
     u32 occupied_object_masks[2]; // 0x38, one bit per player/object slot
 } TUBE;

--- a/src/legoapi/gizmos/traps/gizbombgen.cpp
+++ b/src/legoapi/gizmos/traps/gizbombgen.cpp
@@ -213,8 +213,7 @@ static i32 GizmoBombGen_GetNumOutputs(GIZMO *) {
 static void GizmoBombGen_Activate(GIZMO *gizmo, i32 active) {
     if (gizmo != NULL) {
         GIZBOMBGEN *bomb_generator = static_cast<GIZBOMBGEN *>(gizmo->object);
-        bomb_generator->flags =
-            (bomb_generator->flags & ~GIZBOMBGEN_FLAG_ACTIVE) | (active != 0 ? GIZBOMBGEN_FLAG_ACTIVE : 0);
+        bomb_generator->active = active != 0;
     }
 }
 
@@ -222,9 +221,7 @@ static void GizmoBombGen_SetVisibility(GIZMO *gizmo, i32 visible) {
     if (gizmo != NULL && gizmo->object != NULL) {
         GIZBOMBGEN *bomb_generator = static_cast<GIZBOMBGEN *>(gizmo->object);
         GameAnimSet_SetVisibility(bomb_generator->anim_set, visible);
-        const u8 visible_flag = visible != 0;
-        bomb_generator->flags =
-            static_cast<u8>((bomb_generator->flags & ~GIZBOMBGEN_FLAG_VISIBLE) | (visible_flag << 1));
+        bomb_generator->visible = visible != 0;
     }
 }
 

--- a/src/legoapi/gizmos/traps/gizbombgen.h
+++ b/src/legoapi/gizmos/traps/gizbombgen.h
@@ -27,7 +27,14 @@ typedef struct GIZBOMBGEN_s {
     i32 interval;
     GameObject_s *generated_bomb;
     i16 field_0x28;
-    u8 flags;
+    union {
+        u8 flags;
+        struct {
+            u8 active : 1;
+            u8 visible : 1;
+            u8 reserved_flags : 6;
+        };
+    };
     u8 field_0x2b;
 } GIZBOMBGEN;
 

--- a/src/legoapi/gizmos/traps/giztorpmachine.cpp
+++ b/src/legoapi/gizmos/traps/giztorpmachine.cpp
@@ -129,16 +129,14 @@ static i32 GizTorp_GetNumOutputs(GIZMO *) {
 static void GizTorp_Activate(GIZMO *gizmo, i32 active) {
     if (gizmo != NULL) {
         GIZTORPMACHINE *machine = static_cast<GIZTORPMACHINE *>(gizmo->object);
-        const u8 active_flag = active != 0;
-        machine->flags = static_cast<u8>((machine->flags & ~GIZTORPMACHINE_FLAG_ACTIVE) | active_flag);
+        machine->active = active != 0;
     }
 }
 
 static void GizTorp_SetVisibility(GIZMO *gizmo, i32 visible) {
     if (gizmo != NULL) {
         GIZTORPMACHINE *machine = static_cast<GIZTORPMACHINE *>(gizmo->object);
-        const u8 visible_flag = visible != 0;
-        machine->flags = static_cast<u8>((machine->flags & ~GIZTORPMACHINE_FLAG_VISIBLE) | (visible_flag << 1));
+        machine->visible = visible != 0;
     }
 }
 

--- a/src/legoapi/gizmos/traps/giztorpmachine.h
+++ b/src/legoapi/gizmos/traps/giztorpmachine.h
@@ -19,7 +19,14 @@ typedef struct GIZTORPMACHINE_s {
     f32 activation_time; // 0x1c
     u16 y_rotation;      // 0x20
     u8 reserved_0x22[9];
-    u8 flags; // 0x2b
+    union {
+        u8 flags;
+        struct {
+            u8 active : 1;
+            u8 visible : 1;
+            u8 reserved_flags : 6;
+        };
+    };
 } GIZTORPMACHINE;
 
 DECOMP_ASSERT(sizeof(GIZTORPMACHINE) == 0x2c, "GIZTORPMACHINE ABI");

--- a/src/legoapi/items/base/apiobject.cpp
+++ b/src/legoapi/items/base/apiobject.cpp
@@ -20,12 +20,12 @@ extern "C" {
     void APIObjectCollisions(void) {
     }
 
-    void APIObjectSetUsed(APIOBJECT *object, u8 index, i32 used) {
+    void APIObjectSetUsed(APIOBJECT *object, i32 index, i32 used) {
         if (used != 0) {
-            object->field_0x1f8 |= APIOBJECT_FLAG_IN_USE;
+            object->in_use = 1;
             object->field_0x289 = index;
         } else {
-            object->field_0x1f8 &= ~APIOBJECT_FLAG_IN_USE;
+            object->in_use = 0;
         }
     }
 

--- a/src/legoapi/items/base/apiobject.h
+++ b/src/legoapi/items/base/apiobject.h
@@ -389,6 +389,10 @@ typedef struct APIOBJECT_s {
             u8 flags_low;
             u8 flags_high;
         };
+        struct {
+            u16 in_use : 1;
+            u16 other_object_flags : 15;
+        };
     };
     u8 field_0x1fa; // 0x1fa
     u8 field_0x1fb;
@@ -453,7 +457,7 @@ DECOMP_ASSERT(sizeof(APIOBJECTSYS_s) == 0x214, "APIOBJECTSYS size");
 extern "C" APIOBJECT *APIObjectCreate(APIOBJECTSYS_s *system);
 extern "C" void APIObjectDestroy(APIOBJECTSYS_s *system, APIOBJECT *object);
 extern "C" void APIObjectDestroyAll(APIOBJECTSYS_s *system);
-extern "C" void APIObjectSetUsed(APIOBJECT *object, u8 index, i32 used);
+extern "C" void APIObjectSetUsed(APIOBJECT *object, i32 index, i32 used);
 extern "C" void APIObjectVelocities(GameObject_s *object);
 
 struct rtldata_s {

--- a/src/legoapi/legoapi_types.h
+++ b/src/legoapi/legoapi_types.h
@@ -1107,6 +1107,12 @@ struct GIZMOPICKUP_s {
     union {
         u8 state_flags; // GIZMOPICKUP_STATE_FLAGS
         u8 runtime_flags;
+        struct {
+            u8 state_active : 1;
+            u8 state_enabled : 1;
+            u8 state_visible : 1;
+            u8 other_state_flags : 5;
+        };
     }; // 0x17
     union {
         u8 activation_group;
@@ -3161,7 +3167,19 @@ struct GIZPANEL_s {
     u8 model_variant; // 0x61
     u8 field_0x62[2];
     f32 flash_timer;                // 0x64
-    GIZPANEL_FLAGS flags;           // 0x68
+    union {
+        GIZPANEL_FLAGS flags; // 0x68
+        struct {
+            u8 reserved_flag : 1;
+            u8 state : 1;
+            u8 visible : 1;
+            u8 track_player : 1;
+            u8 player_near : 1;
+            u8 hide_base : 1;
+            u8 hide_target : 1;
+            u8 baddie : 1;
+        };
+    };
     GIZPANEL_DRAW_FLAGS draw_flags; // 0x69
     u8 field_0x6a[2];
     NUVEC floor_position;  // 0x6c
@@ -3453,7 +3471,20 @@ struct LEVER_s {
     u16 animation_frame;        // 0x96
     u16 target_x_rotation;      // 0x98
     u16 target_z_rotation;      // 0x9a
-    u16 flags;                  // 0x9c, LEVER_FLAGS
+    union {
+        u16 flags; // 0x9c, LEVER_FLAGS
+        struct {
+            u8 interacting : 1;
+            u8 being_pulled : 1;
+            u8 goodie : 1;
+            u8 baddie : 1;
+            u8 visible : 1;
+            u8 auto_reset : 1;
+            u8 returning : 1;
+            u8 enabled : 1;
+            u8 flags_high;
+        };
+    };
     char model_variant;         // 0x9e
     u8 field_0x9f[9];
 

--- a/src/nu2api/nu3d/nudlist.h
+++ b/src/nu2api/nu3d/nudlist.h
@@ -187,6 +187,11 @@ extern "C" {
                 u8 render_buffer; // 0x75 bit7 selects the current clip/mtl buffer
             };
             u16 flags_word;
+            struct {
+                u16 update_flags : 5;
+                u16 material_layer_mask : 8;
+                u16 buffer_flags : 3;
+            };
         };
         u8 instance_visibility_enabled; // 0x76 bit0: per-instance visibility buffer is active
         u8 pad_77;

--- a/src/nu2api/nu3d/nugscn.cpp
+++ b/src/nu2api/nu3d/nugscn.cpp
@@ -114,7 +114,7 @@ void NuGScnRestoreTIDs(nugscn_s *) {
 
 void NuGScnMtlLayerMask(nugscn_s *scene, unsigned char mask) {
     NUDLDLISTSCENE *display_list = scene->display_list;
-    display_list->flags_word = (display_list->flags_word & 0xe01f) | (static_cast<u16>(mask) << 5);
+    display_list->material_layer_mask = mask;
 }
 
 void NuGScnLoadShadersPS(char *, variptr_u *, variptr_u) {

--- a/src/nu2api/nucore/nugcutscene.h
+++ b/src/nu2api/nucore/nugcutscene.h
@@ -153,7 +153,14 @@ struct instNUGCUTSCENE_s {
     NUGCUTSCENE_s *cutscene;
     NUGCUTSCENE_s *cutscene_copy;
     u8 pad_60[0x88 - 0x60];
-    u8 flags_88;
+    union {
+        u8 flags_88;
+        struct {
+            u8 flags_88_low : 2;
+            u8 paused : 1;
+            u8 flags_88_high : 5;
+        };
+    };
     u8 flags_89;
     u8 flags_8a;
     u8 flags_8b;

--- a/src/nu2api/nusound/nusound_memorymanager.cpp
+++ b/src/nu2api/nusound/nusound_memorymanager.cpp
@@ -25,11 +25,7 @@ void NuSoundMemoryBuffer::SetPrev(NuSoundMemoryBuffer *prev) {
 }
 
 void NuSoundMemoryBuffer::SetSize(u32 size) {
-    this->size_l = size;
-    this->size_m = (size >> 8);
-    this->size_h = (size >> 16);
-
-    this->flags = this->flags & 0xc0 | (u8)(size >> 24) & 63;
+    this->size = size;
 }
 
 void NuSoundMemoryBuffer::SetAddress(void *address) {
@@ -38,20 +34,18 @@ void NuSoundMemoryBuffer::SetAddress(void *address) {
 
 // libTTapp.so 0x3211d0: alloced flag = flags bit 6.
 void NuSoundMemoryBuffer::SetAlloced(bool alloced) {
-    this->flags = (this->flags & ~0x40) | (((u8)alloced & 1) << 6);
+    this->alloced = alloced;
 }
 
 void *NuSoundMemoryBuffer::Lock(const char *name) {
     BeginCriticalSection();
 
-    u8 c = this->flags;
-    while (c < 0) {
+    while (this->locked) {
         EndCriticalSection();
         NuThreadSleep(0);
         BeginCriticalSection();
-        c = this->flags;
     }
-    this->flags = c | 0x80;
+    this->locked = true;
 
     EndCriticalSection();
 
@@ -60,7 +54,7 @@ void *NuSoundMemoryBuffer::Lock(const char *name) {
 
 void NuSoundMemoryBuffer::Unlock() {
     BeginCriticalSection();
-    this->flags = this->flags & 0x7f;
+    this->locked = false;
     EndCriticalSection();
 }
 
@@ -81,25 +75,24 @@ NuSoundMemoryBuffer *NuSoundMemoryBuffer::GetPrev() {
 
 // libTTapp.so 0x321180
 u32 NuSoundMemoryBuffer::GetSize() {
-    return (u32)this->size_l | (u32)this->size_m << 8 | (u32)this->size_h << 16 | (u32)(this->flags & 63) << 24;
+    return this->size;
 }
 
 // libTTapp.so 0x3211f0: alloced flag = flags bit 6.
 bool NuSoundMemoryBuffer::IsAlloced() {
-    return (this->flags >> 6) & 1;
+    return this->alloced;
 }
 
 // libTTapp.so 0x3211e0: locked flag = flags bit 7.
 bool NuSoundMemoryBuffer::IsLocked() {
-    return (this->flags >> 7) & 1;
+    return this->locked;
 }
 
 NuSoundMemoryBuffer::NuSoundMemoryBuffer() {
     this->address = NULL;
-    this->size_l = 0;
-    this->size_m = 0;
-    this->size_h = 0;
-    this->flags = 0;
+    this->size = 0;
+    this->alloced = false;
+    this->locked = false;
     this->prev = NULL;
     this->next = NULL;
 }
@@ -110,7 +103,7 @@ NuSoundMemoryBuffer::~NuSoundMemoryBuffer() {
 // libTTapp.so 0x321510: the buffer headers come out of the SCRATCH heap.
 NuSoundMemoryBuffer *NuSoundMemoryManager::PopFreeBuffer() {
     NuSoundMemoryBuffer *buf = (NuSoundMemoryBuffer *)NuSoundSystem::_AllocMemory(
-        NuSoundSystem::MemoryDiscipline::SCRATCH, 0x10, 4,
+        NuSoundSystem::MemoryDiscipline::SCRATCH, sizeof(NuSoundMemoryBuffer), 4,
         "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound_memorymanager.cpp:339");
 
     new (buf) NuSoundMemoryBuffer{};

--- a/src/nu2api/nusound/nusound_memorymanager.hpp
+++ b/src/nu2api/nusound/nusound_memorymanager.hpp
@@ -1,25 +1,23 @@
 #pragma once
 
+#include "decomp_assert.h"
 #include "nu2api/nucore/common.h"
 
 #include <pthread.h>
 
-// libTTapp.so layout: address@0x0, size bytes@0x4..0x6, flags@0x7
-// (bit7 = locked, bit6 = alloced), prev@0x8, next@0xc.
 class NuSoundMemoryBuffer {
     void *address;
-    u8 size_l;
-    u8 size_m;
-    u8 size_h;
-    u8 flags;
+    u32 size : 30;
+    bool alloced : 1;
+    bool locked : 1;
     NuSoundMemoryBuffer *prev;
     NuSoundMemoryBuffer *next;
 
   private:
     static pthread_mutex_t s_cs;
 
-    void BeginCriticalSection();
-    void EndCriticalSection();
+    static void BeginCriticalSection();
+    static void EndCriticalSection();
 
   public:
     NuSoundMemoryBuffer();
@@ -40,7 +38,9 @@ class NuSoundMemoryBuffer {
     bool IsAlloced();
     bool IsLocked();
     const char *GetLockReason(); // 0x321360: lock-reason getter, always NULL on device
-};
+} __attribute__((packed));
+
+DECOMP_ASSERT(sizeof(NuSoundMemoryBuffer) == 0x10, "NuSoundMemoryBuffer size");
 
 class NuSoundMemoryManager {
     void *memory;


### PR DESCRIPTION
Reconstruct flag bitfields and the original control flow in existing implementations, adding 22 functions at 100% match. Eleven started below 90%. The full binary comparison shows no score regressions or lost exact matches; exact functions increase from 998 to 1,020.

The packed `NuSoundMemoryBuffer` layout also restores its lock-wait loop: the previous unsigned-byte comparison against zero could never enter the loop. Restore the integer index parameter in `APIObjectSetUsed`, retain raw flag views and ABI layout checks, and refresh `matching.json` and the README.

Functions brought from below 90% to 100%:

| Function | Before |
| --- | ---: |
| `Lever_ActivateRev` | 14.64% |
| `GizmoPickup_SetVisibility` | 44.67% |
| `APIObjectSetUsed` | 55.89% |
| `ZipUp_Activate` | 58.27% |
| `Blowup_GetOutput` | 59.79% |
| `NuSoundMemoryBuffer::SetSize` | 63.81% |
| `NuSoundMemoryBuffer::GetSize` | 65.62% |
| `instNuGCutScenePause` | 66.11% |
| `Lever_GetGizmoName` | 71.11% |
| `GizPanel_GetOutput` | 85.36% |
| `NuSoundMemoryBuffer::SetAlloced` | 88.89% |

Other improvements include `Levers_StoreProgress` (66.56% -> 83.52%), `GizPanels_Reset` (69.39% -> 98.92%), and `Techno_Activate` (96.43% -> 98.93%).

Validation:

- `bazel build --config=target //src:saga_target`
- `bazel test //scripts/checks:checks`
- `bazel run //scripts/checks:check_symbols -- --list` using NDK r8e `nm`: no missing symbols; extra-symbol baseline passes.
- Full objdiff report compared against a clean pre-change build with the same compiler and objdiff version: 22 new exact matches, zero score regressions.
- `git diff --check`
