### PR TITLE
Reformat the sources to match clang-format

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,11 +6,9 @@ common --repo_contents_cache=
 # to refresh it explicitly after dependency changes.
 common --lockfile_mode=error
 
-# rules_python's default launcher starts py_binary under the system `python3`
-# before re-executing under the toolchain interpreter. On macOS that first hop
-# is Apple's xcrun shim, which exports SDKROOT and so overrides the --sysroot
-# given to cross-compiling tools such as clang-tidy. Launching the toolchain
-# interpreter directly skips the shim. rules_python ignores this on Windows.
+# Don't use the system `python3` for the Python bootstrap.
+# (doing so on macOS in particular introduces unwanted environment variables)
+# NOTE: this setting will be ignored on Windows.
 common --@rules_python//python/config_settings:bootstrap_impl=script
 
 build --show_timestamps

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,13 @@ common --repo_contents_cache=
 # to refresh it explicitly after dependency changes.
 common --lockfile_mode=error
 
+# rules_python's default launcher starts py_binary under the system `python3`
+# before re-executing under the toolchain interpreter. On macOS that first hop
+# is Apple's xcrun shim, which exports SDKROOT and so overrides the --sysroot
+# given to cross-compiling tools such as clang-tidy. Launching the toolchain
+# interpreter directly skips the shim. rules_python ignores this on Windows.
+common --@rules_python//python/config_settings:bootstrap_impl=script
+
 build --show_timestamps
 build --verbose_failures
 build --incompatible_strict_action_env

--- a/scripts/checks/linters.bzl
+++ b/scripts/checks/linters.bzl
@@ -192,6 +192,12 @@ clang_tidy_android = _clang_tidy_aspect(
     extra_args = ["--extra-arg=--target=i686-linux-android"],
 )
 
+# clang-tidy otherwise parses with the host triple, so linting these sources on
+# macOS defines __APPLE__ and sends SDL down its Apple branch.
+clang_tidy_wasm = _clang_tidy_aspect(
+    extra_args = ["--extra-arg=--target=wasm32-unknown-emscripten"],
+)
+
 def _clang_tidy_check_impl(_ctx):
     return DefaultInfo()
 
