### PR TITLE
Fix the WebAssembly clang-tidy pass on macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,11 +6,9 @@ common --repo_contents_cache=
 # to refresh it explicitly after dependency changes.
 common --lockfile_mode=error
 
-# rules_python's default launcher starts py_binary under the system `python3`
-# before re-executing under the toolchain interpreter. On macOS that first hop
-# is Apple's xcrun shim, which exports SDKROOT and so overrides the --sysroot
-# given to cross-compiling tools such as clang-tidy. Launching the toolchain
-# interpreter directly skips the shim. rules_python ignores this on Windows.
+# Don't use the system `python3` for the Python bootstrap.
+# (doing so on macOS in particular introduces unwanted environment variables)
+# NOTE: this setting will be ignored on Windows.
 common --@rules_python//python/config_settings:bootstrap_impl=script
 
 build --show_timestamps

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,13 @@ common --repo_contents_cache=
 # to refresh it explicitly after dependency changes.
 common --lockfile_mode=error
 
+# rules_python's default launcher starts py_binary under the system `python3`
+# before re-executing under the toolchain interpreter. On macOS that first hop
+# is Apple's xcrun shim, which exports SDKROOT and so overrides the --sysroot
+# given to cross-compiling tools such as clang-tidy. Launching the toolchain
+# interpreter directly skips the shim. rules_python ignores this on Windows.
+common --@rules_python//python/config_settings:bootstrap_impl=script
+
 build --show_timestamps
 build --verbose_failures
 build --incompatible_strict_action_env

--- a/scripts/checks/linters.bzl
+++ b/scripts/checks/linters.bzl
@@ -192,6 +192,12 @@ clang_tidy_android = _clang_tidy_aspect(
     extra_args = ["--extra-arg=--target=i686-linux-android"],
 )
 
+# clang-tidy otherwise parses with the host triple, so linting these sources on
+# macOS defines __APPLE__ and sends SDL down its Apple branch.
+clang_tidy_wasm = _clang_tidy_aspect(
+    extra_args = ["--extra-arg=--target=wasm32-unknown-emscripten"],
+)
+
 def _clang_tidy_check_impl(_ctx):
     return DefaultInfo()
 
@@ -230,7 +236,7 @@ clang_tidy_wasm_check = rule(
     implementation = _clang_tidy_check_impl,
     attrs = {
         "srcs": attr.label_list(
-            aspects = [clang_tidy],
+            aspects = [clang_tidy_wasm],
             cfg = _wasm_transition,
         ),
         "_allowlist_function_transition": attr.label(

--- a/scripts/checks/linters.bzl
+++ b/scripts/checks/linters.bzl
@@ -192,8 +192,6 @@ clang_tidy_android = _clang_tidy_aspect(
     extra_args = ["--extra-arg=--target=i686-linux-android"],
 )
 
-# clang-tidy otherwise parses with the host triple, so linting these sources on
-# macOS defines __APPLE__ and sends SDL down its Apple branch.
 clang_tidy_wasm = _clang_tidy_aspect(
     extra_args = ["--extra-arg=--target=wasm32-unknown-emscripten"],
 )


### PR DESCRIPTION
`bazel run //scripts:pre_commit` cannot complete on macOS. Its
WebAssembly lint stage fails on every source in `//src:saga_wasm_objects`
with `'sys/types.h' file not found`, and behind that failure sits a
second one. Both are host environment leaking into a cross-compilation.

## SDKROOT overrides the Emscripten sysroot

The `ClangTidy` aspect passes `--sysroot=<emscripten>` correctly, and the
headers are present as declared action inputs. They are ignored anyway.

Bazel runs the lint through `//scripts/checks:run_clang_tidy`, a
`py_binary`. rules_python's default `system_python` bootstrap launches
such targets in two stages: stage one runs under `#!/usr/bin/env
python3`, locates the toolchain interpreter, and re-executes stage two
under it. Bazel clears the environment for the action, so with no `PATH`
the first stage resolves to `/usr/bin/python3` — Apple's `xcrun` shim,
which exports `SDKROOT`, `CPATH`, and `LIBRARY_PATH` before handing on.

clang's Darwin driver prefers `SDKROOT` over `--sysroot`. `-iwithsysroot
/include` then resolves into `MacOSX.sdk/include`, which does not exist
(macOS SDKs use `usr/include`), and the standard headers vanish.

Setting `bootstrap_impl=script` makes the launcher exec the toolchain
interpreter directly, so the shim never runs. rules_python pins this flag
back to `system_python` on Windows, so that platform is unaffected. It
also stops `CPATH=/usr/local/include` from being injected into every
Python-driven action.

## The wasm lint parses with the host triple

With the sysroot honoured, SDL fails on `<AvailabilityMacros.h>`. The
aspect names no target triple, so clang-tidy parses WebAssembly sources
as `arm64-apple-darwin`, defines `__APPLE__`, and sends
`SDL_platform_defines.h` down its Apple branch.

`clang_tidy_android` already solves this for the NDK toolchain by naming
`i686-linux-android`. This adds the matching `clang_tidy_wasm` aspect for
`wasm32-unknown-emscripten` and points `clang_tidy_wasm_check` at it.

## Testing

On macOS 15 / arm64, from a clean checkout of this branch's base:

- `bazel build --config=wasm //src:clang_tidy_wasm` — reproduced the
  `sys/types.h` failure before the change; 511 lint actions pass after it
- `bazel run //scripts:pre_commit` — exits 0 (Pages stages skipped, as
  `res/libTTapp.so` is not present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)