### PR TITLE
Fix WASM worker isolation and download OBBs directly

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -44,7 +44,9 @@ jobs:
         run: bazel build --config=wasm //src:saga_wasm
 
       - name: Assemble Pages
-        run: cp bazel-bin/src/saga.js bazel-bin/src/saga.wasm doc/pages/
+        run: |
+          mkdir -p doc/pages/play
+          cp bazel-bin/src/saga.js bazel-bin/src/saga.wasm doc/pages/play/
 
       - name: Build Pages
         run: bazel run //scripts:plot_binary_match_map

--- a/doc/pages/README.md
+++ b/doc/pages/README.md
@@ -57,16 +57,14 @@ to `play/`, and deploys `doc/pages/`. The player loads those artifacts from
 its own directory so pthread workers stay inside the isolation service worker
 scope.
 
-Remote OBB downloads always use
-`https://cors-header-proxy.avery-eae.workers.dev`, including sources that already
-support CORS. Signed source URLs are encoded into the proxy path, which ends
-in `.obb`. URLs already using the proxy are not wrapped again; same-origin
-server OBBs and local file uploads remain local. A generated service worker
-in `play/` provides the cross-origin isolation required by the threaded WASM
-build on GitHub Pages. It intercepts only document and worker-script requests;
-OBB downloads and other fetches use the browser network path directly, keeping
-long downloads independent of the service worker lifetime. Cross-origin OBB
-responses still need CORS support, provided by the download proxy.
+Remote OBB URLs are fetched directly without a proxy. Cross-origin sources
+must allow CORS requests from the player origin. If a source does not allow
+browser downloads, download the OBB separately and select the local file.
+A generated service worker in `play/` provides the cross-origin isolation
+required by the threaded WASM build on GitHub Pages. It intercepts only
+document and worker-script requests; OBB downloads and other fetches use the
+browser network path directly, keeping long downloads independent of the
+service worker lifetime.
 
 The pre-commit hook is a small shim for the `//scripts:pre_commit` Bazel
 `py_binary`. That target runs the build, symbol check, and Bazel report

--- a/doc/pages/README.md
+++ b/doc/pages/README.md
@@ -63,7 +63,10 @@ support CORS. Signed source URLs are encoded into the proxy path, which ends
 in `.obb`. URLs already using the proxy are not wrapped again; same-origin
 server OBBs and local file uploads remain local. A generated service worker
 in `play/` provides the cross-origin isolation required by the threaded WASM
-build on GitHub Pages.
+build on GitHub Pages. It intercepts only document and worker-script requests;
+OBB downloads and other fetches use the browser network path directly, keeping
+long downloads independent of the service worker lifetime. Cross-origin OBB
+responses still need CORS support, provided by the download proxy.
 
 The pre-commit hook is a small shim for the `//scripts:pre_commit` Bazel
 `py_binary`. That target runs the build, symbol check, and Bazel report

--- a/doc/pages/README.md
+++ b/doc/pages/README.md
@@ -53,8 +53,9 @@ and the download finish. Existing homepage `?obb=` links redirect to the
 player with their query intact. Selecting a file or submitting a URL also
 shows loading progress and starts the game as soon as the data is ready.
 The Pages workflow builds the WASM target, copies `saga.js` and `saga.wasm`
-to the site root, and deploys `doc/pages/`. The player loads those shared
-artifacts from its parent directory.
+to `play/`, and deploys `doc/pages/`. The player loads those artifacts from
+its own directory so pthread workers stay inside the isolation service worker
+scope.
 
 Remote OBB downloads always use
 `https://cors-header-proxy.avery-eae.workers.dev`, including sources that already