@@ -230,7 +236,7 @@ clang_tidy_wasm_check = rule(
     implementation = _clang_tidy_check_impl,
     attrs = {
         "srcs": attr.label_list(
-            aspects = [clang_tidy],
+            aspects = [clang_tidy_wasm],
             cfg = _wasm_transition,
         ),
         "_allowlist_function_transition": attr.label(

--- a/scripts/checks/linters.bzl
+++ b/scripts/checks/linters.bzl
@@ -192,8 +192,6 @@ clang_tidy_android = _clang_tidy_aspect(
     extra_args = ["--extra-arg=--target=i686-linux-android"],
 )
 
-# clang-tidy otherwise parses with the host triple, so linting these sources on
-# macOS defines __APPLE__ and sends SDL down its Apple branch.
 clang_tidy_wasm = _clang_tidy_aspect(
     extra_args = ["--extra-arg=--target=wasm32-unknown-emscripten"],
 )

--- a/src/MechInputTouch/MechInputTouchContextTasks.cpp
+++ b/src/MechInputTouch/MechInputTouchContextTasks.cpp
@@ -19,9 +19,9 @@ void MechTouchTaskTag::Update() {
 }
 
 MechTouchTaskGoTo::MechTouchTaskGoTo(MechInputTouchGestureBasedController &owner, MechObjectInterface *object)
-    : MechTouchTask(owner), target(object), room(-1), field_30(0), field_34(0), field_38(0), field_3c(0),
-      field_40(0), field_44(0), field_4c(0), field_4d(1), field_4e(0), field_4f(0), field_50(0), field_51(0),
-      field_54(0), field_58(0), field_5c(0) {
+    : MechTouchTask(owner), target(object), room(-1), field_30(0), field_34(0), field_38(0), field_3c(0), field_40(0),
+      field_44(0), field_4c(0), field_4d(1), field_4e(0), field_4f(0), field_50(0), field_51(0), field_54(0),
+      field_58(0), field_5c(0) {
 }
 
 void MechTouchTaskGoTo::OnStart() {
@@ -93,7 +93,8 @@ void MechTouchTaskBigJump::Update() {
 void ForceBuildItToUseNext(GIZBUILDIT_s &);
 
 MechTouchTaskBuildIt::MechTouchTaskBuildIt(MechInputTouchGestureBasedController &owner, MechObjectInterface *object,
-                                         VuVec const &) : MechTouchTaskGoTo(owner, object) {
+                                           VuVec const &)
+    : MechTouchTaskGoTo(owner, object) {
     if (object->GetGizBuildit() != NULL) {
         ForceBuildItToUseNext(*object->GetGizBuildit());
     }

--- a/src/MechInputTouch/MechInputTouch_types.h
+++ b/src/MechInputTouch/MechInputTouch_types.h
@@ -420,27 +420,65 @@ struct GIZTURRET_s;
 struct PART_s;
 
 struct MechObjectInterface : NuMechPtr<MechObjectInterface, 4>::ManagedBase {
-    virtual ~MechObjectInterface() {}
-    virtual void GetPos(VuVec &, i32) const {}
+    virtual ~MechObjectInterface() {
+    }
+    virtual void GetPos(VuVec &, i32) const {
+    }
     virtual void GetFloorTargetPos(VuVec &, i32) const;
-    virtual f32 GetRadius() const { return 0.0f; }
-    virtual f32 GetHeight() const { const f32 radius = GetRadius(); return radius + radius; }
-    virtual const char *GetTargetName() const { return ""; }
-    virtual i32 GetObjectType() const { return 0; }
-    virtual void TargetedFlash() {}
-    virtual i32 IsDead() { return 1; }
-    virtual void *GetTgtVoidPtr() { return NULL; }
-    virtual GameObject_s *GetCharacterObject() { return NULL; }
-    virtual GIZOBSTACLE_s *GetGizObstacle() { return NULL; }
-    virtual GIZMOBLOWUP_s *GetGizBlowup() { return NULL; }
-    virtual GIZFORCE_s *GetGizForce() { return NULL; }
-    virtual GIZBUILDIT_s *GetGizBuildit() { return NULL; }
-    virtual LEVER_s *GetGizLever() { return NULL; }
-    virtual TELEPORT_s *GetTeleport() { return NULL; }
-    virtual HATMACHINE_s *GetHatMachine() { return NULL; }
-    virtual GIZPANEL_s *GetPanel() { return NULL; }
-    virtual GIZTURRET_s *GetGizTurret() { return NULL; }
-    virtual PART_s *GetPart() { return NULL; }
+    virtual f32 GetRadius() const {
+        return 0.0f;
+    }
+    virtual f32 GetHeight() const {
+        const f32 radius = GetRadius();
+        return radius + radius;
+    }
+    virtual const char *GetTargetName() const {
+        return "";
+    }
+    virtual i32 GetObjectType() const {
+        return 0;
+    }
+    virtual void TargetedFlash() {
+    }
+    virtual i32 IsDead() {
+        return 1;
+    }
+    virtual void *GetTgtVoidPtr() {
+        return NULL;
+    }
+    virtual GameObject_s *GetCharacterObject() {
+        return NULL;
+    }
+    virtual GIZOBSTACLE_s *GetGizObstacle() {
+        return NULL;
+    }
+    virtual GIZMOBLOWUP_s *GetGizBlowup() {
+        return NULL;
+    }
+    virtual GIZFORCE_s *GetGizForce() {
+        return NULL;
+    }
+    virtual GIZBUILDIT_s *GetGizBuildit() {
+        return NULL;
+    }
+    virtual LEVER_s *GetGizLever() {
+        return NULL;
+    }
+    virtual TELEPORT_s *GetTeleport() {
+        return NULL;
+    }
+    virtual HATMACHINE_s *GetHatMachine() {
+        return NULL;
+    }
+    virtual GIZPANEL_s *GetPanel() {
+        return NULL;
+    }
+    virtual GIZTURRET_s *GetGizTurret() {
+        return NULL;
+    }
+    virtual PART_s *GetPart() {
+        return NULL;
+    }
 };
 DECOMP_ASSERT(sizeof(MechObjectInterface) == 8, "MechObjectInterface ABI");
 DECOMP_ASSERT(sizeof(NuMechPtr<MechObjectInterface, 4>) == 12, "Mech object reference ABI");
@@ -507,17 +545,31 @@ struct MechTempPosInterface {
 struct MechTouchTask {
     MechTouchTask(MechInputTouchGestureBasedController &);
     virtual ~MechTouchTask();
-    virtual const HashedKey &GetHashId() { return HashId; }
-    virtual void OnStart() {}
-    virtual void OnStop() {}
-    virtual void OnSuspend() {}
-    virtual void OnResume() {}
-    virtual void Update() {}
-    virtual void BackgroundProcess() {}
-    virtual void Render() {}
-    virtual void UpdateTarget(MechObjectInterface &) {}
-    virtual i32 IsGoToTask() { return 0; }
-    virtual i32 IsBigJumpTask() { return 0; }
+    virtual const HashedKey &GetHashId() {
+        return HashId;
+    }
+    virtual void OnStart() {
+    }
+    virtual void OnStop() {
+    }
+    virtual void OnSuspend() {
+    }
+    virtual void OnResume() {
+    }
+    virtual void Update() {
+    }
+    virtual void BackgroundProcess() {
+    }
+    virtual void Render() {
+    }
+    virtual void UpdateTarget(MechObjectInterface &) {
+    }
+    virtual i32 IsGoToTask() {
+        return 0;
+    }
+    virtual i32 IsBigJumpTask() {
+        return 0;
+    }
     static HashedKey HashId;
     MechTouchTask *next;
     MechInputTouchGestureBasedController *controller;
@@ -549,14 +601,18 @@ struct MechTouchTaskBlock {
 };
 struct MechTouchTaskGoTo : MechTouchTask {
     MechTouchTaskGoTo(MechInputTouchGestureBasedController &, MechObjectInterface *);
-    const HashedKey &GetHashId() override { return HashId; }
+    const HashedKey &GetHashId() override {
+        return HashId;
+    }
     void OnStart() override;
     void OnStop() override;
     void Render() override;
     void Update() override;
     void UpdateStuck();
     void UpdateTarget(MechObjectInterface &) override;
-    i32 IsGoToTask() override { return 1; }
+    i32 IsGoToTask() override {
+        return 1;
+    }
     virtual ~MechTouchTaskGoTo();
     static HashedKey HashId;
     NuMechPtr<MechObjectInterface, 4> target;
@@ -583,7 +639,9 @@ struct MechTouchTaskGoTo : MechTouchTask {
 DECOMP_ASSERT(sizeof(MechTouchTaskGoTo) == 0x60, "MechTouchTaskGoTo ABI");
 struct MechTouchTaskBuildIt : MechTouchTaskGoTo {
     MechTouchTaskBuildIt(MechInputTouchGestureBasedController &, MechObjectInterface *, VuVec const &);
-    const HashedKey &GetHashId() override { return HashId; }
+    const HashedKey &GetHashId() override {
+        return HashId;
+    }
     void Update() override;
     static HashedKey HashId;
 };

--- a/src/gameapi/ai/aisys/cc.cpp
+++ b/src/gameapi/ai/aisys/cc.cpp
@@ -306,14 +306,18 @@ static void CC_jump_move_speed_scale(NUFPAR *parser) {
 
 static void CC_layer(NUFPAR *parser) {
     GAMECHARACTERDATA_s *data = charconfig.runtime;
-    if ((charconfig.flags & 2) == 0 || data->layer_count >= 32) return;
-    if (NuFParGetWord(parser) == 0 || NuStrLen(parser->word_buf) >= 24) return;
+    if ((charconfig.flags & 2) == 0 || data->layer_count >= 32)
+        return;
+    if (NuFParGetWord(parser) == 0 || NuStrLen(parser->word_buf) >= 24)
+        return;
     GAMECHARACTERLAYER_s *layer = &data->layers[data->layer_count];
     NuStrCpy(layer->name, parser->word_buf);
     const u32 bit = NuFParGetInt(parser);
-    if (bit >= 32) return;
+    if (bit >= 32)
+        return;
     for (i32 i = 0; i < data->layer_count; ++i) {
-        if (data->layers[i].mask_bit == static_cast<i32>(bit)) return;
+        if (data->layers[i].mask_bit == static_cast<i32>(bit))
+            return;
     }
     charconfig.named_layers = 1;
     layer->mask_bit = static_cast<i16>(bit);
@@ -388,8 +392,8 @@ static void CC_minikit_with_scene(NUFPAR *parser) {
     if (NuFParGetWord(parser) != 0 && NuStrICmp(parser->word_buf, "off") == 0) {
         charconfig.character->model_flags &= ~0x4000000u;
     }
-    charconfig.runtime->flags_094[0] = (charconfig.runtime->flags_094[0] & 0xfe) |
-                                      ((charconfig.character->model_flags >> 26) & 1);
+    charconfig.runtime->flags_094[0] =
+        (charconfig.runtime->flags_094[0] & 0xfe) | ((charconfig.character->model_flags >> 26) & 1);
 }
 
 static void CC_miny(NUFPAR *parser) {
@@ -878,11 +882,13 @@ static void CC_SetAnimMiscFlags(NUFPAR *parser, CHARACTERANIM_s *animation, u16 
 static void CC_anim_start(NUFPAR *parser) {
     if (charconfig.animation_count >= 100) {
         while (NuFParGetLine(parser) != 0) {
-            if (NuFParGetWord(parser) != 0 && NuStrICmp(parser->word_buf, "anim_end") == 0) break;
+            if (NuFParGetWord(parser) != 0 && NuStrICmp(parser->word_buf, "anim_end") == 0)
+                break;
         }
         return;
     }
-    if (NuFParGetWord(parser) == 0 || NuStrLen(parser->word_buf) >= 40) return;
+    if (NuFParGetWord(parser) == 0 || NuStrLen(parser->word_buf) >= 40)
+        return;
     char name[40];
     NuStrCpy(name, parser->word_buf);
     CHARACTERANIM_s animation;
@@ -894,24 +900,33 @@ static void CC_anim_start(NUFPAR *parser) {
     animation.playback_rate = 30.0f;
     animation.locator = 0xff;
     while (NuFParGetLine(parser) != 0) {
-        if (NuFParGetWord(parser) == 0) continue;
+        if (NuFParGetWord(parser) == 0)
+            continue;
         if (NuStrICmp(parser->word_buf, "action") == 0) {
-            if (NuFParGetWord(parser) != 0) animation.action_id = static_cast<i16>(ActionFromName(parser->word_buf));
-            if (animation.action_id == -1) return;
+            if (NuFParGetWord(parser) != 0)
+                animation.action_id = static_cast<i16>(ActionFromName(parser->word_buf));
+            if (animation.action_id == -1)
+                return;
         } else if (NuStrICmp(parser->word_buf, "bsa") == 0) {
             if (NuFParGetWord(parser) != 0) {
-                if (NuStrICmp(parser->word_buf, "on") == 0) animation.flags |= 8;
-                else if (NuStrICmp(parser->word_buf, "off") == 0) animation.flags &= ~8u;
+                if (NuStrICmp(parser->word_buf, "on") == 0)
+                    animation.flags |= 8;
+                else if (NuStrICmp(parser->word_buf, "off") == 0)
+                    animation.flags &= ~8u;
             }
         } else if (NuStrICmp(parser->word_buf, "cycle") == 0) {
             if (NuFParGetWord(parser) != 0) {
-                if (NuStrICmp(parser->word_buf, "on") == 0) animation.flags |= 2;
-                else if (NuStrICmp(parser->word_buf, "off") == 0) animation.flags &= ~2u;
+                if (NuStrICmp(parser->word_buf, "on") == 0)
+                    animation.flags |= 2;
+                else if (NuStrICmp(parser->word_buf, "off") == 0)
+                    animation.flags &= ~2u;
             }
         } else if (NuStrICmp(parser->word_buf, "type") == 0) {
             if (NuFParGetWord(parser) != 0) {
-                if (NuStrICmp(parser->word_buf, "idle") == 0) animation.flags |= 0x10;
-                else animation.flags &= ~0x10u;
+                if (NuStrICmp(parser->word_buf, "idle") == 0)
+                    animation.flags |= 0x10;
+                else
+                    animation.flags &= ~0x10u;
             }
         } else if (NuStrICmp(parser->word_buf, "fpsec") == 0) {
             animation.playback_rate = NuFParGetFloat(parser);
@@ -933,15 +948,21 @@ static void CC_anim_start(NUFPAR *parser) {
                 if (NuStrICmp(parser->word_buf, "off") == 0) {
                     animation.flags &= ~0x70100u;
                     break;
-                } else if (NuStrICmp(parser->word_buf, "4frames") == 0) animation.flags |= 0x10000;
-                else if (NuStrICmp(parser->word_buf, "judder") == 0) animation.flags |= 0x20000;
-                else if (NuStrICmp(parser->word_buf, "shake") == 0) animation.flags |= 0x40000;
+                } else if (NuStrICmp(parser->word_buf, "4frames") == 0)
+                    animation.flags |= 0x10000;
+                else if (NuStrICmp(parser->word_buf, "judder") == 0)
+                    animation.flags |= 0x20000;
+                else if (NuStrICmp(parser->word_buf, "shake") == 0)
+                    animation.flags |= 0x40000;
             }
-        } else if (NuStrICmp(parser->word_buf, "no_headturn") == 0 || NuStrICmp(parser->word_buf, "headturn_off") == 0) {
+        } else if (NuStrICmp(parser->word_buf, "no_headturn") == 0 ||
+                   NuStrICmp(parser->word_buf, "headturn_off") == 0) {
             animation.flags |= 0x40;
         } else if (NuStrICmp(parser->word_buf, "headturn") == 0) {
-            if (NuFParGetWord(parser) != 0 && NuStrICmp(parser->word_buf, "off") == 0) animation.flags |= 0x40;
-            else animation.flags &= ~0x40u;
+            if (NuFParGetWord(parser) != 0 && NuStrICmp(parser->word_buf, "off") == 0)
+                animation.flags |= 0x40;
+            else
+                animation.flags &= ~0x40u;
         } else if (NuStrICmp(parser->word_buf, "minreps") == 0) {
             animation.minimum_repetitions = static_cast<i8>(abs(NuFParGetInt(parser)));
         } else if (NuStrICmp(parser->word_buf, "maxreps") == 0) {
@@ -967,13 +988,16 @@ static void CC_anim_start(NUFPAR *parser) {
             animation.flags |= 0x800;
         } else if (NuStrICmp(parser->word_buf, "gun") == 0) {
             if (NuFParGetWord(parser) != 0) {
-                if (NuStrICmp(parser->word_buf, "on") == 0) animation.flags |= 0x800;
-                else if (NuStrICmp(parser->word_buf, "off") == 0) animation.flags |= 0x400;
+                if (NuStrICmp(parser->word_buf, "on") == 0)
+                    animation.flags |= 0x800;
+                else if (NuStrICmp(parser->word_buf, "off") == 0)
+                    animation.flags |= 0x400;
             }
         } else if (NuStrICmp(parser->word_buf, "locator") == 0) {
             if (NuFParGetWord(parser) != 0) {
                 const u32 locator = NuAToI(parser->word_buf);
-                if (locator < 16) animation.locator = static_cast<u8>(locator);
+                if (locator < 16)
+                    animation.locator = static_cast<u8>(locator);
             }
         } else if (NuStrICmp(parser->word_buf, "is_punch") == 0) {
             CC_SetAnimMiscFlags(parser, &animation, 1);
@@ -986,7 +1010,8 @@ static void CC_anim_start(NUFPAR *parser) {
         } else if (NuStrICmp(parser->word_buf, "effect_start") == 0) {
             if ((charconfig.flags & 0x60) != 0x60) {
                 while (NuFParGetLine(parser) != 0) {
-                    if (NuFParGetWord(parser) != 0 && NuStrICmp(parser->word_buf, "effect_end") == 0) break;
+                    if (NuFParGetWord(parser) != 0 && NuStrICmp(parser->word_buf, "effect_end") == 0)
+                        break;
                 }
             } else if (charconfig.effect_count < 32 && animation.action_id != -1) {
                 CHARACTER_EFFECT_s *effect = &charconfig.effect_scratch[charconfig.effect_count];
@@ -1009,39 +1034,58 @@ static void CC_anim_start(NUFPAR *parser) {
                 effect->bits_on = 0;
                 effect->bits_off = 0;
                 while (NuFParGetLine(parser) != 0) {
-                    if (NuFParGetWord(parser) == 0) continue;
+                    if (NuFParGetWord(parser) == 0)
+                        continue;
                     if (NuStrICmp(parser->word_buf, "deb_name") == 0) {
                         if (NuFParGetWord(parser) != 0) {
-                            effect->debris_id = perm_debrissys == NULL ? -1 : static_cast<i16>(FindGameDebris(
-                                static_cast<APIDEBRISSYS_s *>(perm_debrissys), parser->word_buf));
+                            effect->debris_id =
+                                perm_debrissys == NULL
+                                    ? -1
+                                    : static_cast<i16>(FindGameDebris(static_cast<APIDEBRISSYS_s *>(perm_debrissys),
+                                                                      parser->word_buf));
                         }
                     } else if (NuStrICmp(parser->word_buf, "condition") == 0) {
                         if (NuFParGetWord(parser) != 0) {
-                            if (NuStrICmp(parser->word_buf, "on_ground") == 0) effect->flags |= 0x10;
-                            else if (NuStrICmp(parser->word_buf, "under_water") == 0) effect->flags |= 0x20;
-                            else if (NuStrICmp(parser->word_buf, "above_water") == 0) effect->flags |= 0x40;
-                            else if (NuStrICmp(parser->word_buf, "intersect_water") == 0) effect->flags |= 0x80;
+                            if (NuStrICmp(parser->word_buf, "on_ground") == 0)
+                                effect->flags |= 0x10;
+                            else if (NuStrICmp(parser->word_buf, "under_water") == 0)
+                                effect->flags |= 0x20;
+                            else if (NuStrICmp(parser->word_buf, "above_water") == 0)
+                                effect->flags |= 0x40;
+                            else if (NuStrICmp(parser->word_buf, "intersect_water") == 0)
+                                effect->flags |= 0x80;
                         }
-                    } else if (NuStrICmp(parser->word_buf, "in_only") == 0) effect->flags |= 0x100;
-                    else if (NuStrICmp(parser->word_buf, "not_in") == 0) effect->flags |= 0x200;
-                    else if (NuStrICmp(parser->word_buf, "player_only") == 0) effect->flags |= 0x400;
+                    } else if (NuStrICmp(parser->word_buf, "in_only") == 0)
+                        effect->flags |= 0x100;
+                    else if (NuStrICmp(parser->word_buf, "not_in") == 0)
+                        effect->flags |= 0x200;
+                    else if (NuStrICmp(parser->word_buf, "player_only") == 0)
+                        effect->flags |= 0x400;
                     else if (NuStrICmp(parser->word_buf, "num_particles") == 0) {
                         const i32 count = NuFParGetInt(parser);
                         if (count > 0) {
                             effect->particle_count = static_cast<u8>(count);
                             effect->flags |= 1;
                         }
-                    } else if (NuStrICmp(parser->word_buf, "frame") == 0 || NuStrICmp(parser->word_buf, "frame1") == 0) {
+                    } else if (NuStrICmp(parser->word_buf, "frame") == 0 ||
+                               NuStrICmp(parser->word_buf, "frame1") == 0) {
                         effect->frame_1 = NuFParGetFloat(parser);
-                    } else if (NuStrICmp(parser->word_buf, "frame2") == 0) effect->frame_2 = NuFParGetFloat(parser);
-                    else if (NuStrICmp(parser->word_buf, "random") == 0) effect->random = static_cast<u8>(static_cast<i32>(NuFParGetFloat(parser) * 255.0f));
-                    else if (NuStrICmp(parser->word_buf, "rumble") == 0) effect->rumble = fabsf(NuFParGetFloat(parser));
-                    else if (NuStrICmp(parser->word_buf, "buzz") == 0) effect->shake = fabsf(NuFParGetFloat(parser));
-                    else if (NuStrICmp(parser->word_buf, "judder") == 0) effect->judder = NuFParGetFloat(parser);
+                    } else if (NuStrICmp(parser->word_buf, "frame2") == 0)
+                        effect->frame_2 = NuFParGetFloat(parser);
+                    else if (NuStrICmp(parser->word_buf, "random") == 0)
+                        effect->random = static_cast<u8>(static_cast<i32>(NuFParGetFloat(parser) * 255.0f));
+                    else if (NuStrICmp(parser->word_buf, "rumble") == 0)
+                        effect->rumble = fabsf(NuFParGetFloat(parser));
+                    else if (NuStrICmp(parser->word_buf, "buzz") == 0)
+                        effect->shake = fabsf(NuFParGetFloat(parser));
+                    else if (NuStrICmp(parser->word_buf, "judder") == 0)
+                        effect->judder = NuFParGetFloat(parser);
                     else if (NuStrICmp(parser->word_buf, "timing") == 0) {
                         if (NuFParGetWord(parser) != 0) {
-                            if (NuStrICmp(parser->word_buf, "constant") == 0) effect->flags |= 4;
-                            else if (NuStrICmp(parser->word_buf, "between") == 0) effect->flags |= 8;
+                            if (NuStrICmp(parser->word_buf, "constant") == 0)
+                                effect->flags |= 4;
+                            else if (NuStrICmp(parser->word_buf, "between") == 0)
+                                effect->flags |= 8;
                         }
                     } else if (NuStrICmp(parser->word_buf, "particles_per_frame") == 0) {
                         effect->particle_rate = fabsf(NuFParGetFloat(parser));
@@ -1052,45 +1096,65 @@ static void CC_anim_start(NUFPAR *parser) {
                     } else if (NuStrICmp(parser->word_buf, "locators") == 0) {
                         while (NuFParGetWord(parser) != 0) {
                             const u32 locator = NuAToI(parser->word_buf);
-                            if (locator < 16) effect->locators |= 1u << locator;
+                            if (locator < 16)
+                                effect->locators |= 1u << locator;
                         }
                     } else if (NuStrICmp(parser->word_buf, "sfx") == 0) {
-                        if (NuFParGetWord(parser) != 0) effect->sound_id = static_cast<i16>(GetSfxId(parser->word_buf));
-                    } else if (NuStrICmp(parser->word_buf, "sfx_2d") == 0) effect->flags &= ~0x8000u;
+                        if (NuFParGetWord(parser) != 0)
+                            effect->sound_id = static_cast<i16>(GetSfxId(parser->word_buf));
+                    } else if (NuStrICmp(parser->word_buf, "sfx_2d") == 0)
+                        effect->flags &= ~0x8000u;
                     else if (NuStrICmp(parser->word_buf, "volume") == 0) {
                         effect->minimum = fabsf(NuFParGetFloat(parser));
                         effect->flags |= 0x10000;
                     } else if (NuStrICmp(parser->word_buf, "surfaces") == 0) {
-                        if (NuFParGetWord(parser) != 0 && NuStrICmp(parser->word_buf, "non_solid") == 0) effect->surfaces = ~SURFACEBITS_DUST;
-                    } else if (NuStrICmp(parser->word_buf, "at_ter_surface") == 0) effect->flags |= 0x2000;
-                    else if (NuStrICmp(parser->word_buf, "at_obj_bottom") == 0) effect->flags |= 0x1000;
-                    else if (NuStrICmp(parser->word_buf, "at_locator_average") == 0) effect->flags |= 0x800;
-                    else if (NuStrICmp(parser->word_buf, "at_ter_layer") == 0) effect->flags |= 0x4000;
+                        if (NuFParGetWord(parser) != 0 && NuStrICmp(parser->word_buf, "non_solid") == 0)
+                            effect->surfaces = ~SURFACEBITS_DUST;
+                    } else if (NuStrICmp(parser->word_buf, "at_ter_surface") == 0)
+                        effect->flags |= 0x2000;
+                    else if (NuStrICmp(parser->word_buf, "at_obj_bottom") == 0)
+                        effect->flags |= 0x1000;
+                    else if (NuStrICmp(parser->word_buf, "at_locator_average") == 0)
+                        effect->flags |= 0x800;
+                    else if (NuStrICmp(parser->word_buf, "at_ter_layer") == 0)
+                        effect->flags |= 0x4000;
                     else if (NuStrICmp(parser->word_buf, "min_mode") == 0) {
                         if (NuFParGetWord(parser) != 0) {
-                            if (NuStrICmp(parser->word_buf, "xz_speed") == 0) effect->flags |= 0x40000;
-                            else if (NuStrICmp(parser->word_buf, "xyz_speed") == 0) effect->flags |= 0x100000;
+                            if (NuStrICmp(parser->word_buf, "xz_speed") == 0)
+                                effect->flags |= 0x40000;
+                            else if (NuStrICmp(parser->word_buf, "xyz_speed") == 0)
+                                effect->flags |= 0x100000;
                         }
                     } else if (NuStrICmp(parser->word_buf, "max_mode") == 0) {
                         if (NuFParGetWord(parser) != 0) {
-                            if (NuStrICmp(parser->word_buf, "xz_speed") == 0) effect->flags |= 0x80000;
-                            else if (NuStrICmp(parser->word_buf, "xyz_speed") == 0) effect->flags |= 0x200000;
+                            if (NuStrICmp(parser->word_buf, "xz_speed") == 0)
+                                effect->flags |= 0x80000;
+                            else if (NuStrICmp(parser->word_buf, "xyz_speed") == 0)
+                                effect->flags |= 0x200000;
                         }
-                    } else if (NuStrICmp(parser->word_buf, "min_val") == 0) effect->minimum = NuFParGetFloat(parser);
-                    else if (NuStrICmp(parser->word_buf, "max_val") == 0) effect->maximum = NuFParGetFloat(parser);
-                    else if (NuStrICmp(parser->word_buf, "at_obj_speed") == 0) effect->flags |= 0x400000;
-                    else if (NuStrICmp(parser->word_buf, "left_footprint") == 0) effect->flags |= 0x1000000;
-                    else if (NuStrICmp(parser->word_buf, "right_footprint") == 0) effect->flags |= 0x2000000;
-                    else if (NuStrICmp(parser->word_buf, "use_locator_matrix") == 0) effect->flags |= 0x4000000;
+                    } else if (NuStrICmp(parser->word_buf, "min_val") == 0)
+                        effect->minimum = NuFParGetFloat(parser);
+                    else if (NuStrICmp(parser->word_buf, "max_val") == 0)
+                        effect->maximum = NuFParGetFloat(parser);
+                    else if (NuStrICmp(parser->word_buf, "at_obj_speed") == 0)
+                        effect->flags |= 0x400000;
+                    else if (NuStrICmp(parser->word_buf, "left_footprint") == 0)
+                        effect->flags |= 0x1000000;
+                    else if (NuStrICmp(parser->word_buf, "right_footprint") == 0)
+                        effect->flags |= 0x2000000;
+                    else if (NuStrICmp(parser->word_buf, "use_locator_matrix") == 0)
+                        effect->flags |= 0x4000000;
                     else if (NuStrICmp(parser->word_buf, "bits_on") == 0) {
                         while (NuFParGetWord(parser) != 0) {
                             const u32 bit = NuAToI(parser->word_buf);
-                            if (bit < 8) effect->bits_on |= 1u << bit;
+                            if (bit < 8)
+                                effect->bits_on |= 1u << bit;
                         }
                     } else if (NuStrICmp(parser->word_buf, "bits_off") == 0) {
                         while (NuFParGetWord(parser) != 0) {
                             const u32 bit = NuAToI(parser->word_buf);
-                            if (bit < 8) effect->bits_off |= 1u << bit;
+                            if (bit < 8)
+                                effect->bits_off |= 1u << bit;
                         }
                     } else if (NuStrICmp(parser->word_buf, "effect_end") == 0) {
                         ++charconfig.effect_count;
@@ -1099,17 +1163,20 @@ static void CC_anim_start(NUFPAR *parser) {
                 }
             }
         } else if (NuStrICmp(parser->word_buf, "anim_end") == 0) {
-            if (animation.action_id == -1) return;
+            if (animation.action_id == -1)
+                return;
             if ((charconfig.flags & 0x20) != 0) {
                 NuStrCpy(charconfig.animation_names[charconfig.animation_count], name);
                 charconfig.character->animations[charconfig.animation_count++] = animation;
                 charconfig.arena->addr += sizeof(animation);
                 return;
             }
-            if (charconfig.character->animations == NULL) return;
+            if (charconfig.character->animations == NULL)
+                return;
             i32 index = 0;
             while (charconfig.character->animations[index].name != NULL &&
-                   NuStrICmp(charconfig.character->animations[index].name, name) != 0) ++index;
+                   NuStrICmp(charconfig.character->animations[index].name, name) != 0)
+                ++index;
             if (index < charconfig.character->field5_0x14 && charconfig.character->animations[index].name != NULL) {
                 CHARACTERANIM_s *existing = &charconfig.character->animations[index];
                 existing->blend_in_time = animation.blend_in_time;
@@ -1270,8 +1337,10 @@ static void CC_cloak_joint2(NUFPAR *parser) {
 
 static void CC_coin_value(NUFPAR *parser) {
     i32 value = NuFParGetInt(parser);
-    if (value < 0) value = 0;
-    if (value > 10000) value = 10000;
+    if (value < 0)
+        value = 0;
+    if (value > 10000)
+        value = 10000;
     charconfig.runtime->field_0xee = static_cast<i16>(value / 10) * 10;
 }
 
@@ -1773,11 +1842,13 @@ static void CC_sfx_hurt(NUFPAR *parser) {
 
 static void CC_sfx_misc(NUFPAR *parser) {
     i32 index = 0;
-    while (index < 6 && charconfig.runtime->sfx_misc[index] != -1) ++index;
+    while (index < 6 && charconfig.runtime->sfx_misc[index] != -1)
+        ++index;
     if (index < 6 && NuFParGetWord(parser) != 0) {
         charconfig.runtime->sfx_misc[index] = static_cast<i16>(GetSfxId(parser->word_buf));
     }
-    if (index + 1 < 6) charconfig.runtime->sfx_misc[index + 1] = -1;
+    if (index + 1 < 6)
+        charconfig.runtime->sfx_misc[index + 1] = -1;
 }
 
 static void CC_sfx_sabre(NUFPAR *parser) {
@@ -1844,30 +1915,54 @@ static void CC_untargetable(NUFPAR *parser) {
 }
 
 static void CC_variant(NUFPAR *parser) {
-    if (NuFParGetWord(parser) == 0) return;
-    if (NuStrICmp(parser->word_buf, "stormtrooper") == 0) charconfig.runtime->field275_0x116 = 1;
-    else if (NuStrICmp(parser->word_buf, "fett") == 0) charconfig.runtime->field275_0x116 = 2;
-    else if (NuStrICmp(parser->word_buf, "macewindu") == 0) charconfig.runtime->field275_0x116 = 3;
-    else if (NuStrICmp(parser->word_buf, "battledroid") == 0) charconfig.runtime->field275_0x116 = 4;
-    else if (NuStrICmp(parser->word_buf, "hoverdroid") == 0) charconfig.runtime->field275_0x116 = 17;
-    else if (NuStrICmp(parser->word_buf, "walker2legs") == 0) charconfig.runtime->field275_0x116 = 15;
-    else if (NuStrICmp(parser->word_buf, "walker4legs") == 0) charconfig.runtime->field275_0x116 = 16;
-    else if (NuStrICmp(parser->word_buf, "wookiee") == 0) charconfig.runtime->field275_0x116 = 5;
-    else if (NuStrICmp(parser->word_buf, "obiwankenobi") == 0) charconfig.runtime->field275_0x116 = 6;
-    else if (NuStrICmp(parser->word_buf, "leia") == 0) charconfig.runtime->field275_0x116 = 7;
-    else if (NuStrICmp(parser->word_buf, "clone") == 0) charconfig.runtime->field275_0x116 = 8;
-    else if (NuStrICmp(parser->word_buf, "rebel") == 0) charconfig.runtime->field275_0x116 = 9;
-    else if (NuStrICmp(parser->word_buf, "tie") == 0) charconfig.runtime->field275_0x116 = 10;
-    else if (NuStrICmp(parser->word_buf, "lando") == 0) charconfig.runtime->field275_0x116 = 11;
-    else if (NuStrICmp(parser->word_buf, "weirdo") == 0) charconfig.runtime->field275_0x116 = 0;
-    else if (NuStrICmp(parser->word_buf, "luke") == 0) charconfig.runtime->field275_0x116 = 12;
-    else if (NuStrICmp(parser->word_buf, "hansolo") == 0) charconfig.runtime->field275_0x116 = 13;
-    else if (NuStrICmp(parser->word_buf, "padme") == 0) charconfig.runtime->field275_0x116 = 14;
-    else if (NuStrICmp(parser->word_buf, "critter") == 0) charconfig.runtime->field275_0x116 = 18;
-    else if (NuStrICmp(parser->word_buf, "naboostarfighter") == 0) charconfig.runtime->field275_0x116 = 19;
-    else if (NuStrICmp(parser->word_buf, "pod") == 0) charconfig.runtime->field275_0x116 = 20;
-    else if (NuStrICmp(parser->word_buf, "republicgunship") == 0) charconfig.runtime->field275_0x116 = 21;
-    else if (NuStrICmp(parser->word_buf, "henchman") == 0) charconfig.runtime->field275_0x116 = 22;
+    if (NuFParGetWord(parser) == 0)
+        return;
+    if (NuStrICmp(parser->word_buf, "stormtrooper") == 0)
+        charconfig.runtime->field275_0x116 = 1;
+    else if (NuStrICmp(parser->word_buf, "fett") == 0)
+        charconfig.runtime->field275_0x116 = 2;
+    else if (NuStrICmp(parser->word_buf, "macewindu") == 0)
+        charconfig.runtime->field275_0x116 = 3;
+    else if (NuStrICmp(parser->word_buf, "battledroid") == 0)
+        charconfig.runtime->field275_0x116 = 4;
+    else if (NuStrICmp(parser->word_buf, "hoverdroid") == 0)
+        charconfig.runtime->field275_0x116 = 17;
+    else if (NuStrICmp(parser->word_buf, "walker2legs") == 0)
+        charconfig.runtime->field275_0x116 = 15;
+    else if (NuStrICmp(parser->word_buf, "walker4legs") == 0)
+        charconfig.runtime->field275_0x116 = 16;
+    else if (NuStrICmp(parser->word_buf, "wookiee") == 0)
+        charconfig.runtime->field275_0x116 = 5;
+    else if (NuStrICmp(parser->word_buf, "obiwankenobi") == 0)
+        charconfig.runtime->field275_0x116 = 6;
+    else if (NuStrICmp(parser->word_buf, "leia") == 0)
+        charconfig.runtime->field275_0x116 = 7;
+    else if (NuStrICmp(parser->word_buf, "clone") == 0)
+        charconfig.runtime->field275_0x116 = 8;
+    else if (NuStrICmp(parser->word_buf, "rebel") == 0)
+        charconfig.runtime->field275_0x116 = 9;
+    else if (NuStrICmp(parser->word_buf, "tie") == 0)
+        charconfig.runtime->field275_0x116 = 10;
+    else if (NuStrICmp(parser->word_buf, "lando") == 0)
+        charconfig.runtime->field275_0x116 = 11;
+    else if (NuStrICmp(parser->word_buf, "weirdo") == 0)
+        charconfig.runtime->field275_0x116 = 0;
+    else if (NuStrICmp(parser->word_buf, "luke") == 0)
+        charconfig.runtime->field275_0x116 = 12;
+    else if (NuStrICmp(parser->word_buf, "hansolo") == 0)
+        charconfig.runtime->field275_0x116 = 13;
+    else if (NuStrICmp(parser->word_buf, "padme") == 0)
+        charconfig.runtime->field275_0x116 = 14;
+    else if (NuStrICmp(parser->word_buf, "critter") == 0)
+        charconfig.runtime->field275_0x116 = 18;
+    else if (NuStrICmp(parser->word_buf, "naboostarfighter") == 0)
+        charconfig.runtime->field275_0x116 = 19;
+    else if (NuStrICmp(parser->word_buf, "pod") == 0)
+        charconfig.runtime->field275_0x116 = 20;
+    else if (NuStrICmp(parser->word_buf, "republicgunship") == 0)
+        charconfig.runtime->field275_0x116 = 21;
+    else if (NuStrICmp(parser->word_buf, "henchman") == 0)
+        charconfig.runtime->field275_0x116 = 22;
 }
 
 static void CC_vehicle(NUFPAR *parser) {

--- a/src/host/harness/window.cpp
+++ b/src/host/harness/window.cpp
@@ -970,14 +970,14 @@ i32 host_run_window(const HostWindowOptions &options) {
                              scripted_action_active.player_context, scripted_action_active.context_animation,
                              scripted_action_active.queued_context_animation, scripted_action_active.animation_current,
                              scripted_action_active.animation_requested, scripted_action_active.animation_flags);
-                    const GAMECHARACTERDATA *weapon_data = static_cast<const GAMECHARACTERDATA *>(
-                        Player[0]->apiobj.character_data->field11_0x24);
+                    const GAMECHARACTERDATA *weapon_data =
+                        static_cast<const GAMECHARACTERDATA *>(Player[0]->apiobj.character_data->field11_0x24);
                     LOG_INFO("scripted weapon: scale=%.3f model=%d joints=(%d,%d,%d,%d) color=%u flags=0x%x "
                              "models-active=(hilt=%u,green=%u,blue=%u)",
                              Player[0]->weapon_scale, weapon_data->weapon_model, weapon_data->weapon_joints[0],
-                             weapon_data->weapon_joints[1], weapon_data->weapon_joints[2], weapon_data->weapon_joints[3],
-                             weapon_data->field_0x117, weapon_data->field_0x94, WORLD->lev_objs[0x11].active,
-                             WORLD->lev_objs[0x67].active, WORLD->lev_objs[0x69].active);
+                             weapon_data->weapon_joints[1], weapon_data->weapon_joints[2],
+                             weapon_data->weapon_joints[3], weapon_data->field_0x117, weapon_data->field_0x94,
+                             WORLD->lev_objs[0x11].active, WORLD->lev_objs[0x67].active, WORLD->lev_objs[0x69].active);
                     scripted_stage = HostScriptedInputStage::action_wait_release;
                     scripted_stage_ticks = elapsed_ticks;
                 } else if (elapsed_ticks >= scripted_stage_ticks + host_scripted_action_entry_timeout_ms) {

--- a/src/legoapi/actions/character/specialmoves.cpp
+++ b/src/legoapi/actions/character/specialmoves.cpp
@@ -22,8 +22,7 @@ i32 LEGOCONTEXT_SPECIALMOVE_ATTACKER = -1;
 i32 LEGOCONTEXT_SPECIALMOVE_VICTIM = -1;
 
 i32 SpecialMove_Check(GameObject_s *attacker, GameObject_s *victim) {
-    if (SpecialMove != NULL &&
-        ((attacker->apiobj.flags_low & 0x80) == 0 || attacker->field_0xda8 <= 0.0f) &&
+    if (SpecialMove != NULL && ((attacker->apiobj.flags_low & 0x80) == 0 || attacker->field_0xda8 <= 0.0f) &&
         LEGOCONTEXT_SPECIALMOVE_ATTACKER != -1 && LEGOCONTEXT_SPECIALMOVE_VICTIM != -1) {
         for (i32 i = 0; i < SpecialMoveCount; ++i) {
             SPECIALMOVE_s *move = &SpecialMove[i];
@@ -36,7 +35,8 @@ i32 SpecialMove_Check(GameObject_s *attacker, GameObject_s *victim) {
                  (move->victim_action_type != -1 && move->victim_action_type == v->field275_0x116)) &&
                 victim->apiobj.character_model->model_data_b[move->victim_animation] != NULL &&
                 ((victim->apiobj.flags_low & 0x80) == 0 ||
-                 (victim->spawn_protection_timer <= 0.0f && (victim->field_0xefe & 0x40) == 0))) return i;
+                 (victim->spawn_protection_timer <= 0.0f && (victim->field_0xefe & 0x40) == 0)))
+                return i;
         }
     }
     return -1;
@@ -46,7 +46,8 @@ void SpecialMove_Cancel(GameObject_s *) {
 }
 
 u32 SpecialMove_GetFlags(i32 index, u32 mask) {
-    if (index == -1) return 0;
+    if (index == -1)
+        return 0;
     u32 flags = SpecialMove[index].flags;
     return mask == 0 ? flags : flags & mask;
 }

--- a/src/legoapi/actions/combat/hits.cpp
+++ b/src/legoapi/actions/combat/hits.cpp
@@ -592,12 +592,14 @@ i16 InsidePolLines(f32 point_x, f32 point_y, f32 point_z, f32 edge_a_x, f32 edge
 }
 
 u16 ObjHitObj_Flags(GameObject_s *object) {
-    if (object == NULL) return 0;
+    if (object == NULL)
+        return 0;
     const bool player = (object->apiobj.flags_low & 0x80) != 0;
     const u16 ordinary = player ? 0x80c : 0x00a;
     const u16 special = player ? 0x824 : 0x022;
     const u16 scripted = player ? 0x804 : 0x002;
-    if ((object->apiobj.field_0x1f4 & 0x10001) != 0) return scripted | 0x10;
+    if ((object->apiobj.field_0x1f4 & 0x10001) != 0)
+        return scripted | 0x10;
     return (object->apiobj.field_0x1f4 & 4) != 0 ? special : ordinary;
 }
 

--- a/src/legoapi/actions/movement/pushblocks.cpp
+++ b/src/legoapi/actions/movement/pushblocks.cpp
@@ -30,7 +30,8 @@ i32 NewBlockAction(GameObject_s *object) {
             actions[count++] = action;
         }
     }
-    if (count == 0) return 0;
+    if (count == 0)
+        return 0;
     i32 action = actions[0];
     if (count != 1) {
         do {

--- a/src/legoapi/ai/game/creature.cpp
+++ b/src/legoapi/ai/game/creature.cpp
@@ -312,9 +312,10 @@ f32 alert_timer;
 f32 alert_time = 10.0f;
 
 void AlertSurroundingCreatures(GameObject_s *object, nuvec_s *position) {
-    if (object != NULL && ((object->apiobj.field_0x1f8 & 0x1001) != 0x1001 ||
-        (object->apiobj.field_0x1f4 & 5) != 0 ||
-        (static_cast<GAMECHARACTERDATA *>(object->apiobj.character_data->field11_0x24)->flags_090 & 0x8000) != 0)) return;
+    if (object != NULL &&
+        ((object->apiobj.field_0x1f8 & 0x1001) != 0x1001 || (object->apiobj.field_0x1f4 & 5) != 0 ||
+         (static_cast<GAMECHARACTERDATA *>(object->apiobj.character_data->field11_0x24)->flags_090 & 0x8000) != 0))
+        return;
     alert_obj = object;
     alert_pos = *position;
     alert_timer = alert_time;

--- a/src/legoapi/ai/game/gameantinode.cpp
+++ b/src/legoapi/ai/game/gameantinode.cpp
@@ -22,7 +22,8 @@ void GameAntinode_UpdateAntiNodeUsingData(GAMEANTINODESYS_s *, GAMEANTINODE_s *,
                                           float, i32) {
 }
 
-GAMEANTINODE_s *GameAntinode_RegisterAntiNodeUsingData(GAMEANTINODESYS_s *, nuvec_s *, u16, GAMEANTINODEDATA_s *, float, i32) {
+GAMEANTINODE_s *GameAntinode_RegisterAntiNodeUsingData(GAMEANTINODESYS_s *, nuvec_s *, u16, GAMEANTINODEDATA_s *, float,
+                                                       i32) {
     return NULL;
 }
 

--- a/src/legoapi/audio/sfx.cpp
+++ b/src/legoapi/audio/sfx.cpp
@@ -243,7 +243,8 @@ extern "C" {
     }
 
     void SetSfxBit_On(i32 sound) {
-        if (sound >= 0) SetSfxBit_OnEx(g_soundInfo[sound].index);
+        if (sound >= 0)
+            SetSfxBit_OnEx(g_soundInfo[sound].index);
     }
 
     void SfxBit(void) {

--- a/src/legoapi/characters/core/characters.cpp
+++ b/src/legoapi/characters/core/characters.cpp
@@ -644,9 +644,12 @@ void SetProtocolDroidInterfaceAction(GameObject_s *) {
 }
 
 void SetProtocolDroidDeactivatedAction(GameObject_s *object) {
-    if (object->field_0xe38 == 3) object->context_animation = 0x42;
-    else if (object->field_0xe38 == 2) object->context_animation = 0x43;
-    else if (object->field_0xe38 == 1) object->context_animation = 0x44;
+    if (object->field_0xe38 == 3)
+        object->context_animation = 0x42;
+    else if (object->field_0xe38 == 2)
+        object->context_animation = 0x43;
+    else if (object->field_0xe38 == 1)
+        object->context_animation = 0x44;
 }
 
 void LoadPerm1() {

--- a/src/legoapi/characters/core/charconfig.cpp
+++ b/src/legoapi/characters/core/charconfig.cpp
@@ -57,8 +57,10 @@ static i32 RedirectTextFile(char *text, char *filename, i32 strip_comments) {
     NUFPAR *parser = NuFParCreateMem("redirect", text, 0xffff);
     if (parser != NULL) {
         while (NuFParGetLine(parser) != 0) {
-            if (strip_comments != 0 && Text_StripComments(parser->line_buf, parser->line_buf, 1) == 0) continue;
-            if (NuFParGetWord(parser) == 0) continue;
+            if (strip_comments != 0 && Text_StripComments(parser->line_buf, parser->line_buf, 1) == 0)
+                continue;
+            if (NuFParGetWord(parser) == 0)
+                continue;
             if (NuStrICmp(parser->word_buf, "txt_file") == 0) {
                 if (result == 0 && NuFParGetWord(parser) != 0 && NuStrLen(parser->word_buf) < 64) {
                     result = 1;
@@ -146,12 +148,14 @@ static i32 CharConfig(i32 character_id, char *directory, char *filename, VARIPTR
     if (parser != NULL) {
         NuFParPushCom2(parser, CharConfig_GetKeywords(), game_keywords);
         while (NuFParGetLine(parser) != 0) {
-            if (NuFParGetWord(parser) != 0) NuFParInterpretWord(parser);
+            if (NuFParGetWord(parser) != 0)
+                NuFParInterpretWord(parser);
         }
         NuFParDestroy(parser);
     }
     character->model_flags |= 1;
-    if ((charconfig.flags & 0xc) == 4) data->field_0x78 = data->turn_rate;
+    if ((charconfig.flags & 0xc) == 4)
+        data->field_0x78 = data->turn_rate;
     if ((charconfig.flags & 0x10) == 0 && (character->model_flags & 0x2000) != 0) {
         data->ai_update_distance_0 = vehicle_timebase_dist[0];
         data->ai_update_distance_1 = vehicle_timebase_dist[1];
@@ -163,7 +167,8 @@ static i32 CharConfig(i32 character_id, char *directory, char *filename, VARIPTR
         data->ai_update_interval_3 = static_cast<u8>(vehicle_timebase_nframes[3]);
     }
     CharConfig_CalculateJumpStats(data->jump_speed, data->gravity, &data->jump_duration, &data->jump_height);
-    CharConfig_CalculateJumpStats(data->second_jump_speed, data->gravity, &data->second_jump_duration, &data->second_jump_height);
+    CharConfig_CalculateJumpStats(data->second_jump_speed, data->gravity, &data->second_jump_duration,
+                                  &data->second_jump_height);
     if ((charconfig.flags & 0x20) != 0) {
         CHARACTERANIM_s *sentinel = &character->animations[charconfig.animation_count];
         character->field5_0x14 = charconfig.animation_count++;
@@ -197,7 +202,8 @@ static i32 CharConfig(i32 character_id, char *directory, char *filename, VARIPTR
             arena->addr += 32;
             for (i32 bit = 0; bit < 32; ++bit) {
                 for (i32 layer = 0; layer < data->layer_count; ++layer) {
-                    if (data->layers[layer].mask_bit == bit) data->layer_lookup[bit] = static_cast<i8>(layer);
+                    if (data->layers[layer].mask_bit == bit)
+                        data->layer_lookup[bit] = static_cast<i8>(layer);
                 }
             }
         }
@@ -215,7 +221,8 @@ void CharConfig_ConfigureAll(i32 permanent, NUFPCOMJMP *game_keywords) {
         pak = NuFilePakLoad("chars\\charstxt.fpk", &cursor, superbuffer_end, 4);
     }
     for (i32 id = 0; id < CHARCOUNT; ++id) {
-        if (permanent == 0 && apicharsys->playermodelids[id] == -1) continue;
+        if (permanent == 0 && apicharsys->playermodelids[id] == -1)
+            continue;
         CHARACTERDATA *character = &CDataList[id];
         char directory[256];
         char filename[256];
@@ -241,13 +248,15 @@ void CharConfig_ConfigureAll(i32 permanent, NUFPCOMJMP *game_keywords) {
         i32 item = NuFilePakGetItem(pak, path);
         void *address;
         i32 size;
-        if (item == 0 || NuFilePakGetItemInfo(pak, item, &address, &size) == 0 || size < 1) continue;
+        if (item == 0 || NuFilePakGetItemInfo(pak, item, &address, &size) == 0 || size < 1)
+            continue;
         char *text = static_cast<char *>(address);
         char saved = text[size];
         text[size] = 0;
         i32 length = Text_StripComments(text, ConfigBuffer, 1);
         text[size] = saved;
-        if (length < 1) continue;
+        if (length < 1)
+            continue;
         i32 redirected = RedirectTextFile(text, filename, 1);
         if (redirected != 0) {
             NuStrCat(filename, ".txt");
@@ -257,19 +266,22 @@ void CharConfig_ConfigureAll(i32 permanent, NUFPCOMJMP *game_keywords) {
             if (item == 0 || NuFilePakGetItemInfo(pak, item, &address, &size) == 0) {
                 redirected = 0;
             } else {
-                if (size < 1) continue;
+                if (size < 1)
+                    continue;
                 text = static_cast<char *>(address);
                 saved = text[size];
                 text[size] = 0;
                 length = Text_StripComments(text, ConfigBuffer, 1);
                 text[size] = saved;
-                if (length < 1) continue;
+                if (length < 1)
+                    continue;
             }
         }
         CharConfig(id, NULL, NULL, &permbuffer_ptr, &permbuffer_end, 1, ConfigBuffer, length, 0, game_keywords);
         if (redirected == 2) {
             item = NuFilePakGetItem(pak, original_path);
-            if (item == 0 || NuFilePakGetItemInfo(pak, item, &address, &size) == 0 || size < 1) continue;
+            if (item == 0 || NuFilePakGetItemInfo(pak, item, &address, &size) == 0 || size < 1)
+                continue;
             text = static_cast<char *>(address);
             saved = text[size];
             text[size] = 0;
@@ -286,7 +298,8 @@ void CharConfig_ConfigureAll(i32 permanent, NUFPCOMJMP *game_keywords) {
 void CharConfig_CalculateJumpStats(float jump_speed, float gravity, float *duration, float *height) {
     f32 ascent_time = 0.0f;
     const f32 downward_speed = 0.0f - jump_speed;
-    if (gravity != 0.0f && downward_speed != 0.0f) ascent_time = downward_speed / gravity;
+    if (gravity != 0.0f && downward_speed != 0.0f)
+        ascent_time = downward_speed / gravity;
     if (duration != NULL) {
         *duration = ascent_time + ascent_time;
     }

--- a/src/legoapi/characters/core/playeritems.cpp
+++ b/src/legoapi/characters/core/playeritems.cpp
@@ -87,7 +87,8 @@ void SlowWeaponIn(GameObject_s *object) {
         if (action != -1 && object->apiobj.character_model->model_data_b[action] != NULL) {
             const f32 end = NuAnimEndFrame(object->apiobj.character_model->model_data_b[action]);
             f32 start = AnimListFrame(object->apiobj.character_model, action, 0);
-            if (start < 1.0f) start = 1.0f;
+            if (start < 1.0f)
+                start = 1.0f;
             if (start >= 1.0f && start < end) {
                 const f32 finish = AnimListFrame(object->apiobj.character_model, action, 1);
                 if (finish > end || finish > start) {
@@ -104,7 +105,8 @@ void SlowWeaponIn(GameObject_s *object) {
 }
 
 void WeaponInCode(GameObject_s *object) {
-    if (LEGOCONTEXT_WEAPONIN == -1 || object->character_context != LEGOCONTEXT_WEAPONIN) return;
+    if (LEGOCONTEXT_WEAPONIN == -1 || object->character_context != LEGOCONTEXT_WEAPONIN)
+        return;
     GAMECHARACTERDATA *data = static_cast<GAMECHARACTERDATA *>(object->apiobj.character_data->field11_0x24);
     if (object->pad_gamepad->input_magnitude > 0.0f && (data->field_0x94 & 0x1000) == 0) {
         if (object->weapon_scale == 1.0f && object->weapon_scale_state != WEAPON_SCALE_RETRACTING) {
@@ -123,12 +125,15 @@ void WeaponInCode(GameObject_s *object) {
     object->context_animation_timer -= FRAMETIME;
     if (object->context_animation_timer <= 0.0f) {
         object->character_context = -1;
-        if (object->weapon_scale != 1.0f) return;
+        if (object->weapon_scale != 1.0f)
+            return;
     } else {
         if (object->weapon_scale != 1.0f || object->weapon_scale_state == WEAPON_SCALE_RETRACTING ||
-            packet.requested_animation != object->context_animation) return;
+            packet.requested_animation != object->context_animation)
+            return;
         const f32 time = packet.blending ? packet.blend_target_time : packet.current_time;
-        if (time < start) return;
+        if (time < start)
+            return;
     }
     const f32 end = AnimListFrame(object->apiobj.character_model, object->context_animation, 1);
     object->weapon_scale_state = WEAPON_SCALE_RETRACTING;
@@ -189,7 +194,8 @@ void SlowWeaponOut(GameObject_s *object) {
         if (action != -1 && object->apiobj.character_model->model_data_b[action] != NULL) {
             const f32 end = NuAnimEndFrame(object->apiobj.character_model->model_data_b[action]);
             f32 start = AnimListFrame(object->apiobj.character_model, action, 0);
-            if (start < 1.0f) start = 1.0f;
+            if (start < 1.0f)
+                start = 1.0f;
             if (start >= 1.0f && start < end) {
                 const f32 finish = AnimListFrame(object->apiobj.character_model, action, 1);
                 if (finish > end || finish > start) {
@@ -213,7 +219,8 @@ void WeaponOutCode(GameObject_s *object) {
         object->weapon_out_timer = 0.0f;
         if ((object->field_0xe22 & GAMEOBJECT_E22_FLAG_WEAPON_ANIMATION) == 0 && object->character_context != 7) {
             i32 action = 17;
-            if (data->field275_0x116 == 0 && (object->apiobj.character_data->model_flags & 0x80) != 0) action = 127;
+            if (data->field275_0x116 == 0 && (object->apiobj.character_data->model_flags & 0x80) != 0)
+                action = 127;
             if (object->weapon_scale_state == WEAPON_SCALE_IDLE && object->apiobj.field_0x27d != 0 &&
                 object->pad_gamepad->input_magnitude == 0.0f &&
                 object->apiobj.character_model->model_data_b[action] != NULL &&
@@ -227,7 +234,8 @@ void WeaponOutCode(GameObject_s *object) {
                (object->field_0xe22 & GAMEOBJECT_E22_FLAG_WEAPON_ANIMATION) != 0 && object->character_context != 6) {
         SlowWeaponIn(object);
     }
-    if (LEGOCONTEXT_WEAPONOUT == -1 || object->character_context != LEGOCONTEXT_WEAPONOUT) return;
+    if (LEGOCONTEXT_WEAPONOUT == -1 || object->character_context != LEGOCONTEXT_WEAPONOUT)
+        return;
     if (object->pad_gamepad->input_magnitude > 0.0f && (data->field_0x94 & 0x1000) == 0) {
         if (object->weapon_scale == 0.0f && object->weapon_scale_state != WEAPON_SCALE_EXTENDING) {
             FastWeaponOut(object, 0);
@@ -245,12 +253,15 @@ void WeaponOutCode(GameObject_s *object) {
     object->context_animation_timer -= FRAMETIME;
     if (object->context_animation_timer <= 0.0f) {
         object->character_context = -1;
-        if (object->weapon_scale != 0.0f) return;
+        if (object->weapon_scale != 0.0f)
+            return;
     } else {
         if (object->weapon_scale != 0.0f || object->weapon_scale_state == WEAPON_SCALE_EXTENDING ||
-            packet.requested_animation != object->context_animation) return;
+            packet.requested_animation != object->context_animation)
+            return;
         const f32 time = packet.blending ? packet.blend_target_time : packet.current_time;
-        if (time < start) return;
+        if (time < start)
+            return;
     }
     const f32 end = AnimListFrame(object->apiobj.character_model, object->context_animation, 1);
     object->weapon_scale_state = WEAPON_SCALE_EXTENDING;
@@ -267,9 +278,11 @@ void WeaponOutCode(GameObject_s *object) {
 
 void AutoWeaponOnOff(GameObject_s *object) {
     const i8 context = object->character_context;
-    if (context != -1 && (context == LEGOCONTEXT_WEAPONOUT || context == LEGOCONTEXT_WEAPONIN)) return;
+    if (context != -1 && (context == LEGOCONTEXT_WEAPONOUT || context == LEGOCONTEXT_WEAPONIN))
+        return;
     const i32 index = CurrentAnim(&object->apiobj.anim_packet);
-    if (index == -1) return;
+    if (index == -1)
+        return;
     CHARACTERANIM_s *animation = static_cast<CHARACTERANIM_s *>(object->apiobj.character_model->model_data_a[index]);
     const u32 flags = animation->flags;
     const ANIMPACKET_s &packet = object->apiobj.anim_packet;

--- a/src/legoapi/characters/motion/camera.cpp
+++ b/src/legoapi/characters/motion/camera.cpp
@@ -270,7 +270,8 @@ extern "C" {
     extern NUVEC *CutoffCameraVec;
 
     f32 CameraEmitterDistance(NUVEC *position) {
-        if (CutoffCameraVec != NULL) return NuVecDist(position, CutoffCameraVec, NULL);
+        if (CutoffCameraVec != NULL)
+            return NuVecDist(position, CutoffCameraVec, NULL);
         return 0.0f;
     }
 

--- a/src/legoapi/gizmo/base/GizBuildItObjectInterface.h
+++ b/src/legoapi/gizmo/base/GizBuildItObjectInterface.h
@@ -9,10 +9,16 @@ struct GizBuildItObjectInterface : MechObjectInterface {
     void GetPos(VuVec &, i32) const override;
     f32 GetRadius() const override;
     const char *GetTargetName() const override;
-    i32 GetObjectType() const override { return 6; }
+    i32 GetObjectType() const override {
+        return 6;
+    }
     void TargetedFlash() override;
-    void *GetTgtVoidPtr() override { return buildit; }
-    GIZBUILDIT_s *GetGizBuildit() override { return buildit; }
+    void *GetTgtVoidPtr() override {
+        return buildit;
+    }
+    GIZBUILDIT_s *GetGizBuildit() override {
+        return buildit;
+    }
     virtual ~GizBuildItObjectInterface();
     GIZBUILDIT_s *buildit;
 };

--- a/src/legoapi/gizmo/gizmos/gizmos_gizbuildits.cpp
+++ b/src/legoapi/gizmo/gizmos/gizmos_gizbuildits.cpp
@@ -147,7 +147,8 @@ void GizBuildIt_AnyReacting(WORLDINFO_s *) {
 
 GIZBUILDIT_s *GizBuildIt_FindNearest(WORLDINFO_s *world, GameObject_s *player, BUILDIT_FIND_ENUM mode, i32 shadow) {
     GIZBUILDITSYS_s *system = world->giz_buildit_sys;
-    if (system == NULL || player == NULL) return NULL;
+    if (system == NULL || player == NULL)
+        return NULL;
     NUVEC position = player->apiobj.collision_position;
     const f32 bottom = player->apiobj.lower_position.y;
     const f32 top = player->apiobj.upper_position.y;
@@ -158,19 +159,24 @@ GIZBUILDIT_s *GizBuildIt_FindNearest(WORLDINFO_s *world, GameObject_s *player, B
         if (mode != BUILDIT_FIND_ANY) {
             if ((buildit->availability_flags & GIZBUILDIT_AVAILABILITY_VISIBLE) == 0 ||
                 (buildit->availability_flags & GIZBUILDIT_AVAILABILITY_ACTIVE) == 0 ||
-                ((buildit->state_flags & 0x80) != 0 && shadow == 0)) continue;
+                ((buildit->state_flags & 0x80) != 0 && shadow == 0))
+                continue;
             if (mode == BUILDIT_FIND_AVAILABLE) {
-                if (buildit->build_state != 0 || LEGOCONTEXT_BUILDIT == -1) continue;
+                if (buildit->build_state != 0 || LEGOCONTEXT_BUILDIT == -1)
+                    continue;
                 i32 occupied = 0;
                 for (i32 p = 0; p < 8; ++p) {
                     if (Player[p] != NULL && Player[p]->build_context == LEGOCONTEXT_BUILDIT &&
-                        Player[p]->field_0x788 == buildit) occupied = 1;
+                        Player[p]->field_0x788 == buildit)
+                        occupied = 1;
                 }
-                if (occupied != 0) continue;
+                if (occupied != 0)
+                    continue;
             }
         }
         const f32 height = static_cast<f32>(static_cast<u32>(buildit->progress)) / 100.0f * buildit->bounds_radius;
-        if (top < buildit->start_position.y - height || buildit->start_position.y + height < bottom) continue;
+        if (top < buildit->start_position.y - height || buildit->start_position.y + height < bottom)
+            continue;
         const f32 radius = buildit->bounds_radius + 0.3f;
         const f32 distance = NuVecXZDistSqr(&buildit->start_position, &position, NULL);
         if (distance < radius * radius && distance < nearest_distance) {
@@ -200,7 +206,8 @@ void SetHeadTarget(GameObject_s *, NUVEC *, i8, f32, f32, f32);
 void GizBuildIt_SetHeadTarget(GIZBUILDIT_s *buildit, GameObject_s *player) {
     if (buildit->anim_object_count != 0) {
         u32 index = buildit->built_object_count;
-        if (buildit->anim_object_count <= index) index = buildit->anim_object_count - 1;
+        if (buildit->anim_object_count <= index)
+            index = buildit->anim_object_count - 1;
         GIZBUILDITANIMDATA_s *data = static_cast<GIZBUILDITANIMDATA_s *>(buildit->anim_objects[index]->object_data);
         SetHeadTarget(player, reinterpret_cast<NUVEC *>(&data->start_mtx.m30), 0, 2.0f, 1.0f, 2.0f);
     }
@@ -213,11 +220,13 @@ void GizBuildItPushAwayFromStart(GameObject_s *, GIZBUILDIT_s *) {
 }
 
 void GIZBUILDIT_s::ClearMechObjectInterface() {
-    if (mech_object_interface != NULL) delete mech_object_interface;
+    if (mech_object_interface != NULL)
+        delete mech_object_interface;
 }
 
 MechObjectInterface *GIZBUILDIT_s::GetMechObjectInterface() {
-    if (mech_object_interface != NULL) return mech_object_interface;
+    if (mech_object_interface != NULL)
+        return mech_object_interface;
     new GizBuildItObjectInterface(*this);
     return mech_object_interface;
 }

--- a/src/legoapi/gizmo/gizmos/gizmos_gizobstacles.cpp
+++ b/src/legoapi/gizmo/gizmos/gizmos_gizobstacles.cpp
@@ -160,8 +160,8 @@ i32 GizObstacle_CheckExcludeFlagsFn_LSW(GIZOBSTACLE_s *obstacle, GameObject_s *o
 void GizObstacle_EvalAveragePosAndRadius(GIZOBSTACLE_s *obstacle, i32 state) {
     obstacle->field_0x58 = 1.0f;
     obstacle->evaluated_position = obstacle->position;
-    GameAnimSet_GetCentreAndRadius(obstacle->anim_set, &obstacle->evaluated_position, &obstacle->field_0x58,
-                                    state, 1, 1);
+    GameAnimSet_GetCentreAndRadius(obstacle->anim_set, &obstacle->evaluated_position, &obstacle->field_0x58, state, 1,
+                                   1);
 }
 
 void GIZOBSTACLE_s::ClearMechObjectInterface() {

--- a/src/legoapi/gizmo/gizmos/gizmos_newblowup.cpp
+++ b/src/legoapi/gizmo/gizmos/gizmos_newblowup.cpp
@@ -17,11 +17,12 @@ i32 GizmoBlowupBlowup(GIZMOBLOWUP_s *, i32, i32, i32, GameObject_s *, i32);
 void Bolt_AddDeflectedBolt(BOLT_s *, NUVEC *, NUVEC *, u8 *);
 void NewRumble(nupad_s *, f32, i32);
 
-GIZMOBLOWUP_s *GizmoBlowUp_Hit(GameObject_s *object, NUVEC *points, i32 point_count, f32 radius,
-                              NUVEC *minimum, NUVEC *maximum, BOLT_s *bolt, u32 hit_type, u8 *flags) {
+GIZMOBLOWUP_s *GizmoBlowUp_Hit(GameObject_s *object, NUVEC *points, i32 point_count, f32 radius, NUVEC *minimum,
+                               NUVEC *maximum, BOLT_s *bolt, u32 hit_type, u8 *flags) {
     const u32 exclude_flag_1 = EXBLOWUPFLAGS & 1;
     const u32 exclude_flag_2 = EXBLOWUPFLAGS & 2;
-    const bool airborne_damage = object != NULL &&
+    const bool airborne_damage =
+        object != NULL &&
         static_cast<GAMECHARACTERDATA *>(object->apiobj.character_data->field11_0x24)->field_0x28 > 0.0f;
     GIZMOBLOWUP_s *nearest = NULL;
     f32 nearest_distance = 1000000.0f;
@@ -35,27 +36,25 @@ GIZMOBLOWUP_s *GizmoBlowUp_Hit(GameObject_s *object, NUVEC *points, i32 point_co
             (exclude_flag_1 && (properties & 0x80000) && airborne_damage)) {
             continue;
         }
-        if (exclude_flag_2 && (properties & 0x200000) && hit_type - 8 < 2 &&
-            BlowupExFunc != NULL && BlowupExFunc(blowup, hit_type)) {
+        if (exclude_flag_2 && (properties & 0x200000) && hit_type - 8 < 2 && BlowupExFunc != NULL &&
+            BlowupExFunc(blowup, hit_type)) {
             continue;
         }
         if (bolt != NULL && (blowup->platform_id != -1 || (properties & 0x8000) == 0 ||
-            ((properties & 0x80000) && (object == NULL || object->field_0xcc0 == NULL)))) {
+                             ((properties & 0x80000) && (object == NULL || object->field_0xcc0 == NULL)))) {
             continue;
         }
         if (hit_type == 0 && (properties & 0x10000) == 0) {
             continue;
         }
-        if ((hit_type == 3 && (properties & 0x200000)) ||
-            ((properties & 0x20) && ShadowMode == 0) ||
+        if ((hit_type == 3 && (properties & 0x200000)) || ((properties & 0x20) && ShadowMode == 0) ||
             ((properties & 0x40) != 0) != (hit_type == 7)) {
             continue;
         }
         const NUVEC &center = blowup->mid_position;
         const f32 extent = blowup->target_scale;
-        if (!(center.x - extent <= maximum->x && minimum->x <= center.x + extent &&
-              center.z - extent <= maximum->z && minimum->z <= center.z + extent &&
-              center.y - extent <= maximum->y && minimum->y <= center.y + extent)) {
+        if (!(center.x - extent <= maximum->x && minimum->x <= center.x + extent && center.z - extent <= maximum->z &&
+              minimum->z <= center.z + extent && center.y - extent <= maximum->y && minimum->y <= center.y + extent)) {
             continue;
         }
         for (i32 point = point_count - 1; point >= 0; --point) {
@@ -115,8 +114,8 @@ f32 GizmoBlowUpOpponent_Range2;
 i32 GizmoBlowUpOpponent_Behind;
 extern i16 LEGOACT_PUNCH_BEHIND;
 
-GIZMOBLOWUP_s *GizmoBlowUpOpponent(GameObject_s *object, f32 range, f32 extra_radius,
-                                  f32 minimum_radius, i32 mode, u32 mask, u32 value, u32 secondary_mask) {
+GIZMOBLOWUP_s *GizmoBlowUpOpponent(GameObject_s *object, f32 range, f32 extra_radius, f32 minimum_radius, i32 mode,
+                                   u32 mask, u32 value, u32 secondary_mask) {
     if (forceNextAttackOpponent != NULL && (object->apiobj.flags_low & 0x80) != 0) {
         return forceNextAttackOpponent->GetGizBlowup();
     }
@@ -131,22 +130,29 @@ GIZMOBLOWUP_s *GizmoBlowUpOpponent(GameObject_s *object, f32 range, f32 extra_ra
             if ((target->status_flags & 0x80c001) != 0x80c000 ||
                 ((object->apiobj.flags_low & 0x80) != 0 && target->platform_id != -1 &&
                  target->platform_id == object->apiobj.supporting_platform_id) ||
-                ((flags & 0x20) != 0 && ShadowMode == 0)) continue;
-            if (mask != 0 && (value == 0 ? (flags & mask) == 0 : (flags & mask) != value)) continue;
-            if (secondary_mask != 0 && (target->secondary_flags & secondary_mask) == 0) continue;
-            if (mode == 4 && (flags & 0x80) == 0) continue;
+                ((flags & 0x20) != 0 && ShadowMode == 0))
+                continue;
+            if (mask != 0 && (value == 0 ? (flags & mask) == 0 : (flags & mask) != value))
+                continue;
+            if (secondary_mask != 0 && (target->secondary_flags & secondary_mask) == 0)
+                continue;
+            if (mode == 4 && (flags & 0x80) == 0)
+                continue;
             NUVEC delta;
             f32 distance;
             if (mode == 5) {
                 f32 bottom = object->apiobj.collision_min.y;
                 f32 top = object->apiobj.collision_max.y;
-                if ((top - bottom) * 1.5f + top < target->bounds_min.y || target->bounds_max.y < bottom) continue;
+                if ((top - bottom) * 1.5f + top < target->bounds_min.y || target->bounds_max.y < bottom)
+                    continue;
                 distance = NuVecXZDistSqr(&object->apiobj.collision_position, &target->mid_position, &delta);
             } else {
-                if (target->bounds_min.y > object->apiobj.collision_max.y) continue;
+                if (target->bounds_min.y > object->apiobj.collision_max.y)
+                    continue;
                 distance = NuVecDistSqr(&object->apiobj.collision_position, &target->mid_position, &delta);
             }
-            if (distance >= nearest_distance) continue;
+            if (distance >= nearest_distance)
+                continue;
             if (mode == 2) {
                 GizmoBlowUpOpponent_Behind = 0;
                 nearest = target;
@@ -156,17 +162,20 @@ GIZMOBLOWUP_s *GizmoBlowUpOpponent(GameObject_s *object, f32 range, f32 extra_ra
             if (extra_radius > 0.0f) {
                 f32 radius = object->apiobj.field_0x1dc + target->target_scale;
                 f32 maximum = radius + extra_radius;
-                if (distance >= maximum * maximum) continue;
+                if (distance >= maximum * maximum)
+                    continue;
                 if (minimum_radius > 0.0f) {
                     f32 minimum = radius + minimum_radius;
-                    if (distance < minimum * minimum) continue;
+                    if (distance < minimum * minimum)
+                        continue;
                 }
             }
             NuVecRotateY(&delta, &delta, -object->apiobj.movement_facing_angle);
             i32 behind = 0;
             if (delta.z >= 0.0f) {
                 if (mode != 4 || LEGOACT_PUNCH_BEHIND == -1 ||
-                    object->apiobj.character_model->model_data_b[LEGOACT_PUNCH_BEHIND] == NULL) continue;
+                    object->apiobj.character_model->model_data_b[LEGOACT_PUNCH_BEHIND] == NULL)
+                    continue;
                 behind = 1;
             }
             nearest = target;

--- a/src/legoapi/gizmo/object/gizbuildit.cpp
+++ b/src/legoapi/gizmo/object/gizbuildit.cpp
@@ -43,16 +43,24 @@ void GizBuildItPushAwayFromStart(GameObject_s *, GIZBUILDIT_s *);
 void GizBuildItPushAwayFromEnd(GameObject_s *);
 
 void BuildIt_MoveCode(GameObject_s *player) {
-    if (LEGOCONTEXT_BUILDIT == -1) return;
-    if ((player->apiobj.character_data->model_flags & 0x2010) != 0) return;
+    if (LEGOCONTEXT_BUILDIT == -1)
+        return;
+    if ((player->apiobj.character_data->model_flags & 0x2010) != 0)
+        return;
     if (player->build_context != LEGOCONTEXT_BUILDIT) {
-        if (LEGOACT_BUILD == -1 || player->apiobj.character_model->model_data_b[LEGOACT_BUILD] == NULL) return;
-        if (AnimPlaying(&player->apiobj.anim_packet, LEGOACT_BUILD, 1, 1) != NULL) return;
-        if (player->apiobj.field_0x27d == 0) return;
-        if (ObjLandReady(player) == 0 && objInNetWaitContext(player, LEGOCONTEXT_BUILDIT) == 0) return;
-        if (player->touch_task != NULL && player->touch_task->GetHashId().value != MechTouchTaskBuildIt::HashId.value) return;
+        if (LEGOACT_BUILD == -1 || player->apiobj.character_model->model_data_b[LEGOACT_BUILD] == NULL)
+            return;
+        if (AnimPlaying(&player->apiobj.anim_packet, LEGOACT_BUILD, 1, 1) != NULL)
+            return;
+        if (player->apiobj.field_0x27d == 0)
+            return;
+        if (ObjLandReady(player) == 0 && objInNetWaitContext(player, LEGOCONTEXT_BUILDIT) == 0)
+            return;
+        if (player->touch_task != NULL && player->touch_task->GetHashId().value != MechTouchTaskBuildIt::HashId.value)
+            return;
         GIZBUILDIT_s *buildit = nextBuildit.Get() != NULL ? nextBuildit->GetGizBuildit() : NULL;
-        if (buildit == NULL) buildit = GizBuildIt_FindNearest(WORLD, player, BUILDIT_FIND_AVAILABLE, ShadowMode);
+        if (buildit == NULL)
+            buildit = GizBuildIt_FindNearest(WORLD, player, BUILDIT_FIND_AVAILABLE, ShadowMode);
         if (objInNetWaitContext(player, LEGOCONTEXT_BUILDIT) != 0) {
             player->context_animation_timer -= FRAMETIME;
             if (player->context_animation_timer <= 0.0f) {
@@ -60,7 +68,8 @@ void BuildIt_MoveCode(GameObject_s *player) {
                 player->big_jump_data = NULL;
             }
         }
-        if (buildit == NULL || static_cast<i8>(player->apiobj.flags_low) >= 0) return;
+        if (buildit == NULL || static_cast<i8>(player->apiobj.flags_low) >= 0)
+            return;
         if (player->apiobj.field_0x27d != 0 && (buildit->state_flags & 4) != 0) {
             GizBuildItPushAwayFromStart(player, buildit);
         }
@@ -69,7 +78,8 @@ void BuildIt_MoveCode(GameObject_s *player) {
         if ((player->pad_gamepad->buttons_pressed & GAMEPAD_SPECIAL) != 0 ||
             (objInNetWaitContext(player, LEGOCONTEXT_BUILDIT) != 0 &&
              (player->pad_gamepad->buttons_held & GAMEPAD_SPECIAL) != 0)) {
-            if (GizBuildIt_CanStartBuildingFn != NULL && GizBuildIt_CanStartBuildingFn(buildit, player) == 0) return;
+            if (GizBuildIt_CanStartBuildingFn != NULL && GizBuildIt_CanStartBuildingFn(buildit, player) == 0)
+                return;
             nextBuildit.Reset();
             player->context_animation_timer = 0.4f;
             player->field_0x788 = buildit;
@@ -86,9 +96,11 @@ void BuildIt_MoveCode(GameObject_s *player) {
         }
         return;
     }
-    if (BoltSys->stop_targeting != NULL) BoltSys->stop_targeting(player, &player->apiobj.collision_position);
+    if (BoltSys->stop_targeting != NULL)
+        BoltSys->stop_targeting(player, &player->apiobj.collision_position);
     GIZBUILDIT_s *buildit = static_cast<GIZBUILDIT_s *>(player->field_0x788);
-    if (buildit == NULL) return;
+    if (buildit == NULL)
+        return;
     GizBuildIt_SetHeadTarget(buildit, player);
     buildit = static_cast<GIZBUILDIT_s *>(player->field_0x788);
     if ((buildit->state_flags & 0x80) != 0 && ShadowMode == 0) {
@@ -98,7 +110,8 @@ void BuildIt_MoveCode(GameObject_s *player) {
     }
     const i32 animation = player->context_animation;
     if (player->apiobj.character_model->model_data_b[animation] != NULL &&
-        AnimPlaying(&player->apiobj.anim_packet, animation, 1, 0) == NULL) return;
+        AnimPlaying(&player->apiobj.anim_packet, animation, 1, 0) == NULL)
+        return;
     buildit = static_cast<GIZBUILDIT_s *>(player->field_0x788);
     if (buildit->build_state == 0 && (player->pad_gamepad->buttons_held & GAMEPAD_SPECIAL) != 0 &&
         player->context_animation_timer < 0.2f) {

--- a/src/legoapi/gizmo/object/gizforce.cpp
+++ b/src/legoapi/gizmo/object/gizforce.cpp
@@ -28,14 +28,17 @@ void ReleaseForce(GameObject_s *object, i32 mode) {
     } else if (object->character_context == 0x1d) {
         if (object->force_part != NULL) {
             object->force_part->force_player_mask &= ~(1u << (object->apiobj.field_0x27c & 31));
-            if (object->force_part->force_player_mask == 0) object->force_part->force_player_mask = -1;
+            if (object->force_part->force_player_mask == 0)
+                object->force_part->force_player_mask = -1;
             object->force_part->gravity = ForceThrowGravity;
             object->force_part = NULL;
         }
         object->character_context = -1;
     } else if (object->character_context == 8) {
-        if ((object->apiobj.flags_low & 0x80) != 0) GameCam_Blend(GameCam, 1.0f, 0.0f, 1);
-    } else return;
+        if ((object->apiobj.flags_low & 0x80) != 0)
+            GameCam_Blend(GameCam, 1.0f, 0.0f, 1);
+    } else
+        return;
     EndForce(object, mode);
 }
 

--- a/src/legoapi/gizmo/object/gizmoblowups.cpp
+++ b/src/legoapi/gizmo/object/gizmoblowups.cpp
@@ -64,7 +64,8 @@ i32 InitGizmoBlowups(WORLDINFO_s *world) {
 extern "C" void AddFiniteShotDebrisEffect(i32 *, i32, NUVEC *, i32);
 
 void GizBlowup_Respawn(GIZMOBLOWUP_s *blowup) {
-    if (blowup == NULL) return;
+    if (blowup == NULL)
+        return;
     blowup->state_flags |= 0x80;
     blowup->output_flags &= ~1;
     blowup->field_0x9f &= ~1;
@@ -74,7 +75,8 @@ void GizBlowup_Respawn(GIZMOBLOWUP_s *blowup) {
     nuinstanim_s *animation = NuSpecialGetInstAnim(&blowup->type->animated_special);
     if (animation != NULL && animation->playing != 0) {
         blowup->state_flags |= 0x10;
-        if (animation->repeating != 0) blowup->state_flags |= 0x48;
+        if (animation->repeating != 0)
+            blowup->state_flags |= 0x48;
     }
     blowup->state_flags |= 1;
     if (BonusArea != 0 && VehicleArea != 0 && (blowup->draw_flags & 0x1000000) != 0) {
@@ -100,9 +102,11 @@ void GizBlowup_Respawn(GIZMOBLOWUP_s *blowup) {
             (blowup->state_flags & 0x10) != 0) {
             animation->playing = 1;
         }
-        if (animation->playing != 0 && animation->repeating != 0) blowup->state_flags |= 0x48;
+        if (animation->playing != 0 && animation->repeating != 0)
+            blowup->state_flags |= 0x48;
     }
-    if (blowup->platform_id != -1) PlatOnOff(blowup->platform_id, 1);
+    if (blowup->platform_id != -1)
+        PlatOnOff(blowup->platform_id, 1);
     if (blowup->type->particle_types[2] != -1) {
         i32 handle = -1;
         AddFiniteShotDebrisEffect(&handle, blowup->type->particle_types[2], &blowup->mid_position, 1);
@@ -114,9 +118,8 @@ void GizBlowup_Respawn(GIZMOBLOWUP_s *blowup) {
 }
 
 i32 GizmoBlowupBlowup(GIZMOBLOWUP_s *blowup, i32 effects, i32 hit_type, i32 damage, GameObject_s *object,
-                     i32 hit_context) {
-    if (blowup == NULL || (blowup->state_flags & 0x80) == 0 ||
-        ((blowup->draw_flags & 0x20) && ShadowMode == 0) ||
+                      i32 hit_context) {
+    if (blowup == NULL || (blowup->state_flags & 0x80) == 0 || ((blowup->draw_flags & 0x20) && ShadowMode == 0) ||
         !TouchHacks::CanBlowupBeBlownUp(*blowup, hit_type)) {
         return 0;
     }
@@ -139,19 +142,45 @@ i32 GizmoBlowupBlowup(GIZMOBLOWUP_s *blowup, i32 effects, i32 hit_type, i32 dama
         }
     }
     switch (hit_type) {
-    case 1: blowup->output_flags |= 2; break;
-    case 2: blowup->output_flags |= 4; break;
-    case 3: blowup->output_flags |= 8; break;
-    case 4: blowup->output_flags |= 0x20; break;
-    case 5: blowup->output_flags |= 0x10; break;
-    case 6: blowup->output_flags |= 0x40; break;
-    case 7: blowup->output_flags |= 0x80; break;
-    case 8: blowup->visibility_flags |= 1; break;
-    case 9: blowup->visibility_flags |= 2; break;
-    case 10: blowup->visibility_flags |= 4; break;
-    case 11: blowup->visibility_flags |= 8; break;
-    case 12: blowup->visibility_flags |= 0x10; break;
-    case 13: blowup->visibility_flags |= 0x20; break;
+        case 1:
+            blowup->output_flags |= 2;
+            break;
+        case 2:
+            blowup->output_flags |= 4;
+            break;
+        case 3:
+            blowup->output_flags |= 8;
+            break;
+        case 4:
+            blowup->output_flags |= 0x20;
+            break;
+        case 5:
+            blowup->output_flags |= 0x10;
+            break;
+        case 6:
+            blowup->output_flags |= 0x40;
+            break;
+        case 7:
+            blowup->output_flags |= 0x80;
+            break;
+        case 8:
+            blowup->visibility_flags |= 1;
+            break;
+        case 9:
+            blowup->visibility_flags |= 2;
+            break;
+        case 10:
+            blowup->visibility_flags |= 4;
+            break;
+        case 11:
+            blowup->visibility_flags |= 8;
+            break;
+        case 12:
+            blowup->visibility_flags |= 0x10;
+            break;
+        case 13:
+            blowup->visibility_flags |= 0x20;
+            break;
     }
     const i32 has_burst = NuSpecialExistsFn(&type->burst_special);
     if (has_burst) {
@@ -279,7 +308,8 @@ void GizBlowup_InitTerrain() {
             GIZMOBLOWUP_s *blowup = &WORLD->gizmo_blowups[i];
             blowup->platform_id = -1;
             blowup->field_0x10c = -1;
-            if ((blowup->draw_flags & 4) != 0) GizBlowup_InitSingleTerrain(blowup);
+            if ((blowup->draw_flags & 4) != 0)
+                GizBlowup_InitSingleTerrain(blowup);
         }
     }
 }
@@ -428,7 +458,8 @@ void GizmoBlowupGenShadowMatrix(GIZMOBLOWUP_s *, numtx_s *) {
 }
 
 i32 GizBlowup_InitSingleTerrain(GIZMOBLOWUP_s *blowup) {
-    if (blowup == NULL || (blowup->output_flags & 1) != 0 || (blowup->draw_flags & 4) == 0) return 0;
+    if (blowup == NULL || (blowup->output_flags & 1) != 0 || (blowup->draw_flags & 4) == 0)
+        return 0;
     if (blowup->platform_id == -1) {
         i32 instance = NuSpecialGetInstanceix(&blowup->type->animated_special);
         if (blowup->override_special != NULL && NuSpecialExistsFn(blowup->override_special)) {
@@ -439,21 +470,26 @@ i32 GizBlowup_InitSingleTerrain(GIZMOBLOWUP_s *blowup) {
         } else {
             blowup->platform_id = FindPlatInst(instance);
         }
-        if (blowup->platform_id == -1) return 0;
-        if ((blowup->visibility_flags & 0x40) == 0) PlatOnOff(blowup->platform_id, 0);
+        if (blowup->platform_id == -1)
+            return 0;
+        if ((blowup->visibility_flags & 0x40) == 0)
+            PlatOnOff(blowup->platform_id, 0);
     }
     PlatInstRotate(blowup->platform_id, 1);
     if (blowup->field_0x10c == -1 && NuSpecialExistsFn(&blowup->type->burst_special)) {
         blowup->field_0x10c = NewPlatInst(blowup, NuSpecialGetInstanceix(&blowup->type->burst_special));
-        if (blowup->field_0x10c == -1) return -1;
+        if (blowup->field_0x10c == -1)
+            return -1;
     }
     PlatInstRotate(blowup->field_0x10c, 1);
     return 1;
 }
 
 void GizBlowup_DeleteSingleTerrain(GIZMOBLOWUP_s *blowup) {
-    if (blowup == NULL) return;
-    if ((blowup->override_special == NULL || !NuSpecialExistsFn(blowup->override_special)) && blowup->platform_id != -1) {
+    if (blowup == NULL)
+        return;
+    if ((blowup->override_special == NULL || !NuSpecialExistsFn(blowup->override_special)) &&
+        blowup->platform_id != -1) {
         DeletePlatinst(blowup->platform_id);
         blowup->platform_id = -1;
     }

--- a/src/legoapi/gizmos/door/zipups.h
+++ b/src/legoapi/gizmos/door/zipups.h
@@ -25,19 +25,19 @@ enum ZIPUP_RUNTIME_FLAGS {
 };
 
 typedef struct ZIPUP_s {
-    char name[16];               // 0x00
-    NUVEC lower_position;        // 0x10
-    NUVEC hook_origin;           // 0x1c
-    NUVEC upper_position;        // 0x28
-    u16 hook_x_rotation;         // 0x34
-    u16 hook_y_rotation;         // 0x36
-    NUVEC hook_position;         // 0x38
-    u8 reserved_0x44[0x18];      // 0x44 .. 0x5c
-    GameObject_s *occupant;      // 0x5c
-    u8 reserved_0x60[2];         // 0x60 .. 0x62
-    u16 direction;               // 0x62
-    u16 facing_angle;            // 0x64
-    u8 reserved_0x66[2];         // 0x66 .. 0x68
+    char name[16];          // 0x00
+    NUVEC lower_position;   // 0x10
+    NUVEC hook_origin;      // 0x1c
+    NUVEC upper_position;   // 0x28
+    u16 hook_x_rotation;    // 0x34
+    u16 hook_y_rotation;    // 0x36
+    NUVEC hook_position;    // 0x38
+    u8 reserved_0x44[0x18]; // 0x44 .. 0x5c
+    GameObject_s *occupant; // 0x5c
+    u8 reserved_0x60[2];    // 0x60 .. 0x62
+    u16 direction;          // 0x62
+    u16 facing_angle;       // 0x64
+    u8 reserved_0x66[2];    // 0x66 .. 0x68
     union {
         u8 flags;
         struct {

--- a/src/legoapi/gizmos/object/newblowup.cpp
+++ b/src/legoapi/gizmos/object/newblowup.cpp
@@ -140,8 +140,8 @@ void GizmoBlowupEarlyUpdate(void *world_ptr, void *, float) {
                 UpdateMidPos(blowup);
             }
             if (animation != NULL) {
-                const f32 end_frame = NuAnimEndFrameOld(
-                    type->animated_special.scene->instance_animation_data[animation->anim_ix]);
+                const f32 end_frame =
+                    NuAnimEndFrameOld(type->animated_special.scene->instance_animation_data[animation->anim_ix]);
                 if ((blowup->state_flags & GIZMOBLOWUP_STATE_REPEAT_ANIMATION) != 0) {
                     if ((type->animation_runtime_flags & GIZMOBLOWUPTYPE_ANIMATION_UPDATED) == 0 &&
                         ((type->animation_flags & GIZMOBLOWUPTYPE_ANIMATION_INCLUDES_INSTANCE_TRANSFORM) != 0 ||
@@ -197,12 +197,12 @@ void GizmoBlowupEarlyUpdate(void *world_ptr, void *, float) {
                 GizmoBlowupBlowup(blowup, 1, -1, 1, NULL, 1);
             }
             if (type->particle_types[7] != -1) {
-                AddVariableShotDebrisEffectTimed1(type->particle_types[7], &blowup->mid_position, 60,
-                                                 FRAMETIME, 0, 0, NULL);
+                AddVariableShotDebrisEffectTimed1(type->particle_types[7], &blowup->mid_position, 60, FRAMETIME, 0, 0,
+                                                  NULL);
             }
             if (type->particle_types[8] != -1) {
-                AddVariableShotDebrisEffectTimed1(type->particle_types[8], &blowup->mid_position, 60,
-                                                 FRAMETIME, 0, 0, NULL);
+                AddVariableShotDebrisEffectTimed1(type->particle_types[8], &blowup->mid_position, 60, FRAMETIME, 0, 0,
+                                                  NULL);
             }
         } else if ((blowup->state_flags & GIZMOBLOWUP_STATE_ACTIVATED) == 0 && animation != NULL &&
                    animation->playing != 0) {

--- a/src/legoapi/items/base/apiobject.cpp
+++ b/src/legoapi/items/base/apiobject.cpp
@@ -101,8 +101,8 @@ extern "C" {
         }
     }
 
-    void StoreLocatorCoordinates(CHARACTERMODEL_s *model, NUMTX *world_matrix, NUMTX *joint_matrices,
-                                 NUVEC *positions, NUMTX *matrices) {
+    void StoreLocatorCoordinates(CHARACTERMODEL_s *model, NUMTX *world_matrix, NUMTX *joint_matrices, NUVEC *positions,
+                                 NUMTX *matrices) {
         if (positions != NULL || matrices != NULL) {
             for (i32 index = 0; index < 16; ++index) {
                 if (model->points_of_interest[index] != NULL) {

--- a/src/legoapi/items/collect/bolt.cpp
+++ b/src/legoapi/items/collect/bolt.cpp
@@ -31,20 +31,23 @@ bool LineIntersectCircle(NUVEC *, NUVEC *, NUVEC *, f32);
 
 BOLT_s *FindIncomingBolt(GameObject_s *object, i32 exclude_players, i32 mark_direct_hit) {
     BOLT_s *nearest = NULL;
-    f32 radius = object->apiobj.field_0x1e0 > object->apiobj.field_0x1dc ?
-                 object->apiobj.field_0x1e0 : object->apiobj.field_0x1dc;
+    f32 radius = object->apiobj.field_0x1e0 > object->apiobj.field_0x1dc ? object->apiobj.field_0x1e0
+                                                                         : object->apiobj.field_0x1dc;
     f32 nearest_distance = 1.0e8f;
     for (i32 i = 0; i < 32; ++i) {
         BOLT_s *bolt = &Bolt[i];
-        if (bolt->active == 0) continue;
+        if (bolt->active == 0)
+            continue;
         GameObject_s *owner = bolt->owner;
         if (exclude_players != 0 && owner != NULL && (owner->apiobj.field_0x1f8 & 0x1001) == 0x1001 &&
-            owner->apiobj.field_0x287 == 0 && owner->apiobj.field_0x27c != -1) continue;
+            owner->apiobj.field_0x287 == 0 && owner->apiobj.field_0x27c != -1)
+            continue;
         f32 time = TouchHacks::TouchControlsActive ? 1.5f : 0.5f;
         f32 distance = NuVecDistSqr(&bolt->position, &object->apiobj.collision_position, NULL);
         if (distance < time * bolt->speed * time * bolt->speed &&
-            LineIntersectSphere(&bolt->position, &bolt->field_0xac, &object->apiobj.collision_position,
-                                radius * radius, NULL) && distance < nearest_distance) {
+            LineIntersectSphere(&bolt->position, &bolt->field_0xac, &object->apiobj.collision_position, radius * radius,
+                                NULL) &&
+            distance < nearest_distance) {
             nearest = bolt;
             nearest_distance = distance;
         }
@@ -52,7 +55,8 @@ BOLT_s *FindIncomingBolt(GameObject_s *object, i32 exclude_players, i32 mark_dir
     if (nearest != NULL && mark_direct_hit != 0) {
         radius = object->apiobj.field_0x1dc * 0.75f;
         if (LineIntersectCircle(&nearest->position, &nearest->field_0xac, &object->apiobj.collision_position,
-                                radius * radius)) object->field_0xe21 |= 0x20;
+                                radius * radius))
+            object->field_0xe21 |= 0x20;
     }
     return nearest;
 }

--- a/src/legoapi/items/collect/bolts.cpp
+++ b/src/legoapi/items/collect/bolts.cpp
@@ -14,10 +14,11 @@ struct quickboltinfo;
 static void Bolt_Debris_Default(BOLT_s *, NUVEC *, i32, NUVEC *, i32);
 static void Bolt_GetShootOrigin_Default(GameObject_s *, NUVEC *);
 static void Bolt_GetShootDirection_Default(GameObject_s *, NUVEC *);
-BOLTTYPE_s GlobalBoltType_Default = {"null", 4.0f, 2.0f, 0.0f, 0.125f, 1.0f, 0.1f,
-    -1, -1, -1, 0, -1, 0, 1, 255, 0, {}, NULL, NULL, 0, -1, -1, {}};
-static BOLTSYS BoltSys_Default = {&GlobalBoltType_Default, 1, NULL, Bolt_Debris_Default,
-    Bolt_GetShootOrigin_Default, Bolt_GetShootDirection_Default, NULL, NULL};
+BOLTTYPE_s GlobalBoltType_Default = {"null", 4.0f, 2.0f, 0.0f, 0.125f, 1.0f, 0.1f, -1, -1, -1, 0, -1,
+                                     0,      1,    255,  0,    {},     NULL, NULL, 0,  -1, -1, {}};
+static BOLTSYS BoltSys_Default = {
+    &GlobalBoltType_Default,        1,    NULL, Bolt_Debris_Default, Bolt_GetShootOrigin_Default,
+    Bolt_GetShootDirection_Default, NULL, NULL};
 BOLTSYS *BoltSys = &BoltSys_Default;
 
 void Bolt_Alloc() {
@@ -40,14 +41,19 @@ void BoltSys_Init(BOLTSYS *system) {
     for (i32 i = 0; i < system->count; ++i) {
         BOLTTYPE_s *type = &system->types[i];
         type->hit_sfx_id = -1;
-        if (type->hit_sfx != NULL) type->hit_sfx_id = GetSfxId(type->hit_sfx);
+        if (type->hit_sfx != NULL)
+            type->hit_sfx_id = GetSfxId(type->hit_sfx);
         type->shoot_sfx_id = -1;
-        if (type->shoot_sfx != NULL) type->shoot_sfx_id = GetSfxId(type->shoot_sfx);
+        if (type->shoot_sfx != NULL)
+            type->shoot_sfx_id = GetSfxId(type->shoot_sfx);
     }
     BoltSys = system;
-    if (system->debris == NULL) system->debris = Bolt_Debris_Default;
-    if (system->shoot_origin == NULL) system->shoot_origin = Bolt_GetShootOrigin_Default;
-    if (system->shoot_direction == NULL) system->shoot_direction = Bolt_GetShootDirection_Default;
+    if (system->debris == NULL)
+        system->debris = Bolt_Debris_Default;
+    if (system->shoot_origin == NULL)
+        system->shoot_origin = Bolt_GetShootOrigin_Default;
+    if (system->shoot_direction == NULL)
+        system->shoot_direction = Bolt_GetShootDirection_Default;
 }
 
 void Bolt_Reflect(nuvec_s *, nuvec_s *, nuvec_s *) {

--- a/src/legoapi/menus/core/text.cpp
+++ b/src/legoapi/menus/core/text.cpp
@@ -787,21 +787,26 @@ void MultilineDump(char const *) {
 void GetMatchLength(unsigned char *, unsigned char *, abi_ulong) {
 }
 i32 MakeLayerList_Name(CHARACTERMODEL_s *model, i16 *output, u32 mask) {
-    if (output == NULL || model == NULL) return 0;
+    if (output == NULL || model == NULL)
+        return 0;
     GAMECHARACTERDATA_s *data = &GCDataList[model->model_id];
     i32 count = 0;
     u32 flag = 1;
     for (i32 bit = 0; bit < 32; ++bit, flag <<= 1) {
-        if ((mask & flag) == 0 || bit >= data->layer_count) continue;
+        if ((mask & flag) == 0 || bit >= data->layer_count)
+            continue;
         i32 layer;
         if (data->layer_lookup == NULL) {
             for (layer = 0; layer < data->layer_count; ++layer) {
-                if (data->layers[layer].mask_bit == bit) break;
+                if (data->layers[layer].mask_bit == bit)
+                    break;
             }
-            if (layer == data->layer_count) continue;
+            if (layer == data->layer_count)
+                continue;
         } else {
             layer = data->layer_lookup[bit];
-            if (layer == -1) continue;
+            if (layer == -1)
+                continue;
         }
         const i16 hierarchy_layer = data->layers[layer].hierarchy_layer_index;
         if (hierarchy_layer != -1) {

--- a/src/legoapi/misc/supportall.cpp
+++ b/src/legoapi/misc/supportall.cpp
@@ -73,10 +73,8 @@ void RndrTexQuad(float, float, float, float, i32, numtl_s *, i32) {
 }
 
 i32 SuperWeirdo(GameObject_s *object) {
-    if ((object->apiobj.flags_low & 0x80) != 0 && (Game.field_0x7c26[1] & 1) != 0 &&
-        CharacterCustomiser != NULL &&
-        (object->id == CharacterCustomiser->character_ids[0] ||
-         object->id == CharacterCustomiser->character_ids[1])) {
+    if ((object->apiobj.flags_low & 0x80) != 0 && (Game.field_0x7c26[1] & 1) != 0 && CharacterCustomiser != NULL &&
+        (object->id == CharacterCustomiser->character_ids[0] || object->id == CharacterCustomiser->character_ids[1])) {
         return 1;
     }
     return 0;

--- a/src/legoapi/misc/utilities.cpp
+++ b/src/legoapi/misc/utilities.cpp
@@ -167,7 +167,8 @@ bool LineIntersectCircle(NUVEC *origin, NUVEC *direction, NUVEC *center, f32 rad
     f32 x = center->x - origin->x;
     f32 z = center->z - origin->z;
     f32 projection = direction->x * x + direction->z * z;
-    if (projection >= 0.0f) return x * x + z * z - projection * projection <= radius_squared;
+    if (projection >= 0.0f)
+        return x * x + z * z - projection * projection <= radius_squared;
     return false;
 }
 
@@ -176,10 +177,13 @@ i32 LineIntersectSphere(NUVEC *origin, NUVEC *direction, NUVEC *center, f32 radi
     f32 y = center->y - origin->y;
     f32 z = center->z - origin->z;
     f32 projection = direction->x * x + direction->y * y + direction->z * z;
-    if (projection < 0.0f) return 0;
+    if (projection < 0.0f)
+        return 0;
     f32 distance = x * x + y * y + z * z - projection * projection;
-    if (radius_squared < distance) return 0;
-    if (distance_squared != NULL) *distance_squared = distance;
+    if (radius_squared < distance)
+        return 0;
+    if (distance_squared != NULL)
+        *distance_squared = distance;
     return 1;
 }
 
@@ -202,7 +206,8 @@ bool SphereSphereOverlap(NUVEC *a, f32 radius_a, NUVEC *b, f32 radius_b) {
 
 void CalcAveragePosAndRad(GIZBUILDIT_s &buildit, VuVec &position, float &radius, bool include_built) {
     u32 first = 0;
-    if (!include_built) first = buildit.built_object_count;
+    if (!include_built)
+        first = buildit.built_object_count;
     position = VuVec(0, 0, 0, 1);
     radius = 0.0f;
     i32 count = 0;
@@ -227,12 +232,15 @@ void CalcAveragePosAndRad(GIZBUILDIT_s &buildit, VuVec &position, float &radius,
             const f32 x = position.x - matrix->m30;
             const f32 z = position.z - matrix->m32;
             const f32 distance = x * x + 0.0f + z * z;
-            if (maximum <= distance) maximum = distance;
+            if (maximum <= distance)
+                maximum = distance;
         }
     }
-    if (maximum > 0.0f) maximum = NuFsqrt(maximum);
+    if (maximum > 0.0f)
+        maximum = NuFsqrt(maximum);
     radius = maximum;
-    if (buildit.radius_scale > 0.0f) radius = maximum * buildit.radius_scale;
+    if (buildit.radius_scale > 0.0f)
+        radius = maximum * buildit.radius_scale;
 }
 
 void LineToPlaneIntersecion(VuVec &, VuVec &, VuVec &, VuVec *) {

--- a/src/legoapi/render/core/render.cpp
+++ b/src/legoapi/render/core/render.cpp
@@ -741,7 +741,8 @@ static NUGSCN *NuReadGraphicsData(VARIPTR *buf, VARIPTR *buf_end, char *path, NU
         u32 animation_texture_count = 0;
         for (i32 i = 0; i < fixed_scene->num_texture_anims; ++i) {
             u32 end = reinterpret_cast<usize>(animations[i].texture_ids) + animations[i].texture_count;
-            if (animation_texture_count < end) animation_texture_count = end;
+            if (animation_texture_count < end)
+                animation_texture_count = end;
         }
         for (u32 i = 0; i < animation_texture_count; ++i) {
             fixed_scene->texture_anim_ids[i] = fixed_scene->texture_ids[fixed_scene->texture_anim_ids[i]];
@@ -864,10 +865,8 @@ void DrawStreaks() {
 void Draw_LOADED() {
 }
 
-void Draw3DObject(WORLDINFO_s *world, i32 object_index, nuvec_s *position,
-                                                           u16 x_rotation, u16 y_rotation, u16 z_rotation,
-                                                           float scale_x, float scale_y, float scale_z,
-                                                           i32 rotate_order) {
+void Draw3DObject(WORLDINFO_s *world, i32 object_index, nuvec_s *position, u16 x_rotation, u16 y_rotation,
+                  u16 z_rotation, float scale_x, float scale_y, float scale_z, i32 rotate_order) {
     if (object_index == -1) {
         return;
     }
@@ -965,10 +964,10 @@ void DrawQuestion(nuvec_s *, float, float) {
 void DrawRectRGBA(float, float, float, float, u32, numtl_s *, i32, float) {
 }
 
-void DrawItem(nuhspecial_s *special, nuvec_s *position, float scale_value,
-                                                       float unused, float y_push, u16 x_rot, u16 y_rot, u16 z_rot);
-static void Shop_DrawCharacter(shopitem_s *item, NUVEC *position, f32 scale_value, f32 ypush,
-                                                         u16 xrot, u16 yrot, u16 zrot);
+void DrawItem(nuhspecial_s *special, nuvec_s *position, float scale_value, float unused, float y_push, u16 x_rot,
+              u16 y_rot, u16 z_rot);
+static void Shop_DrawCharacter(shopitem_s *item, NUVEC *position, f32 scale_value, f32 ypush, u16 xrot, u16 yrot,
+                               u16 zrot);
 
 void DrawSubItems() {
     /* The sub-shelf is laid out as seven positions, with the centre position
@@ -1137,8 +1136,8 @@ void DrawSubItems() {
     }
 }
 
-static void Shop_DrawCharacter(shopitem_s *item, NUVEC *position, f32 scale_value, f32 ypush,
-                                                         u16 xrot, u16 yrot, u16 zrot) {
+static void Shop_DrawCharacter(shopitem_s *item, NUVEC *position, f32 scale_value, f32 ypush, u16 xrot, u16 yrot,
+                               u16 zrot) {
     const bool top_shelf_character = item == &TopShelf[1];
     if (top_shelf_character) {
         const f32 cycle_length = static_cast<f32>(SHOPCHARCOUNT) * 0.2f;
@@ -1688,12 +1687,9 @@ void DrawGameMessages() {
             if (message->update_fn != NULL) {
                 message->update_fn(reinterpret_cast<GAMEMESSAGE_s *>(message));
             }
-            position.x =
-                position.x + (message->target_position.x - position.x) * progress;
-            position.y =
-                position.y + (message->target_position.y - position.y) * progress;
-            position.z =
-                position.z + (message->target_position.z - position.z) * progress;
+            position.x = position.x + (message->target_position.x - position.x) * progress;
+            position.y = position.y + (message->target_position.y - position.y) * progress;
+            position.z = position.z + (message->target_position.z - position.z) * progress;
         }
         if ((message->flags & 0x20) != 0) {
             scale += (message->target_scale - scale) * progress;
@@ -1792,10 +1788,8 @@ void DrawStatusScreen(WORLDINFO_s *) {
 void Draw_LOADCORRUPT() {
 }
 
-void Draw3DObjectAlpha(WORLDINFO_s *world, i32 object_index, nuvec_s *position,
-                                                                u16 x_rotation, u16 y_rotation, u16 z_rotation,
-                                                                float scale_x, float scale_y, float scale_z,
-                                                                i32 rotate_order, float alpha) {
+void Draw3DObjectAlpha(WORLDINFO_s *world, i32 object_index, nuvec_s *position, u16 x_rotation, u16 y_rotation,
+                       u16 z_rotation, float scale_x, float scale_y, float scale_z, i32 rotate_order, float alpha) {
     if (object_index == -1) {
         return;
     }
@@ -2163,10 +2157,12 @@ void DrawGameMessage_Targets(GAMEMESSAGE_s *, nuvec_s *, float) {
 void DrawTorpedoTargetSprite(void *, unsigned char, float) {
 }
 
-i32 DrawPanel3DObjectNoAlpha(float x, float y, float z, float scale_x, float scale_y, float scale_z,
-                            u16 rotate_x, u16 rotate_y, u16 rotate_z, nuhspecial_s *special, i32 rotate_order) {
-    if (special == NULL || NuSpecialExistsFn(special) == 0) return 0;
-    if (scale_y == 0.0f && scale_x == 0.0f && scale_z == 0.0f) return 0;
+i32 DrawPanel3DObjectNoAlpha(float x, float y, float z, float scale_x, float scale_y, float scale_z, u16 rotate_x,
+                             u16 rotate_y, u16 rotate_z, nuhspecial_s *special, i32 rotate_order) {
+    if (special == NULL || NuSpecialExistsFn(special) == 0)
+        return 0;
+    if (scale_y == 0.0f && scale_x == 0.0f && scale_z == 0.0f)
+        return 0;
     NUVEC scale = {scale_x / CameraZoom, scale_y / CameraZoom, scale_z / CameraZoom};
     NUMTX matrix;
     NuMtxSetScale(&matrix, &scale);
@@ -2185,8 +2181,8 @@ void DrawPanel3DObjectMtxNoAlpha(nuhspecial_s *, numtx_s *) {
 void Draw_OK(MENU_s *) {
 }
 
-void DrawItem(nuhspecial_s *special, nuvec_s *position, float scale_value,
-                                                       float, float y_push, u16 x_rot, u16 y_rot, u16 z_rot) {
+void DrawItem(nuhspecial_s *special, nuvec_s *position, float scale_value, float, float y_push, u16 x_rot, u16 y_rot,
+              u16 z_rot) {
     if (position != NULL) {
         if (NuSpecialExistsFn(special) != 0) {
             NUANGVEC rotation = {x_rot, y_rot, z_rot};
@@ -2391,8 +2387,8 @@ static __used__ bool MatrixReflection_CanOverride() {
 static __used__ void DrawStarFighter(starfighter_s *) {
 }
 
-static void DrawWeapon_SetSabreObjects(GameObject_s *object, i32 red, i32 green, i32 blue, i32 purple,
-                                      i32 *models, i32 *hilt) {
+static void DrawWeapon_SetSabreObjects(GameObject_s *object, i32 red, i32 green, i32 blue, i32 purple, i32 *models,
+                                       i32 *hilt) {
     if (red || green || blue || purple) {
         if (object->id == id_DARTHMAUL) {
             *hilt = models[0] = 0x12;
@@ -2487,8 +2483,8 @@ static void DrawWeapons(GameObject_s *object, i32 reflection, f32 weapon_scale) 
                             } else if (color == 1 && object->id == id_GRIEVOUS && (hand == 0 || hand == 3)) {
                                 color = 2;
                             }
-                            DrawWeapon_SetSabreObjects(object, color == 0, color == 1, color == 2, color == 3,
-                                                       models, &hilt);
+                            DrawWeapon_SetSabreObjects(object, color == 0, color == 1, color == 2, color == 3, models,
+                                                       &hilt);
                             sabre = true;
                         }
                     }
@@ -2535,7 +2531,7 @@ static void DrawWeapons(GameObject_s *object, i32 reflection, f32 weapon_scale) 
                 }
                 NuMtxPreScale(&blade_matrix, &scale);
                 const NUMTX saved_matrix = blade_matrix;
-                for (i32 side = 0; ; ++side) {
+                for (i32 side = 0;; ++side) {
                     for (i32 part = 0; part < 4; ++part) {
                         if (models[part] == -1 || (side && models[part] == hilt)) {
                             continue;

--- a/src/legoapi/render/core/rtl.cpp
+++ b/src/legoapi/render/core/rtl.cpp
@@ -223,9 +223,11 @@ extern "C" {
     }
 
     i32 rtlDynamicAlloc(void) {
-        if (rtl_dynamic_pool == NULL) return -1;
+        if (rtl_dynamic_pool == NULL)
+            return -1;
         rtl_s *light = reinterpret_cast<rtl_s *>(NuLstAllocTail(rtl_dynamic_pool));
-        if (light == NULL) return -1;
+        if (light == NULL)
+            return -1;
         light->type = 4;
         NuVecClear(&light->position);
         light->inner_radius = 1.0f;
@@ -259,7 +261,8 @@ extern "C" {
         NuVecRotateX(&light->direction, &light->direction, light->pitch);
         NuVecRotateY(&light->direction, &light->direction, light->yaw);
         light->uid = rtl_uid;
-        if (++rtl_uid == 0) ++rtl_uid;
+        if (++rtl_uid == 0)
+            ++rtl_uid;
         ++rtl_dynamic_cnt;
         return (reinterpret_cast<NULNKHDR *>(light) - 1)->id;
     }
@@ -281,20 +284,26 @@ extern "C" {
     }
 
     bool rtlDynamicEnable(i32 id, i32 enabled) {
-        if (rtl_dynamic_pool == NULL || id < 0 || id >= rtl_dynamic_max) return false;
+        if (rtl_dynamic_pool == NULL || id < 0 || id >= rtl_dynamic_max)
+            return false;
         rtl_s *light = reinterpret_cast<rtl_s *>(NuLstGetByIdx(rtl_dynamic_pool, id));
-        if (light == NULL) return false;
+        if (light == NULL)
+            return false;
         bool previous = (light->flags & 1) == 0;
         light->flags = (light->flags & ~1) | (enabled == 0);
         return previous;
     }
 
     i32 rtlDynamicSetColours(i32 id, NUVEC *colour, NUVEC *secondary) {
-        if (rtl_dynamic_pool == NULL || id < 0 || id >= rtl_dynamic_max) return 0;
+        if (rtl_dynamic_pool == NULL || id < 0 || id >= rtl_dynamic_max)
+            return 0;
         rtl_s *light = reinterpret_cast<rtl_s *>(NuLstGetByIdx(rtl_dynamic_pool, id));
-        if (light == NULL || (colour == NULL && secondary == NULL)) return 0;
-        if (colour != NULL) light->colour = *colour;
-        if (secondary != NULL) light->secondary_colour = *secondary;
+        if (light == NULL || (colour == NULL && secondary == NULL))
+            return 0;
+        if (colour != NULL)
+            light->colour = *colour;
+        if (secondary != NULL)
+            light->secondary_colour = *secondary;
         return 1;
     }
 
@@ -302,27 +311,34 @@ extern "C" {
     }
 
     i32 rtlDynamicSetPos(i32 id, NUVEC *position) {
-        if (rtl_dynamic_pool == NULL || id < 0 || id >= rtl_dynamic_max) return 0;
+        if (rtl_dynamic_pool == NULL || id < 0 || id >= rtl_dynamic_max)
+            return 0;
         rtl_s *light = reinterpret_cast<rtl_s *>(NuLstGetByIdx(rtl_dynamic_pool, id));
-        if (light == NULL || position == NULL) return 0;
+        if (light == NULL || position == NULL)
+            return 0;
         light->position = *position;
         return 1;
     }
 
     i32 rtlDynamicSetRadii(i32 id, f32 inner, f32 outer) {
-        if (rtl_dynamic_pool == NULL || id < 0 || id >= rtl_dynamic_max) return 0;
+        if (rtl_dynamic_pool == NULL || id < 0 || id >= rtl_dynamic_max)
+            return 0;
         rtl_s *light = reinterpret_cast<rtl_s *>(NuLstGetByIdx(rtl_dynamic_pool, id));
-        if (light == NULL) return 0;
+        if (light == NULL)
+            return 0;
         light->inner_radius = inner;
-        if (outer < inner) outer = inner;
+        if (outer < inner)
+            outer = inner;
         light->outer_radius = outer;
         return 1;
     }
 
     i32 rtlDynamicSetType(i32 id, i32 type) {
-        if (rtl_dynamic_pool == NULL || id < 0 || id >= rtl_dynamic_max || type <= 0 || type >= 9) return 0;
+        if (rtl_dynamic_pool == NULL || id < 0 || id >= rtl_dynamic_max || type <= 0 || type >= 9)
+            return 0;
         rtl_s *light = reinterpret_cast<rtl_s *>(NuLstGetByIdx(rtl_dynamic_pool, id));
-        if (light == NULL) return 0;
+        if (light == NULL)
+            return 0;
         light->type = type;
         return 1;
     }

--- a/src/legoapi/render/core/screen.cpp
+++ b/src/legoapi/render/core/screen.cpp
@@ -193,8 +193,7 @@ void HandleStillRender() {
         NuRndrEndScene();
     }
 
-    if (grab_screen_image != 2 && pause_rndr_on != 0 && pause_rt != 0 &&
-        FadeSys.pending_type == FADE_TYPE_NONE) {
+    if (grab_screen_image != 2 && pause_rndr_on != 0 && pause_rt != 0 && FadeSys.pending_type == FADE_TYPE_NONE) {
         DrawStillScreen(clear_screen_onstill);
     }
 

--- a/src/legoapi/render/core/terrain.cpp
+++ b/src/legoapi/render/core/terrain.cpp
@@ -242,7 +242,8 @@ namespace {
         writer->group_shape_count = 0;
     }
 
-    static TERRAIN_SHAPE *TerrainScaleShape(TERRAIN_SHAPE *candidate, const TERRAIN_GROUP &group, TerrainScanWriter *writer) {
+    static TERRAIN_SHAPE *TerrainScaleShape(TERRAIN_SHAPE *candidate, const TERRAIN_GROUP &group,
+                                            TerrainScanWriter *writer) {
         if (TerI->object_scale != 1.0f) {
             TERRAIN_SHAPE *source = candidate;
             candidate = &ScaleTerrain[writer->scaled_shape_count++];
@@ -254,22 +255,19 @@ namespace {
             for (i32 vector_index = 0; vector_index < 3; ++vector_index) {
                 candidate->vectors[vector_index].x = source->vectors[vector_index].x;
                 candidate->vectors[vector_index].y =
-                    (source->vectors[vector_index].y + group.origin.y) * TerI->inverse_object_scale -
-                    group.origin.y;
+                    (source->vectors[vector_index].y + group.origin.y) * TerI->inverse_object_scale - group.origin.y;
                 candidate->vectors[vector_index].z = source->vectors[vector_index].z;
             }
 
             if (source->normals[1].y < 65535.0f) {
                 candidate->vectors[3].x = source->vectors[3].x;
                 candidate->vectors[3].y =
-                    (source->vectors[3].y + group.origin.y) * TerI->inverse_object_scale -
-                    group.origin.y;
+                    (source->vectors[3].y + group.origin.y) * TerI->inverse_object_scale - group.origin.y;
                 candidate->vectors[3].z = source->vectors[3].z;
 
-                const f32 length =
-                    NuFsqrt(source->normals[1].x * source->normals[1].x +
-                            source->normals[1].y * source->normals[1].y * TerI->object_scale_sq +
-                            source->normals[1].z * source->normals[1].z);
+                const f32 length = NuFsqrt(source->normals[1].x * source->normals[1].x +
+                                           source->normals[1].y * source->normals[1].y * TerI->object_scale_sq +
+                                           source->normals[1].z * source->normals[1].z);
                 const f32 inverse_length = length == 0.0f ? 0.0f : 1.0f / length;
                 candidate->normals[1].x = source->normals[1].x * inverse_length;
                 candidate->normals[1].y = source->normals[1].y * TerI->object_scale * inverse_length;
@@ -278,10 +276,9 @@ namespace {
                 candidate->normals[1].y = 65536.0f;
             }
 
-            const f32 length =
-                NuFsqrt(source->normals[0].x * source->normals[0].x +
-                        source->normals[0].y * source->normals[0].y * TerI->object_scale_sq +
-                        source->normals[0].z * source->normals[0].z);
+            const f32 length = NuFsqrt(source->normals[0].x * source->normals[0].x +
+                                       source->normals[0].y * source->normals[0].y * TerI->object_scale_sq +
+                                       source->normals[0].z * source->normals[0].z);
             const f32 inverse_length = length == 0.0f ? 0.0f : 1.0f / length;
             candidate->normals[0].x = source->normals[0].x * inverse_length;
             candidate->normals[0].y = source->normals[0].y * TerI->object_scale * inverse_length;
@@ -290,14 +287,16 @@ namespace {
         return candidate;
     }
 
-    static void TerrainScanPlatformGroup(TerrainScanWriter *writer, const TerrainScanBounds &bounds,
-                                         i32 group_index, i32 terrain_mask, i32 scan_flags, f32 movement_scale) {
+    static void TerrainScanPlatformGroup(TerrainScanWriter *writer, const TerrainScanBounds &bounds, i32 group_index,
+                                         i32 terrain_mask, i32 scan_flags, f32 movement_scale) {
         TERRAIN_GROUP &group = CurTerr->groups[group_index];
         TERRAIN_PLATFORM &platform = CurTerr->platforms[group.scene_index];
-        if (group.chunk_type == -1) return;
+        if (group.chunk_type == -1)
+            return;
         if (platform.scene_transform != NULL) {
             const u8 visible_mask = (platform.flags & TERRAIN_PLATFORM_FLAG_DISPLAY_LIST_BACKED) != 0 ? 2 : 1;
-            if ((*static_cast<u8 *>(platform.scene_transform) & visible_mask) == 0) return;
+            if ((*static_cast<u8 *>(platform.scene_transform) & visible_mask) == 0)
+                return;
         }
         TerrainScanBounds local = bounds;
         NUMTX *matrix = static_cast<NUMTX *>(platform.scene_object);
@@ -305,9 +304,18 @@ namespace {
             const f32 dx = (matrix->m30 - platform.previous_matrix.m30) * movement_scale;
             const f32 dy = (matrix->m31 - platform.previous_matrix.m31) * movement_scale;
             const f32 dz = (matrix->m32 - platform.previous_matrix.m32) * movement_scale;
-            if (dx > 0.0f) local.max_x += dx; else local.min_x += dx;
-            if (dy > 0.0f) local.max_y += dy; else local.min_y += dy;
-            if (dz > 0.0f) local.max_z += dz; else local.min_z += dz;
+            if (dx > 0.0f)
+                local.max_x += dx;
+            else
+                local.min_x += dx;
+            if (dy > 0.0f)
+                local.max_y += dy;
+            else
+                local.min_y += dy;
+            if (dz > 0.0f)
+                local.max_z += dz;
+            else
+                local.min_z += dz;
         }
         local.min_x -= group.origin.x;
         local.max_x -= group.origin.x;
@@ -316,19 +324,22 @@ namespace {
         local.min_z -= group.origin.z;
         local.max_z -= group.origin.z;
         const bool rotating = (platform.flags & TERRAIN_PLATFORM_FLAG_ROTATING) != 0;
-        if (!rotating && !TerrainBoundsOverlap(local, group.bounds_min, group.bounds_max)) return;
+        if (!rotating && !TerrainBoundsOverlap(local, group.bounds_min, group.bounds_max))
+            return;
         TERRAIN_SHAPE_BATCH *batch = static_cast<TERRAIN_SHAPE_BATCH *>(group.data);
         while (batch->marker >= 0) {
             TERRAIN_SHAPE *shapes = reinterpret_cast<TERRAIN_SHAPE *>(batch + 1);
-            if (rotating || (local.max_x >= batch->min_x && batch->max_x > local.min_x &&
-                             local.max_z >= batch->min_z && batch->max_z > local.min_z)) {
+            if (rotating || (local.max_x >= batch->min_x && batch->max_x > local.min_x && local.max_z >= batch->min_z &&
+                             batch->max_z > local.min_z)) {
                 for (i32 i = 0; i < batch->shape_count; ++i) {
                     TERRAIN_SHAPE *shape = &shapes[i];
-                    if (!rotating && !TerrainShapeOverlaps(local, *shape)) continue;
+                    if (!rotating && !TerrainShapeOverlaps(local, *shape))
+                        continue;
                     platinrange = 1;
                     if (reinterpret_cast<u8 *>(writer->cursor) >= writer->limit ||
                         (shape->material[1] != 0 && (shape->material[1] & terrain_mask) == 0) ||
-                        (shape->flags & scan_flags) == 0x40) continue;
+                        (shape->flags & scan_flags) == 0x40)
+                        continue;
                     if (!rotating) {
                         shape = TerrainScaleShape(shape, group, writer);
                     } else {
@@ -347,7 +358,8 @@ namespace {
                             vertices[3].z = shape->vectors[3].z;
                             vertices[3].w = 0.0f;
                             NuVec4MtxTransformVU0(&vertices[3], &vertices[3], matrix);
-                        } else vertices[3] = vertices[2];
+                        } else
+                            vertices[3] = vertices[2];
                         bool above_min_x = false, below_max_x = false;
                         bool above_min_z = false, below_max_z = false;
                         for (i32 v = 0; v < 4; ++v) {
@@ -356,7 +368,8 @@ namespace {
                             above_min_z |= vertices[v].z > local.min_z;
                             below_max_z |= vertices[v].z < local.max_z;
                         }
-                        if (!above_min_x || !below_max_x || !above_min_z || !below_max_z) continue;
+                        if (!above_min_x || !below_max_x || !above_min_z || !below_max_z)
+                            continue;
                         TERRAIN_SHAPE *transformed = &ScaleTerrain[writer->scaled_shape_count++];
                         transformed->material[0] = shape->material[0];
                         transformed->material[1] = shape->material[1];
@@ -368,7 +381,8 @@ namespace {
                                 (vertices[v].y + group.origin.y) * TerI->inverse_object_scale - group.origin.y;
                             transformed->vectors[v].z = vertices[v].z;
                         }
-                        if (!quad) transformed->normals[1].y = 65536.0f;
+                        if (!quad)
+                            transformed->normals[1].y = 65536.0f;
                         for (i32 n = quad ? 1 : 0; n >= 0; --n) {
                             NUVEC a, b;
                             NUVEC *v = transformed->vectors;
@@ -444,22 +458,24 @@ namespace {
         for (TERRAIN_SPATIAL_NODE *node = CurTerr->spatial_nodes; node != NULL;
              node = *reinterpret_cast<TERRAIN_SPATIAL_NODE **>(reinterpret_cast<u8 *>(node) - sizeof(void *))) {
             const u8 mask = node->field_0x02 >> 8;
-            if (mask != 0 && (mask & terrain_mask) == 0) continue;
+            if (mask != 0 && (mask & terrain_mask) == 0)
+                continue;
             for (i32 first = 0; first < node->point_count; first += 16) {
                 NUVEC *points = node->points + first;
                 i32 end = node->point_count;
                 if (points[0].y != 2147483648.0f) {
-                    if (points[1].y < bounds.min_x || points[0].y > bounds.max_x ||
-                        points[3].y < bounds.min_z || points[2].y > bounds.max_z) continue;
+                    if (points[1].y < bounds.min_x || points[0].y > bounds.max_x || points[3].y < bounds.min_z ||
+                        points[2].y > bounds.max_z)
+                        continue;
                     end = MIN(end, first + 16);
                 }
                 for (i32 i = first; i < end; ++i) {
                     NUVEC &a = node->points[i];
                     NUVEC &b = node->points[i + 1];
-                    if ((a.x < bounds.min_x || b.x > bounds.max_x) &&
-                        (b.x < bounds.min_x || a.x > bounds.max_x)) continue;
-                    if ((a.z < bounds.min_z || b.z > bounds.max_z) &&
-                        (b.z < bounds.min_z || a.z > bounds.max_z)) continue;
+                    if ((a.x < bounds.min_x || b.x > bounds.max_x) && (b.x < bounds.min_x || a.x > bounds.max_x))
+                        continue;
+                    if ((a.z < bounds.min_z || b.z > bounds.max_z) && (b.z < bounds.min_z || a.z > bounds.max_z))
+                        continue;
                     if (WallSplCount < 64) {
                         WallSplList[WallSplCount].position = a;
                         WallSplList[WallSplCount + 1].position = b;
@@ -1067,7 +1083,6 @@ void ScanTerrain(i32 scan_type, i32 terrain_mask, i32 scan_flags) {
 
     const TerrainScanBounds bounds = TerrainGetScanBounds(*TerI);
 
-
     for (i32 cell_index = 0; cell_index < CurTerr->used_cell_count; ++cell_index) {
         const TERRAIN_CELL &cell = CurTerr->cells[cell_index];
         if (bounds.max_x < cell.min_x || bounds.max_z < cell.min_z || cell.max_x < bounds.min_x ||
@@ -1134,16 +1149,21 @@ void ScanTerrain(i32 scan_type, i32 terrain_mask, i32 scan_flags) {
         platform_bounds.max_z += 0.05f;
         const i16 *groups = CurTerr->active_platform_groups;
         i32 count = CurTerr->active_platform_count;
-        if (platform_bounds.min_x <= CurTerr->platform_scan_min.x || platform_bounds.max_x >= CurTerr->platform_scan_max.x ||
-            platform_bounds.min_z <= CurTerr->platform_scan_min.z || platform_bounds.max_z >= CurTerr->platform_scan_max.z) {
+        if (platform_bounds.min_x <= CurTerr->platform_scan_min.x ||
+            platform_bounds.max_x >= CurTerr->platform_scan_max.x ||
+            platform_bounds.min_z <= CurTerr->platform_scan_min.z ||
+            platform_bounds.max_z >= CurTerr->platform_scan_max.z) {
             const TERRAIN_CELL &cell = CurTerr->cells[TERRAIN_PLATFORM_CELL];
             groups = CurTerr->group_indices + cell.first_group;
             count = cell.group_count;
         }
         for (i32 i = 0; i < count; ++i) {
             const TERRAIN_GROUP &group = CurTerr->groups[groups[i]];
-            if (group.origin.x - group.radius > platform_bounds.max_x || group.origin.x + group.radius < platform_bounds.min_x ||
-                group.origin.z - group.radius > platform_bounds.max_z || group.origin.z + group.radius < platform_bounds.min_z) continue;
+            if (group.origin.x - group.radius > platform_bounds.max_x ||
+                group.origin.x + group.radius < platform_bounds.min_x ||
+                group.origin.z - group.radius > platform_bounds.max_z ||
+                group.origin.z + group.radius < platform_bounds.min_z)
+                continue;
             TerrainScanPlatformGroup(&writer, platform_bounds, groups[i], terrain_mask, scan_flags, 1.0f);
         }
     }
@@ -1767,12 +1787,14 @@ void ScanWallSplineTerrain(i32, i32 terrain_mask, i32) {
 
 i32 HitWallSpline() {
     i32 hit = 0;
-    if (WallSplCount == 0) return hit;
+    if (WallSplCount == 0)
+        return hit;
     for (i32 i = 0; i < WallSplCount; i += 2) {
         const NUVEC &a = WallSplList[i].position;
         const NUVEC &b = WallSplList[i + 1].position;
         TerrainQuery_s *query = TerI;
-        if (fabsf(query->position.x - a.x) >= 64.0f || fabsf(query->position.z - a.z) >= 64.0f) continue;
+        if (fabsf(query->position.x - a.x) >= 64.0f || fabsf(query->position.z - a.z) >= 64.0f)
+            continue;
         NUVEC normal = {b.z - a.z, 0.0f, a.x - b.x};
         NuVecNorm(&normal, &normal);
         const f32 radius = query->collision_radius;
@@ -1795,8 +1817,8 @@ i32 HitWallSpline() {
             }
             const f32 dx = b.x - a.x;
             const f32 dz = b.z - a.z;
-            if ((x - a.x) * dx + dz * (z - a.z) >= -0.00005f &&
-                -dx * (x - b.x) - (z - b.z) * dz >= -0.00005f && time < query->hit_time) {
+            if ((x - a.x) * dx + dz * (z - a.z) >= -0.00005f && -dx * (x - b.x) - (z - b.z) * dz >= -0.00005f &&
+                time < query->hit_time) {
                 query->shape_adjusted = 4;
                 query->terrain_group_index = -1;
                 query->hit_type = start_distance > 0.0f ? 1 : 0x11;
@@ -1813,7 +1835,8 @@ i32 HitWallSpline() {
         const f32 dz = a.z - pz;
         const f32 reach = radius + 0.005f + query->horizontal_movement_length;
         const f32 distance_sq = dx * dx + dz * dz;
-        if (fabsf(dx) >= 64.0f || fabsf(dz) >= 64.0f || distance_sq >= reach * reach) continue;
+        if (fabsf(dx) >= 64.0f || fabsf(dz) >= 64.0f || distance_sq >= reach * reach)
+            continue;
         NUVEC direction = {mx, 0.0f, mz};
         NuVecNorm(&direction, &direction);
         const f32 along = direction.x * dx + direction.z * dz;
@@ -1821,7 +1844,8 @@ i32 HitWallSpline() {
         bool penetrating = false;
         f32 time = 0.0f;
         if (along < 0.0f) {
-            if (distance_sq > padded_radius * padded_radius) continue;
+            if (distance_sq > padded_radius * padded_radius)
+                continue;
             penetrating = true;
         } else {
             const f32 side_x = a.x - (direction.x * along + px);
@@ -1832,18 +1856,22 @@ i32 HitWallSpline() {
                 const f32 distance = along - NuFsqrt((radius * radius - side_x_sq) - side_z_sq);
                 const f32 movement_sq = mx * mx + mz * mz;
                 if (distance < -0.0005f || movement_sq < distance * distance) {
-                    if (distance_sq > padded_radius * padded_radius) continue;
+                    if (distance_sq > padded_radius * padded_radius)
+                        continue;
                     penetrating = true;
                 } else {
                     const f32 length = NuFsqrt(movement_sq);
-                    if (length != 0.0f && distance != 0.0f) time = MAX(distance / length, 0.0f);
-                    if (time >= query->hit_time) continue;
+                    if (length != 0.0f && distance != 0.0f)
+                        time = MAX(distance / length, 0.0f);
+                    if (time >= query->hit_time)
+                        continue;
                     normal.x = direction.x * distance + px - a.x;
                     normal.z = distance * direction.z + pz - a.z;
                     NuVecNorm(&normal, &normal);
                 }
             } else {
-                if (distance_sq > padded_radius * padded_radius) continue;
+                if (distance_sq > padded_radius * padded_radius)
+                    continue;
                 penetrating = true;
             }
         }
@@ -1865,7 +1893,8 @@ i32 HitWallSpline() {
         hit = 1;
     }
     TerI->unclamped_hit_time = TerI->hit_time;
-    if (TerI->hit_time < 0.0f) TerI->hit_time = 0.0f;
+    if (TerI->hit_time < 0.0f)
+        TerI->hit_time = 0.0f;
     return hit;
 }
 i32 TerrainImpactPlatform(unsigned char *hit_flags) {

--- a/src/legoapi/render/fx/parts.cpp
+++ b/src/legoapi/render/fx/parts.cpp
@@ -287,11 +287,13 @@ extern "C" {
         AddFiniteShotDebrisEffect2(handle, effect, position, NULL, NULL, count);
     }
 
-    void AddFiniteShotDebrisEffect2(i32 *handle, i32 effect, NUVEC *position,
-                                  NUVEC *emitter_momentum, NUVEC *particle_momentum, i32 count) {
-        if (debris_suspended != 0) return;
+    void AddFiniteShotDebrisEffect2(i32 *handle, i32 effect, NUVEC *position, NUVEC *emitter_momentum,
+                                    NUVEC *particle_momentum, i32 count) {
+        if (debris_suspended != 0)
+            return;
         AddDebrisEffect(handle, effect, position->x, position->y, position->z);
-        if (*handle == -1) return;
+        if (*handle == -1)
+            return;
         debkeydatatype_s &key = debkeydata[*handle];
         key.field_1d4 = count;
         const f32 now = debtab[effect]->time_group == 4 ? panelglobaltime : globaltime;
@@ -304,13 +306,16 @@ extern "C" {
         key.cutoff_distance = CameraEmitterDistance(position);
         if (key.process_collision_sound != 0) {
             f32 range = debtab[effect]->sound_range_override;
-            if (range == 0.0f) range = debtab[effect]->sound_range;
-            if (range == 0.0f) range = debtab[effect]->clip_extent;
+            if (range == 0.0f)
+                range = debtab[effect]->sound_range;
+            if (range == 0.0f)
+                range = debtab[effect]->clip_extent;
             f32 volume = 0.0f;
             if (key.cutoff_distance < range) {
                 for (i32 i = 0; i < 4; ++i) {
                     const i32 sound = debtab[effect]->sound_data[i * 3];
-                    if (sound != -1) SetSfxBit_On(sound);
+                    if (sound != -1)
+                        SetSfxBit_On(sound);
                 }
                 volume = (range - key.cutoff_distance) / range;
             }
@@ -352,8 +357,8 @@ extern "C" {
 
     void AddVariableShotDebrisEffect(i32, NUVEC *, i32, i16, i16);
 
-    i32 AddGameDebrisRot(APIDEBRISSYS_s *system, i32 effect, NUVEC *position, i32 count,
-                         i16 z_rotation, i16 y_rotation) {
+    i32 AddGameDebrisRot(APIDEBRISSYS_s *system, i32 effect, NUVEC *position, i32 count, i16 z_rotation,
+                         i16 y_rotation) {
         if (effect < 0 || effect >= system->capacity || system->entries[effect].effect == -1 || count < 1) {
             return 0;
         }
@@ -422,8 +427,8 @@ extern "C" {
         AddVariableShotDebrisEffectMtx(effect, position, count, z_rotation, y_rotation, NULL);
     }
 
-    void AddVariableShotDebrisEffectMtx(i32 effect, NUVEC *position, i32 count, i16 z_rotation,
-                                      i16 y_rotation, NUMTX *particle_orientation) {
+    void AddVariableShotDebrisEffectMtx(i32 effect, NUVEC *position, i32 count, i16 z_rotation, i16 y_rotation,
+                                        NUMTX *particle_orientation) {
         NUMTX orientation;
         NuMtxSetIdentity(&orientation);
         NuMtxRotateZ(&orientation, z_rotation);
@@ -432,35 +437,42 @@ extern "C" {
     }
 
     void AddVariableShotDebrisEffectMtx3(i32 effect, NUVEC *position, NUVEC *momentum, i32 count,
-                                       NUMTX *emitter_orientation, NUMTX *particle_orientation) {
-        if (effect < 0 || debtab[effect] == NULL) return;
+                                         NUMTX *emitter_orientation, NUMTX *particle_orientation) {
+        if (effect < 0 || debtab[effect] == NULL)
+            return;
         i16 priority = 20000;
         switch (debtab[effect]->particle_type) {
-            case 2: priority = static_cast<i16>(40000); break;
-            case 3: priority = 30000; break;
-            case 7: priority = 10000; break;
+            case 2:
+                priority = static_cast<i16>(40000);
+                break;
+            case 3:
+                priority = 30000;
+                break;
+            case 7:
+                priority = 10000;
+                break;
         }
-        AddVariableShotDebrisEffectMtx4(effect, position, momentum, count, emitter_orientation,
-                                       particle_orientation, priority, 0);
+        AddVariableShotDebrisEffectMtx4(effect, position, momentum, count, emitter_orientation, particle_orientation,
+                                        priority, 0);
     }
 
     void AddVariableShotDebrisEffectMtx4(i32 effect, NUVEC *position, NUVEC *momentum, i32 count,
-                                       NUMTX *emitter_orientation, NUMTX *particle_orientation,
-                                       i16 priority, u8 flags) {
+                                         NUMTX *emitter_orientation, NUMTX *particle_orientation, i16 priority,
+                                         u8 flags) {
         AddVariableShotDebrisEffectTimed5(effect, position, momentum, NULL, count * 30, timeincrement,
-                                         emitter_orientation, particle_orientation, priority, flags);
+                                          emitter_orientation, particle_orientation, priority, flags);
     }
 
     void AddVariableShotDebrisEffectTimed3(i32, NUVEC *, NUVEC *, i32, f32, NUMTX *, NUMTX *);
 
-    void AddVariableShotDebrisEffectTimed1(i32 effect, NUVEC *position, i32 count, f32 time,
-                                         i16 z_rotation, i16 y_rotation, NUMTX *particle_orientation) {
+    void AddVariableShotDebrisEffectTimed1(i32 effect, NUVEC *position, i32 count, f32 time, i16 z_rotation,
+                                           i16 y_rotation, NUMTX *particle_orientation) {
         NUMTX orientation;
         NuMtxSetIdentity(&orientation);
         NuMtxRotateZ(&orientation, z_rotation);
         NuMtxRotateY(&orientation, y_rotation);
-        AddVariableShotDebrisEffectTimed3(effect, position, &nuvec_zero, count, time,
-                                         &orientation, particle_orientation);
+        AddVariableShotDebrisEffectTimed3(effect, position, &nuvec_zero, count, time, &orientation,
+                                          particle_orientation);
     }
 
     void AddVariableShotDebrisEffectTimed3(i32 effect_index, NUVEC *position, NUVEC *momentum, i32 count, f32 time,
@@ -853,7 +865,8 @@ PART_s *FindIncomingPart(void *owner, NUVEC *position, f32 radius, u32 flags, f3
     f32 nearest_distance = range > 0.0f ? range : 100.0f;
     for (i32 i = 0; i < MAXPARTS; ++i) {
         PART_s *part = &Part[i];
-        if ((part->active & 1) == 0 || part->owner == owner || (part->flags & flags) != flags) continue;
+        if ((part->active & 1) == 0 || part->owner == owner || (part->flags & flags) != flags)
+            continue;
         if (range <= 0.0f) {
             f32 speed = NuVecMag(&part->velocity);
             if (speed != 0.0f) {
@@ -907,7 +920,8 @@ void PartUpdate_Basketball(PART_s *) {
 PART_s *Part_FindFromHSpecial(nuhspecial_s *special) {
     if (special != NULL) {
         for (i32 i = 0; i < MAXPARTS; ++i) {
-            if ((Part[i].active & 1) != 0 && NuSpecialCompare(&Part[i].special, special)) return &Part[i];
+            if ((Part[i].active & 1) != 0 && NuSpecialCompare(&Part[i].special, special))
+                return &Part[i];
         }
     }
     return NULL;

--- a/src/legoapi/world/levels/episode.cpp
+++ b/src/legoapi/world/levels/episode.cpp
@@ -252,7 +252,8 @@ i32 Episode_CountOpenAreas(i32 episode_index, i32 area_index, AREASAVE_s *saves)
     EpFreePlayBuildUpTotal = EpFreePlayBuildUpCount = 0;
     EpRedBrickTotal = EpRedBrickCount = 0;
     EpGoldBrickTotal = EpGoldBrickCount = 0;
-    if (episode_index == -1) return 0;
+    if (episode_index == -1)
+        return 0;
     if (GOLDBRICKFORSUPERSTORY != 0 && area_index == -1) {
         EpGoldBrickTotal = 1;
         if (Game_EpisodeSave != NULL && (Game_EpisodeSave[episode_index].flags & 0xff) != 0)
@@ -261,28 +262,35 @@ i32 Episode_CountOpenAreas(i32 episode_index, i32 area_index, AREASAVE_s *saves)
     i32 open = 0;
     for (i32 i = 0; i < EDataList[episode_index].area_count; ++i) {
         const i32 id = EDataList[episode_index].area_ids[i];
-        if (id != area_index && area_index != -1) continue;
+        if (id != area_index && area_index != -1)
+            continue;
         AREADATA *area = &ADataList[id];
-        if (area == HUB_ADATA || (area->flags & 0x22) != 0) continue;
+        if (area == HUB_ADATA || (area->flags & 0x22) != 0)
+            continue;
         if ((area->flags & 0x100) != 0) {
             if (GOLDBRICKFORSUPERBONUS != 0) {
                 ++EpGoldBrickTotal;
-                if (saves[i].area_complete != 0) ++EpGoldBrickCount;
+                if (saves[i].area_complete != 0)
+                    ++EpGoldBrickCount;
             }
             continue;
         }
-        if ((area->flags & 4) != 0) continue;
+        if ((area->flags & 4) != 0)
+            continue;
         AREASAVE_s *save = &saves[id];
         ++EpCompleteTotal;
         EpMiniKitTotal += 10;
-        if (save->complete != 0) ++open;
+        if (save->complete != 0)
+            ++open;
         if (save->area_complete != 0) {
             ++EpCompleteCount;
             ++EpGoldBrickCount;
         }
         ++EpGoldBrickTotal;
-        if ((area->flags & 0x10) == 0) continue;
-        if (save->minikit_count != 0) ++EpGoldBrickCount;
+        if ((area->flags & 0x10) == 0)
+            continue;
+        if (save->minikit_count != 0)
+            ++EpGoldBrickCount;
         EpMiniKitCount += save->field_0x5[0];
         if (BOTHTRUEJEDIGOLDBRICKS == 0) {
             ++EpBuildUpTotal;
@@ -306,13 +314,16 @@ i32 Episode_CountOpenAreas(i32 episode_index, i32 area_index, AREASAVE_s *saves)
             }
         }
         ++EpRedBrickTotal;
-        if (save->field_0x5[1] != 0) ++EpRedBrickCount;
+        if (save->field_0x5[1] != 0)
+            ++EpRedBrickCount;
         if (Store_IsPackUnlocked(8)) {
             ++EpCharKitTotal;
-            if (GOLDBRICKFORCHALLENGE != 0) ++EpGoldBrickTotal;
+            if (GOLDBRICKFORCHALLENGE != 0)
+                ++EpGoldBrickTotal;
             if (save->field_0x5[2] != 0) {
                 ++EpCharKitCount;
-                if (GOLDBRICKFORCHALLENGE != 0) ++EpGoldBrickCount;
+                if (GOLDBRICKFORCHALLENGE != 0)
+                    ++EpGoldBrickCount;
             }
         }
     }

--- a/src/nu2api/nu3d/nutexanm.h
+++ b/src/nu2api/nu3d/nutexanm.h
@@ -63,19 +63,27 @@ struct nutexanim_s {
 static_assert(sizeof(void *) != 4 || offsetof(nutexanim_s, next) == 0x00, "texture animation next offset");
 static_assert(sizeof(void *) != 4 || offsetof(nutexanim_s, env) == 0x14, "texture animation environment offset");
 static_assert(sizeof(void *) != 4 || sizeof(nutexanim_s) == 0x20, "texture animation size");
-static_assert(sizeof(void *) != 4 || offsetof(nutexanim_s, program_name) == 0x1c, "texture animation program name offset");
-static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, instruction_index) == 0x04, "texture animation instruction offset");
-static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, loop_depth) == 0x88, "texture animation loop depth offset");
-static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, call_depth) == 0xcc, "texture animation call depth offset");
+static_assert(sizeof(void *) != 4 || offsetof(nutexanim_s, program_name) == 0x1c,
+              "texture animation program name offset");
+static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, instruction_index) == 0x04,
+              "texture animation instruction offset");
+static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, loop_depth) == 0x88,
+              "texture animation loop depth offset");
+static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, call_depth) == 0xcc,
+              "texture animation call depth offset");
 static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, material) == 0xdc, "texture animation material offset");
-static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, texture_ids) == 0xe0, "texture animation texture table offset");
-static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, texture_index) == 0xe4, "texture animation texture index offset");
+static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, texture_ids) == 0xe0,
+              "texture animation texture table offset");
+static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, texture_index) == 0xe4,
+              "texture animation texture index offset");
 static_assert(sizeof(void *) != 4 || offsetof(nutexanimenv_s, flags) == 0xe8, "texture animation flags offset");
 static_assert(sizeof(void *) != 4 || sizeof(nutexanimenv_s) == 0xec, "texture animation environment size");
 static_assert(sizeof(void *) != 4 || offsetof(nutexanimprog_s, on_signal) == 0x28, "texture program on signal offset");
-static_assert(sizeof(void *) != 4 || offsetof(nutexanimprog_s, off_signal) == 0xa8, "texture program off signal offset");
+static_assert(sizeof(void *) != 4 || offsetof(nutexanimprog_s, off_signal) == 0xa8,
+              "texture program off signal offset");
 static_assert(sizeof(void *) != 4 || offsetof(nutexanimprog_s, label_ids) == 0x130, "texture program label IDs offset");
-static_assert(sizeof(void *) != 4 || offsetof(nutexanimprog_s, instructions) == 0x1ba, "texture program instructions offset");
+static_assert(sizeof(void *) != 4 || offsetof(nutexanimprog_s, instructions) == 0x1ba,
+              "texture program instructions offset");
 static_assert(sizeof(void *) != 4 || sizeof(nutexanimprog_s) == 0x1bc, "texture program size");
 #endif
 
@@ -92,7 +100,6 @@ extern nutexanimlist_s *ntal_free;
 
 void NuTexAnimProgInit(nutexanimprog_s *program);
 nutexanimprog_s *NuTexAnimProgParseFile(i32 file, VARIPTR *buffer, VARIPTR end, i32 flags);
-
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/nu2api/nucore/hashedkey.hpp
+++ b/src/nu2api/nucore/hashedkey.hpp
@@ -7,7 +7,9 @@
 struct HashedKey {
     u32 value;
 
-    explicit HashedKey(const char *name = NULL) { Set(name); }
+    explicit HashedKey(const char *name = NULL) {
+        Set(name);
+    }
     void Set(const char *name) {
         if (name == NULL) {
             value = 0;
@@ -16,7 +18,8 @@ struct HashedKey {
         u32 hash = 0x811c9dc5;
         for (; *name != '\0'; ++name) {
             u32 character = static_cast<i8>(*name);
-            if (character - 'a' < 26) character -= 'a' - 'A';
+            if (character - 'a' < 26)
+                character -= 'a' - 'A';
             hash = character ^ hash * 0x1000193;
         }
         value = hash;

--- a/src/nu2api/nucore/nucore_plain.cpp
+++ b/src/nu2api/nucore/nucore_plain.cpp
@@ -382,10 +382,12 @@ extern "C" {
     }
     static void NuCameraBuildClipProjection(NUMTX *projection, NUCAMERA *camera, f32 x_scale, f32 y_scale) {
         f32 far_clip = camera->unknown_64;
-        if (far_clip == 0.0f) far_clip = camera->far_clip;
+        if (far_clip == 0.0f)
+            far_clip = camera->far_clip;
         far_clip -= nucamera_farclip_hack;
         f32 near_clip = camera->unknown_60;
-        if (near_clip == 0.0f) near_clip = camera->near_clip;
+        if (near_clip == 0.0f)
+            near_clip = camera->near_clip;
         const i32 angle = static_cast<i32>(camera->fov * 0.5f * 10430.378f);
         const f32 cotangent = NuTrigTable[(angle + 0x4000) >> 1 & 0x7fff] / NuTrigTable[angle >> 1 & 0x7fff];
         const f32 x = camera->aspect * cotangent * x_scale;
@@ -417,9 +419,12 @@ extern "C" {
     void NuCameraTransformScreenClip(NUVEC *screen, NUVEC *world, i32 count, NUMTX *matrix) {
         NUVEC *end = world + count;
         NUMTX transform;
-        if (matrix == NULL) transform = vpc_vport_mtx;
-        else NuMtxMulH(&transform, matrix, &vpc_vport_mtx);
-        for (; world < end; ++world, ++screen) NuVecMtxTransformH(screen, world, &transform);
+        if (matrix == NULL)
+            transform = vpc_vport_mtx;
+        else
+            NuMtxMulH(&transform, matrix, &vpc_vport_mtx);
+        for (; world < end; ++world, ++screen)
+            NuVecMtxTransformH(screen, world, &transform);
     }
     void NuCameraTransformScreenVU0(void) {
     }

--- a/src/nu2api/nucore/nulst.cpp
+++ b/src/nu2api/nucore/nulst.cpp
@@ -95,7 +95,7 @@ NULSTHDR *NuLstCreateBuff(i32 count, i32 size, VARIPTR *buffer, VARIPTR end, i32
 
 NULNKHDR *NuLstGetByIdx(NULSTHDR *list, i32 index) {
     NULNKHDR *node = reinterpret_cast<NULNKHDR *>(reinterpret_cast<u8 *>(list + 1) +
-        static_cast<i16>(list->element_size_total) * index);
+                                                  static_cast<i16>(list->element_size_total) * index);
     return node->is_used ? node + 1 : NULL;
 }
 

--- a/src/nu2api/nucore/numechptr.hpp
+++ b/src/nu2api/nucore/numechptr.hpp
@@ -5,7 +5,8 @@
 #include <stddef.h>
 
 struct NuMechPtr_ManagedObject {
-    virtual ~NuMechPtr_ManagedObject() {}
+    virtual ~NuMechPtr_ManagedObject() {
+    }
 };
 
 template <class T, i32 Tag> class NuMechPtr {
@@ -13,7 +14,8 @@ template <class T, i32 Tag> class NuMechPtr {
     struct ManagedBase : NuMechPtr_ManagedObject {
         NuMechPtr *managed_links;
 
-        ManagedBase() : managed_links(NULL) {}
+        ManagedBase() : managed_links(NULL) {
+        }
         virtual ~ManagedBase() {
             NuMechPtr *head = managed_links;
             if (head != NULL) {
@@ -32,9 +34,15 @@ template <class T, i32 Tag> class NuMechPtr {
         }
     };
 
-    NuMechPtr(T *value = NULL) : object(NULL), next(NULL), previous(NULL) { Attach(value); }
-    NuMechPtr(const NuMechPtr &other) : object(NULL), next(NULL), previous(NULL) { Attach(other.object); }
-    ~NuMechPtr() { Reset(); }
+    NuMechPtr(T *value = NULL) : object(NULL), next(NULL), previous(NULL) {
+        Attach(value);
+    }
+    NuMechPtr(const NuMechPtr &other) : object(NULL), next(NULL), previous(NULL) {
+        Attach(other.object);
+    }
+    ~NuMechPtr() {
+        Reset();
+    }
 
     NuMechPtr &operator=(const NuMechPtr &other) {
         T *value = other.object;
@@ -42,8 +50,12 @@ template <class T, i32 Tag> class NuMechPtr {
         Attach(value);
         return *this;
     }
-    T *Get() const { return object; }
-    T *operator->() const { return object; }
+    T *Get() const {
+        return object;
+    }
+    T *operator->() const {
+        return object;
+    }
 
     void Reset() {
         if (object != NULL) {
@@ -52,7 +64,8 @@ template <class T, i32 Tag> class NuMechPtr {
             } else {
                 next->previous = previous;
                 previous->next = next;
-                if (object->managed_links == this) object->managed_links = next;
+                if (object->managed_links == this)
+                    object->managed_links = next;
             }
             object = NULL;
             next = NULL;

--- a/src/nu2api/nucore/nutexanim.cpp
+++ b/src/nu2api/nucore/nutexanim.cpp
@@ -35,9 +35,11 @@ extern "C" void NuTexAnimSetSignals(u32 signals) {
 }
 
 static i32 NuTexAnimLabelIndex(char *name, char (*table)[21], i32 *count) {
-    if (strlen(name) > 20) name[20] = '\0';
+    if (strlen(name) > 20)
+        name[20] = '\0';
     for (i32 i = 0; i < *count; ++i) {
-        if (NuStrICmp(table[i], name) == 0) return i;
+        if (NuStrICmp(table[i], name) == 0)
+            return i;
     }
     NuStrCpy(table[(*count)++], name);
     return *count - 1;
@@ -46,7 +48,8 @@ static i32 NuTexAnimLabelIndex(char *name, char (*table)[21], i32 *count) {
 static void pftaRepeat(nufpar_s *parser) {
     i32 value0 = NuFParGetInt(parser);
     i32 value1 = NuFParGetInt(parser);
-    if (value0 == 0) value0 = -1;
+    if (value0 == 0)
+        value0 = -1;
     i16 index = parprog->instruction_count;
     parprog->instructions[index] = 13;
     parprog->instructions[static_cast<i16>(index + 1)] = static_cast<i16>(value0);
@@ -198,8 +201,10 @@ static void pftaRate(nufpar_s *parser) {
     i32 value1 = NuFParGetInt(parser);
     i16 index = parprog->instruction_count;
     parprog->instructions[index] = 7;
-    parprog->instructions[static_cast<i16>(index + 1)] = static_cast<i16>(static_cast<i32>(value0 * (1.0f / 60.0f) * 4096.0f));
-    parprog->instructions[static_cast<i16>(index + 2)] = static_cast<i16>(static_cast<i32>(value1 * (1.0f / 60.0f) * 4096.0f));
+    parprog->instructions[static_cast<i16>(index + 1)] =
+        static_cast<i16>(static_cast<i32>(value0 * (1.0f / 60.0f) * 4096.0f));
+    parprog->instructions[static_cast<i16>(index + 2)] =
+        static_cast<i16>(static_cast<i32>(value1 * (1.0f / 60.0f) * 4096.0f));
     parprog->instruction_count = index + 3;
 }
 
@@ -216,8 +221,10 @@ static void pftaWait(nufpar_s *parser) {
     i32 value1 = NuFParGetInt(parser);
     i16 index = parprog->instruction_count;
     parprog->instructions[index] = 4;
-    parprog->instructions[static_cast<i16>(index + 1)] = static_cast<i16>(static_cast<i32>(value0 * (1.0f / 60.0f) * 4096.0f));
-    parprog->instructions[static_cast<i16>(index + 2)] = static_cast<i16>(static_cast<i32>(value1 * (1.0f / 60.0f) * 4096.0f));
+    parprog->instructions[static_cast<i16>(index + 1)] =
+        static_cast<i16>(static_cast<i32>(value0 * (1.0f / 60.0f) * 4096.0f));
+    parprog->instructions[static_cast<i16>(index + 2)] =
+        static_cast<i16>(static_cast<i32>(value1 * (1.0f / 60.0f) * 4096.0f));
     parprog->instruction_count = index + 3;
 }
 
@@ -265,7 +272,8 @@ static NUFPCOMJMP nutexanimcomtab[] = {
 };
 
 void NuTexAnimProgInit(nutexanimprog_s *program) {
-    if (program == NULL) return;
+    if (program == NULL)
+        return;
     for (i32 i = 0; i < 32; ++i) {
         program->off_signal[i] = -1;
         program->on_signal[i] = -1;
@@ -297,7 +305,8 @@ nutexanimprog_s *NuTexAnimProgParseFile(i32 file, VARIPTR *buffer, VARIPTR, i32)
     labtabcnt = 0;
     memset(labtab, 0, sizeof(labtab));
     NUFPAR *parser = NuFParOpen(file);
-    if (parser == NULL) return NULL;
+    if (parser == NULL)
+        return NULL;
     NuFParPushCom(parser, nutexanimcomtab);
     NuTexAnimProgInit(program);
     parprog = program;
@@ -316,7 +325,8 @@ nutexanimprog_s *NuTexAnimProgParseFile(i32 file, VARIPTR *buffer, VARIPTR, i32)
     NuFParClose(parser);
     NuTexAnimProgAssembleEnd(program);
     program->next = sys_progs;
-    if (sys_progs != NULL) sys_progs->previous = program;
+    if (sys_progs != NULL)
+        sys_progs->previous = program;
     program->previous = NULL;
     sys_progs = program;
     return program;
@@ -328,27 +338,37 @@ void NuTexAnimResetList(nutexanim_s *anim);
 
 static bool TextureCondition(i32 condition, i32 texture, i32 value) {
     switch (condition) {
-    case 0: return texture == value;
-    case 1: return texture < value;
-    case 2: return texture > value;
-    case 3: return texture <= value;
-    case 4: return texture >= value;
-    case 5: return texture != value;
-    default: return false;
+        case 0:
+            return texture == value;
+        case 1:
+            return texture < value;
+        case 2:
+            return texture > value;
+        case 3:
+            return texture <= value;
+        case 4:
+            return texture >= value;
+        case 5:
+            return texture != value;
+        default:
+            return false;
     }
 }
 
 extern "C" void NuTexAnimAddList(nutexanim_s *anim) {
-    if (anim == NULL) return;
+    if (anim == NULL)
+        return;
     NuThreadCriticalSectionBegin(g_texAnimCriticalSection);
     nutexanimlist_s *node = ntal_free;
     if (node != NULL) {
-        if (node->next == NULL) NuSevereWarning("Ran out of texture anim slots!");
+        if (node->next == NULL)
+            NuSevereWarning("Ran out of texture anim slots!");
         ntal_free = node->next;
         node->previous = NULL;
         node->first = anim;
         node->next = ntal_first;
-        if (ntal_first != NULL) ntal_first->previous = node;
+        if (ntal_first != NULL)
+            ntal_first->previous = node;
         ntal_first = node;
     }
     NuThreadCriticalSectionEnd(g_texAnimCriticalSection);
@@ -360,8 +380,7 @@ extern "C" void NuTexAnimCreate(void) {
 extern "C" void NuTexAnimDestroy(void) {
 }
 
-extern "C" nutexanimenv_s *NuTexAnimEnvCreate(VARIPTR *buffer, numtl_s *material, u16 *ids,
-                                             nutexanimprog_s *program) {
+extern "C" nutexanimenv_s *NuTexAnimEnvCreate(VARIPTR *buffer, numtl_s *material, u16 *ids, nutexanimprog_s *program) {
     nutexanimenv_s *env;
     if (buffer == NULL) {
         env = static_cast<nutexanimenv_s *>(NU_ALLOC(sizeof(*env), alignof(nutexanimenv_s), 1, "", 0));
@@ -374,8 +393,10 @@ extern "C" nutexanimenv_s *NuTexAnimEnvCreate(VARIPTR *buffer, numtl_s *material
         env->material = material;
         NuTexAnimEnvReset(env);
         env->texture_ids = ids;
-        if (buffer == NULL) env->flags |= 1;
-        else env->flags &= ~1;
+        if (buffer == NULL)
+            env->flags |= 1;
+        else
+            env->flags &= ~1;
     }
     return env;
 }
@@ -385,7 +406,8 @@ extern "C" void NuTexAnimEnvDestroy(void) {
 
 extern "C" void NuTexAnimEnvProc(nutexanimenv_s *env) {
     nutexanimprog_s *program = env->program;
-    if (program == NULL || (program->mask & nta_script_mask) == 0) return;
+    if (program == NULL || (program->mask & nta_script_mask) == 0)
+        return;
     numtl_s *material = env->material;
     u32 signals = nta_sig_off & program->off_mask;
     if (signals != 0) {
@@ -413,120 +435,132 @@ extern "C" void NuTexAnimEnvProc(nutexanimenv_s *env) {
     }
     if (env->wait_remaining != 0) {
         env->wait_remaining -= nta_iframetime;
-        if (env->wait_remaining > 0) return;
+        if (env->wait_remaining > 0)
+            return;
     }
     for (;;) {
         i16 *instruction = program->instructions + env->instruction_index;
         i32 next_instruction;
         switch (static_cast<u16>(instruction[0])) {
-        case 0:
-            env->texture_index = instruction[1];
-            next_instruction = env->instruction_index + 2;
-            break;
-        case 1:
-            env->texture_index = NuRand(&texanim_rand) % instruction[1];
-            next_instruction = env->instruction_index + 2;
-            break;
-        case 2: {
-            i32 texture = env->texture_index + instruction[1];
-            if (texture < instruction[2]) texture = instruction[2];
-            if (texture > instruction[3]) texture = instruction[3];
-            env->texture_index = texture;
-            next_instruction = env->instruction_index + 4;
-            break;
-        }
-        case 3: {
-            i32 texture = NuRand(&texanim_rand) % (instruction[2] - instruction[1] + 1);
-            texture += instruction[1] + env->texture_index;
-            if (texture < instruction[3]) texture = instruction[3];
-            if (texture > instruction[4]) texture = instruction[4];
-            env->texture_index = texture;
-            next_instruction = env->instruction_index + 5;
-            break;
-        }
-        case 4:
-            env->wait_remaining += instruction[1];
-            if (instruction[2] != 0) env->wait_remaining += NuRand(&texanim_rand) % instruction[2];
-            env->instruction_index += 3;
-            if (env->wait_remaining < 0) env->wait_remaining = 0;
-            return;
-        case 7:
-            env->wait_base = instruction[1];
-            env->wait_random = instruction[2];
-            env->instruction_index += 3;
-            continue;
-        case 9:
-            env->instruction_index = instruction[1];
-            continue;
-        case 10:
-            env->return_stack[env->call_depth++] = env->instruction_index + 2;
-            env->instruction_index = instruction[1];
-            continue;
-        case 11:
-            if (TextureCondition(instruction[1], env->texture_index, instruction[2]))
-                env->instruction_index = instruction[3];
-            else env->instruction_index += 4;
-            continue;
-        case 12:
-            env->instruction_index = env->return_stack[--env->call_depth];
-            continue;
-        case 13:
-            env->loop_counts[env->loop_depth] = instruction[1];
-            if (instruction[2] != 0)
-                env->loop_counts[env->loop_depth] += NuRand(&texanim_rand) % instruction[2];
-            env->instruction_index += 3;
-            env->loop_starts[env->loop_depth++] = env->instruction_index;
-            continue;
-        case 14:
-            if (env->loop_counts[env->loop_depth - 1] == 0) {
-                --env->loop_depth;
-                ++env->instruction_index;
-            } else {
-                env->instruction_index = env->loop_starts[env->loop_depth - 1];
-                --env->loop_counts[env->loop_depth - 1];
+            case 0:
+                env->texture_index = instruction[1];
+                next_instruction = env->instruction_index + 2;
+                break;
+            case 1:
+                env->texture_index = NuRand(&texanim_rand) % instruction[1];
+                next_instruction = env->instruction_index + 2;
+                break;
+            case 2: {
+                i32 texture = env->texture_index + instruction[1];
+                if (texture < instruction[2])
+                    texture = instruction[2];
+                if (texture > instruction[3])
+                    texture = instruction[3];
+                env->texture_index = texture;
+                next_instruction = env->instruction_index + 4;
+                break;
             }
-            continue;
-        case 15:
-            if (TextureCondition(instruction[1], env->texture_index, instruction[2]) ||
-                env->loop_counts[env->loop_depth - 1] == 0) {
-                --env->loop_depth;
+            case 3: {
+                i32 texture = NuRand(&texanim_rand) % (instruction[2] - instruction[1] + 1);
+                texture += instruction[1] + env->texture_index;
+                if (texture < instruction[3])
+                    texture = instruction[3];
+                if (texture > instruction[4])
+                    texture = instruction[4];
+                env->texture_index = texture;
+                next_instruction = env->instruction_index + 5;
+                break;
+            }
+            case 4:
+                env->wait_remaining += instruction[1];
+                if (instruction[2] != 0)
+                    env->wait_remaining += NuRand(&texanim_rand) % instruction[2];
                 env->instruction_index += 3;
-            } else {
-                --env->loop_counts[env->loop_depth - 1];
-                env->instruction_index = env->loop_starts[env->loop_depth - 1];
-            }
-            continue;
-        case 16:
-            if (env->wait_remaining < 0) env->wait_remaining = 0;
-            return;
-        case 17:
-            for (nutexanimlist_s *list = ntal_first; list != NULL; list = list->next) {
-                for (nutexanim_s *anim = list->first; anim != NULL; anim = anim->next) {
-                    nutexanimenv_s *other = anim->env;
-                    if (other == NULL || other == env || other->program == NULL) continue;
-                    for (i32 i = 0; i < other->program->label_count; ++i) {
-                        if (other->program->label_ids[i] == instruction[1]) {
-                            other->instruction_index = other->program->label_offsets[i];
-                            other->wait_remaining = 0;
-                            other->call_depth = 0;
-                            other->loop_depth = 0;
-                            break;
+                if (env->wait_remaining < 0)
+                    env->wait_remaining = 0;
+                return;
+            case 7:
+                env->wait_base = instruction[1];
+                env->wait_random = instruction[2];
+                env->instruction_index += 3;
+                continue;
+            case 9:
+                env->instruction_index = instruction[1];
+                continue;
+            case 10:
+                env->return_stack[env->call_depth++] = env->instruction_index + 2;
+                env->instruction_index = instruction[1];
+                continue;
+            case 11:
+                if (TextureCondition(instruction[1], env->texture_index, instruction[2]))
+                    env->instruction_index = instruction[3];
+                else
+                    env->instruction_index += 4;
+                continue;
+            case 12:
+                env->instruction_index = env->return_stack[--env->call_depth];
+                continue;
+            case 13:
+                env->loop_counts[env->loop_depth] = instruction[1];
+                if (instruction[2] != 0)
+                    env->loop_counts[env->loop_depth] += NuRand(&texanim_rand) % instruction[2];
+                env->instruction_index += 3;
+                env->loop_starts[env->loop_depth++] = env->instruction_index;
+                continue;
+            case 14:
+                if (env->loop_counts[env->loop_depth - 1] == 0) {
+                    --env->loop_depth;
+                    ++env->instruction_index;
+                } else {
+                    env->instruction_index = env->loop_starts[env->loop_depth - 1];
+                    --env->loop_counts[env->loop_depth - 1];
+                }
+                continue;
+            case 15:
+                if (TextureCondition(instruction[1], env->texture_index, instruction[2]) ||
+                    env->loop_counts[env->loop_depth - 1] == 0) {
+                    --env->loop_depth;
+                    env->instruction_index += 3;
+                } else {
+                    --env->loop_counts[env->loop_depth - 1];
+                    env->instruction_index = env->loop_starts[env->loop_depth - 1];
+                }
+                continue;
+            case 16:
+                if (env->wait_remaining < 0)
+                    env->wait_remaining = 0;
+                return;
+            case 17:
+                for (nutexanimlist_s *list = ntal_first; list != NULL; list = list->next) {
+                    for (nutexanim_s *anim = list->first; anim != NULL; anim = anim->next) {
+                        nutexanimenv_s *other = anim->env;
+                        if (other == NULL || other == env || other->program == NULL)
+                            continue;
+                        for (i32 i = 0; i < other->program->label_count; ++i) {
+                            if (other->program->label_ids[i] == instruction[1]) {
+                                other->instruction_index = other->program->label_offsets[i];
+                                other->wait_remaining = 0;
+                                other->call_depth = 0;
+                                other->loop_depth = 0;
+                                break;
+                            }
                         }
                     }
                 }
-            }
-            env->instruction_index += 2;
-            continue;
-        default:
-            continue;
+                env->instruction_index += 2;
+                continue;
+            default:
+                continue;
         }
         u16 texture = env->texture_ids[env->texture_index];
         material->tex_id = texture;
         material->shader_desc.diffuse_map_tex_id[0] = texture & 0x7fff;
         env->instruction_index = next_instruction;
         env->wait_remaining += env->wait_base;
-        if (env->wait_random != 0) env->wait_remaining += NuRand(&texanim_rand) % env->wait_random;
-        if (env->wait_remaining < 0) env->wait_remaining = 0;
+        if (env->wait_random != 0)
+            env->wait_remaining += NuRand(&texanim_rand) % env->wait_random;
+        if (env->wait_remaining < 0)
+            env->wait_remaining = 0;
         return;
     }
 }
@@ -552,19 +586,37 @@ extern "C" void NuTexAnimProgAssembleEnd(nutexanimprog_s *program) {
     i16 index = 0;
     while (index < program->instruction_count) {
         switch (program->instructions[index]) {
-        case 0: case 1: case 17: index += 2; break;
-        case 3: index += 5; break;
-        case 4: case 7: case 13: case 15: index += 3; break;
-        case 9: case 10:
-            program->instructions[index + 1] = nta_labels[program->instructions[index + 1]];
-            index += 2;
-            break;
-        case 11:
-            program->instructions[index + 3] = nta_labels[program->instructions[index + 3]];
-            index += 4;
-            break;
-        case 2: index += 4; break;
-        case 12: case 14: case 16: ++index; break;
+            case 0:
+            case 1:
+            case 17:
+                index += 2;
+                break;
+            case 3:
+                index += 5;
+                break;
+            case 4:
+            case 7:
+            case 13:
+            case 15:
+                index += 3;
+                break;
+            case 9:
+            case 10:
+                program->instructions[index + 1] = nta_labels[program->instructions[index + 1]];
+                index += 2;
+                break;
+            case 11:
+                program->instructions[index + 3] = nta_labels[program->instructions[index + 3]];
+                index += 4;
+                break;
+            case 2:
+                index += 4;
+                break;
+            case 12:
+            case 14:
+            case 16:
+                ++index;
+                break;
         }
     }
 }
@@ -577,7 +629,8 @@ extern "C" void NuTexAnimProgDestroy(void) {
 
 extern "C" nutexanimprog_s *NuTexAnimProgFind(char *name) {
     for (nutexanimprog_s *program = sys_progs; program != NULL; program = program->next) {
-        if (NuStrICmp(name, program->name) == 0) return program;
+        if (NuStrICmp(name, program->name) == 0)
+            return program;
     }
     return NULL;
 }
@@ -605,7 +658,8 @@ extern "C" void NuTexAnimProgRelease(void) {
 
 extern "C" void NuTexAnimProgSysInit(void) {
     sys_progs = NULL;
-    for (i32 i = 0; i < 63; ++i) ntalsysbuff[i].next = &ntalsysbuff[i + 1];
+    for (i32 i = 0; i < 63; ++i)
+        ntalsysbuff[i].next = &ntalsysbuff[i + 1];
     ntalsysbuff[63].next = NULL;
     xdeflabtabcnt = 0;
     nta_sig_old = 0;
@@ -622,10 +676,14 @@ extern "C" void NuTexAnimProgWrite(void) {
 extern "C" void NuTexAnimRemoveList(void *anim) {
     NuThreadCriticalSectionBegin(g_texAnimCriticalSection);
     for (nutexanimlist_s *node = ntal_first; node != NULL; node = node->next) {
-        if (node->first != anim) continue;
-        if (node->next != NULL) node->next->previous = node->previous;
-        if (node->previous != NULL) node->previous->next = node->next;
-        else ntal_first = node->next;
+        if (node->first != anim)
+            continue;
+        if (node->next != NULL)
+            node->next->previous = node->previous;
+        if (node->previous != NULL)
+            node->previous->next = node->next;
+        else
+            ntal_first = node->next;
         node->next = ntal_free;
         ntal_free = node;
         break;
@@ -635,7 +693,8 @@ extern "C" void NuTexAnimRemoveList(void *anim) {
 
 extern "C" void NuTexAnimRestart(void) {
     NuThreadCriticalSectionBegin(g_texAnimCriticalSection);
-    for (nutexanimlist_s *node = ntal_first; node != NULL; node = node->next) NuTexAnimResetList(node->first);
+    for (nutexanimlist_s *node = ntal_first; node != NULL; node = node->next)
+        NuTexAnimResetList(node->first);
     NuThreadCriticalSectionEnd(g_texAnimCriticalSection);
 }
 
@@ -643,18 +702,21 @@ extern "C" void NuTexAnimProcess(f32 frame_time) {
     nta_iframetime = static_cast<i32>(frame_time * 4096.0f);
     nta_script_mask = script_mask;
     NuThreadCriticalSectionBegin(g_texAnimCriticalSection);
-    for (nutexanimlist_s *node = ntal_first; node != NULL; node = node->next) NuTexAnimProcessList(node->first);
+    for (nutexanimlist_s *node = ntal_first; node != NULL; node = node->next)
+        NuTexAnimProcessList(node->first);
     NuThreadCriticalSectionEnd(g_texAnimCriticalSection);
 }
 extern "C" void NuTexAnimProcessEx(f32 frame_time, u16 mask) {
     nta_iframetime = static_cast<i32>(frame_time * 4096.0f);
     nta_script_mask = mask;
     NuThreadCriticalSectionBegin(g_texAnimCriticalSection);
-    for (nutexanimlist_s *node = ntal_first; node != NULL; node = node->next) NuTexAnimProcessList(node->first);
+    for (nutexanimlist_s *node = ntal_first; node != NULL; node = node->next)
+        NuTexAnimProcessList(node->first);
     NuThreadCriticalSectionEnd(g_texAnimCriticalSection);
 }
 extern "C" void NuTexAnimProcessList(nutexanim_s *anim) {
     for (; anim != NULL; anim = anim->next) {
-        if (anim->env != NULL) NuTexAnimEnvProc(anim->env);
+        if (anim->env != NULL)
+            NuTexAnimEnvProc(anim->env);
     }
 }


### PR DESCRIPTION
Stacked on #70 — that PR's commit is included here until it merges.
Review only the "Reformat the sources to match clang-format" commit.

## What

`bazel run //scripts:pre_commit` reformats and auto-stages 41 files on an
otherwise clean checkout of `main`. Every contributor therefore picks the same
churn up into their own branch before they have written anything, and either
carries it through review or has to strip it out by hand. This applies it once.

## Why it drifted

Nothing enforces formatting: `build-bazel.yaml` runs the clang-tidy passes but
never `clang-format`, so the tree is only as formatted as the last person to
run `pre_commit` locally left it.

## Scope

Whitespace only. With all whitespace stripped, each of the 41 files is
byte-identical to its previous contents, so no token moved and no codegen can
change. `SortIncludes` is `Never`, so no include order moved either. The
reflowing is what makes the line counts look larger than the change is.

Produced with the repo's own pinned formatter, `//scripts/checks:clang_format`
(clang-format 22.1.8), over the same file set `pre_commit` selects.

## Verification

On macOS 15 / arm64: `bazel run //scripts:pre_commit` exits 0 and no longer
reports a formatting stage, leaving the tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
