### PR TITLE
Remove CORS proxy from WASM player

### DIFF
--- a/doc/pages/README.md
+++ b/doc/pages/README.md
@@ -56,11 +56,9 @@ The Pages workflow builds the WASM target, copies `saga.js` and `saga.wasm`
 to the site root, and deploys `doc/pages/`. The player loads those shared
 artifacts from its parent directory.
 
-Remote OBB downloads always use
-`https://cors-header-proxy.avery-eae.workers.dev`, including sources that already
-support CORS. Signed source URLs are encoded into the proxy path, which ends
-in `.obb`. URLs already using the proxy are not wrapped again; same-origin
-server OBBs and local file uploads remain local. A generated service worker
+Remote OBB downloads fetch the source URL directly, so the host must
+permit cross-origin access. Same-origin server OBBs and local file uploads
+remain local. A generated service worker
 in `play/` provides the cross-origin isolation required by the threaded WASM
 build on GitHub Pages.
 

--- a/scripts/wasm_player.html
+++ b/scripts/wasm_player.html
@@ -80,7 +80,6 @@
         const loadingProgress = document.getElementById("loading-progress");
         const runtimeError = document.getElementById("runtime-error");
         const obbName = "main.1060.com.wb.lego.tcs.obb";
-        const corsProxyOrigin = "https://cors-header-proxy.avery-eae.workers.dev";
         let resolveRuntime;
         let rejectRuntime;
         let started = false;
@@ -188,12 +187,9 @@
             if (source.protocol !== "http:" && source.protocol !== "https:") {
                 throw new Error("The OBB URL must use HTTP or HTTPS.");
             }
-            const downloadUrl = source.origin === location.origin || source.origin === corsProxyOrigin
-                ? source.href
-                : `${corsProxyOrigin}/download/${encodeURIComponent(source.href)}/${obbName}`;
             let response;
             try {
-                response = await fetch(downloadUrl, { credentials: "omit" });
+                response = await fetch(source.href, { credentials: "omit" });
             } catch (error) {
                 throw new Error("The OBB download could not be reached. Check the URL and try again.");
             }


### PR DESCRIPTION
Fetch remote OBB URLs directly instead of routing through the cors-header-proxy worker. Hosts must permit cross-origin access; same-origin server OBBs and local file uploads are unchanged. Docs updated to match.