--- a/scripts/plot_binary_match_map.py
+++ b/scripts/plot_binary_match_map.py
@@ -137,6 +137,10 @@ COI_SERVICE_WORKER = r"""if (typeof window === "undefined") {
   self.addEventListener("install", () => self.skipWaiting());
   self.addEventListener("activate", event => event.waitUntil(self.clients.claim()));
   self.addEventListener("fetch", event => {
+    // Only browsing contexts and workers need synthetic isolation headers.
+    // Leave downloads to the browser so long OBB streams do not depend on
+    // the service worker lifetime. Returning without respondWith bypasses it.
+    if (!["document", "worker", "sharedworker"].includes(event.request.destination)) return;
     if (event.request.cache === "only-if-cached" && event.request.mode !== "same-origin") return;
     event.respondWith(fetch(event.request).then(response => {
       if (response.status === 0) return response;

--- a/scripts/test_pages.py
+++ b/scripts/test_pages.py
@@ -43,7 +43,7 @@ class PagesTest(unittest.TestCase):
             self.assertNotIn('id="progress"', player)
             self.assertNotIn("d3.min.js", player)
             self.assertIn('src="./coi-serviceworker.js"', player)
-            self.assertIn('runtimeScript.src = "../saga.js"', player)
+            self.assertIn('runtimeScript.src = "./saga.js"', player)
             self.assertIn('href="../site.css"', player)
             self.assertTrue((output.parent / "site.css").is_file())
             self.assertTrue((output.parent / "play/coi-serviceworker.js").is_file())

--- a/scripts/wasm_player.html
+++ b/scripts/wasm_player.html
@@ -302,7 +302,8 @@
             }
             runtimeLoadStarted = true;
             const runtimeScript = document.createElement("script");
-            runtimeScript.src = "../saga.js";
+            // Keep pthread worker URLs inside the isolation service worker scope.
+            runtimeScript.src = "./saga.js";
             runtimeScript.async = true;
             runtimeScript.addEventListener("error", () => {
                 const error = new Error("The WebAssembly build could not be loaded.");

--- a/scripts/wasm_player.html
+++ b/scripts/wasm_player.html
@@ -80,7 +80,6 @@
         const loadingProgress = document.getElementById("loading-progress");
         const runtimeError = document.getElementById("runtime-error");
         const obbName = "main.1060.com.wb.lego.tcs.obb";
-        const corsProxyOrigin = "https://cors-header-proxy.avery-eae.workers.dev";
         let resolveRuntime;
         let rejectRuntime;
         let started = false;
@@ -188,14 +187,11 @@
             if (source.protocol !== "http:" && source.protocol !== "https:") {
                 throw new Error("The OBB URL must use HTTP or HTTPS.");
             }
-            const downloadUrl = source.origin === location.origin || source.origin === corsProxyOrigin
-                ? source.href
-                : `${corsProxyOrigin}/download/${encodeURIComponent(source.href)}/${obbName}`;
             let response;
             try {
-                response = await fetch(downloadUrl, { credentials: "omit" });
+                response = await fetch(source.href, { credentials: "omit" });
             } catch (error) {
-                throw new Error("The OBB download could not be reached. Check the URL and try again.");
+                throw new Error("The OBB download could not be reached. Check the URL and that its server allows cross-origin downloads, or select a local OBB file.");
             }
             if (!response.ok) throw new Error(`OBB download failed: HTTP ${response.status}`);
             if ((response.headers.get("content-type") || "").includes("text/html")) {

--- a/scripts/wasm_server.py
+++ b/scripts/wasm_server.py
@@ -89,8 +89,8 @@ class WasmRequestHandler(SimpleHTTPRequestHandler):
         if path == f"/{OBB_NAME}":
             self._serve_local_obb(head_only=False)
             return
-        if path in {"/saga.js", "/saga.wasm"} and self._serve_wasm_asset(
-            path[1:], head_only=False
+        if path in {"/saga.js", "/saga.wasm", "/play/saga.js", "/play/saga.wasm"} and self._serve_wasm_asset(
+            path.rsplit("/", 1)[-1], head_only=False
         ):
             return
         if path == "/":
@@ -106,8 +106,8 @@ class WasmRequestHandler(SimpleHTTPRequestHandler):
         if path == f"/{OBB_NAME}":
             self._serve_local_obb(head_only=True)
             return
-        if path in {"/saga.js", "/saga.wasm"} and self._serve_wasm_asset(
-            path[1:], head_only=True
+        if path in {"/saga.js", "/saga.wasm", "/play/saga.js", "/play/saga.wasm"} and self._serve_wasm_asset(
+            path.rsplit("/", 1)[-1], head_only=True
         ):
             return
         if path == "/":


### PR DESCRIPTION
The deployed player loads `/saga.js`, which starts pthread workers outside the isolation service worker's `/play/` scope. Workers fail after the OBB loads, while the local server masks the issue by supplying isolation headers directly. The service worker also intercepts OBB downloads unnecessarily, making long streams depend on its lifetime.

Place the JavaScript and WASM assets under `play/`, load the runtime from that directory, and support those paths in the local server. Limit service worker interception to documents and worker scripts so OBB downloads use the browser's normal network path. Remove the CORS proxy and fetch supplied OBB URLs directly, preserving signed query strings. Cross-origin source servers must allow CORS; the error message offers local file selection when direct downloads fail. Update the page test and deployment documentation.

Validation:
- Browser reproduction without server isolation headers: worker outside the service worker scope fails; worker inside the scope starts and receives shared memory.
- Generated service worker handler check: fetch/download requests bypass interception; documents and workers retain isolation headers and response bodies.
- Direct-download check: supplied URL and signed query are preserved, credentials omitted, and invalid URL schemes rejected.
- `python -m unittest scripts.test_pages` passes.
- `git diff --check` passes.
- Full Bazel checks could not run because Bash is missing on this Windows host.
- Long-download behavior has not been tested in Firefox itself.

