### PR TITLE
Restore Android native interfaces and ARMv7 hardware testing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,10 @@ build:target --extra_toolchains=@android_ndk_r8e//:toolchain
 build:target --define=SAGA_BUILD=target
 try-import %workspace%/bazel/android_per_file_copts.bazelrc
 
+build:android-armv7 --config=target
+build:android-armv7 --platforms=//bazel/platforms:android_armv7
+build:android-armv7 --extra_toolchains=@android_ndk_r8e//:toolchain_armv7
+
 build:native --config=saga-common
 build:native --define=SAGA_BUILD=native
 build:native --define=SAGA_MODE=debug

--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,8 @@ build:target --extra_toolchains=@android_ndk_r8e//:toolchain
 build:target --define=SAGA_BUILD=target
 try-import %workspace%/bazel/android_per_file_copts.bazelrc
 
+# Runtime testing on real Android hardware only; not an assembly-matching target.
+# Android x86 (--config=target) remains the reference matching configuration.
 build:android-armv7 --config=target
 build:android-armv7 --platforms=//bazel/platforms:android_armv7
 build:android-armv7 --extra_toolchains=@android_ndk_r8e//:toolchain_armv7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # _saga_
 
-![Progress](https://img.shields.io/badge/matching-18.00%25-red)
+![Progress](https://img.shields.io/badge/matching-19.81%25-red)
 [![Bazel build](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml/badge.svg)](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml)
 [![Discord](https://img.shields.io/discord/1467775700894224555?color=%235865F2&logo=discord&logoColor=%23FFFFFF)](https://discord.gg/2HJuMtzA7q)
 [![status & wasm build](https://img.shields.io/badge/status%20%26%20wasm%20build-click%20here-orange?style=flat)](https://ttdecomp.github.io/saga/)
@@ -58,30 +58,30 @@ See https://ttdecomp.github.io/saga/
 
 | Directory | Fuzzy % | Funcs % |
 |---|---:|---:|
-| `(root)` | 61.8% | 0.0% |
+| `(root)` | 62.0% | 0.0% |
 | `MechInputTouch` | 9.7% | 6.1% |
 | `editor` | 3.2% | 1.7% |
 | `gameapi` | 12.0% | 1.5% |
 | `gameframework` | 99.9% | 5.9% |
-| `gamelib` | 9.0% | 5.1% |
-| `java` | 10.5% | 0.0% |
-| `legoapi` | 17.5% | 7.8% |
+| `gamelib` | 16.0% | 4.9% |
+| `java` | 96.0% | 0.0% |
+| `legoapi` | 18.2% | 7.9% |
 | `legoapi/actions` | 8.2% | 1.3% |
-| `legoapi/ai` | 13.1% | 0.0% |
+| `legoapi/ai` | 13.3% | 0.0% |
 | `legoapi/audio` | 8.2% | 5.7% |
-| `legoapi/characters` | 19.0% | 5.1% |
-| `legoapi/core` | 25.7% | 6.6% |
+| `legoapi/characters` | 19.6% | 5.1% |
+| `legoapi/core` | 25.9% | 6.6% |
 | `legoapi/cutscenes` | 11.4% | 3.0% |
 | `legoapi/gizmo` | 15.7% | 3.9% |
-| `legoapi/gizmos` | 42.6% | 30.8% |
+| `legoapi/gizmos` | 43.1% | 30.8% |
 | `legoapi/items` | 10.6% | 4.1% |
-| `legoapi/menus` | 16.0% | 6.4% |
-| `legoapi/misc` | 9.7% | 4.0% |
-| `legoapi/props` | 28.8% | 2.2% |
-| `legoapi/render` | 13.0% | 6.2% |
+| `legoapi/menus` | 16.1% | 6.4% |
+| `legoapi/misc` | 9.9% | 4.0% |
+| `legoapi/props` | 29.9% | 2.2% |
+| `legoapi/render` | 15.9% | 7.2% |
 | `legoapi/world` | 24.1% | 6.4% |
 | `legogame` | 57.2% | 10.7% |
-| `nu2api` | 33.9% | 14.9% |
+| `nu2api` | 41.7% | 17.9% |
 
 <!-- matching-table-end -->
 

--- a/bazel/android_cc_toolchain_config.bzl
+++ b/bazel/android_cc_toolchain_config.bzl
@@ -1,4 +1,4 @@
-"""NDK r8e toolchains for Android x86 matching and ARMv7 builds."""
+"""NDK r8e: x86 assembly matching and ARMv7 hardware runtime testing only."""
 
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc:cc_toolchain_config_lib.bzl", "feature", "flag_group", "flag_set", "tool_path")

--- a/bazel/android_cc_toolchain_config.bzl
+++ b/bazel/android_cc_toolchain_config.bzl
@@ -1,4 +1,4 @@
-"""C++ toolchain configuration for the matching Android x86 build."""
+"""NDK r8e toolchains for Android x86 matching and ARMv7 builds."""
 
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 load("@rules_cc//cc:cc_toolchain_config_lib.bzl", "feature", "flag_group", "flag_set", "tool_path")
@@ -7,9 +7,14 @@ load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfig
 
 def _android_cc_toolchain_config_impl(ctx):
     ndk_root = ctx.file.ndk_marker.dirname
-    toolchain = ndk_root + "/toolchains/x86-4.7/prebuilt/" + ctx.attr.host_system_name
-    real_toolchain = ctx.attr.real_ndk_root + "/toolchains/x86-4.7/prebuilt/" + ctx.attr.host_system_name
-    prefix = "ndk/toolchains/x86-4.7/prebuilt/" + ctx.attr.host_system_name + "/bin/i686-linux-android-"
+    arm = ctx.attr.arch == "armv7"
+    arch = "arm" if arm else "x86"
+    abi = "armeabi-v7a" if arm else "x86"
+    triple = "arm-linux-androideabi" if arm else "i686-linux-android"
+    toolchain_dir = "arm-linux-androideabi-4.7" if arm else "x86-4.7"
+    toolchain = ndk_root + "/toolchains/" + toolchain_dir + "/prebuilt/" + ctx.attr.host_system_name
+    real_toolchain = ctx.attr.real_ndk_root + "/toolchains/" + toolchain_dir + "/prebuilt/" + ctx.attr.host_system_name
+    prefix = "ndk/toolchains/" + toolchain_dir + "/prebuilt/" + ctx.attr.host_system_name + "/bin/" + triple + "-"
     suffix = ctx.attr.tool_suffix
     compile_actions = [
         ACTION_NAMES.c_compile,
@@ -64,13 +69,25 @@ def _android_cc_toolchain_config_impl(ctx):
                             "-isystem",
                             ndk_root + "/sources/cxx-stl/gnu-libstdc++/4.7/include",
                             "-isystem",
-                            ndk_root + "/sources/cxx-stl/gnu-libstdc++/4.7/libs/x86/include",
+                            ndk_root + "/sources/cxx-stl/gnu-libstdc++/4.7/libs/" + abi + "/include",
                         ]),
                     ],
                 ),
             ],
         ),
     ]
+    if arm:
+        features.append(feature(
+            name = "armv7_android_abi",
+            enabled = True,
+            flag_sets = [flag_set(
+                actions = compile_actions + link_actions,
+                flag_groups = [flag_group(flags = [
+                    "-march=armv7-a", "-mfloat-abi=softfp", "-mfpu=vfpv3-d16",
+                    "-B" + real_toolchain + "/" + triple + "/bin/",
+                ])],
+            )],
+        ))
     if ctx.attr.host_system_name == "windows-x86_64":
         # Preserve the flags applied by the former CMake build when driving
         # the Android NDK from Windows.
@@ -114,35 +131,36 @@ def _android_cc_toolchain_config_impl(ctx):
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,
         abi_libc_version = "bionic-api-9",
-        abi_version = "x86",
-        builtin_sysroot = ndk_root + "/platforms/android-9/arch-x86",
+        abi_version = abi,
+        builtin_sysroot = ndk_root + "/platforms/android-9/arch-" + arch,
         compiler = "gcc-4.7",
         cxx_builtin_include_directories = [
-            ndk_root + "/platforms/android-9/arch-x86/usr/include",
-            toolchain + "/lib/gcc/i686-linux-android/4.7/include",
-            toolchain + "/lib/gcc/i686-linux-android/4.7/include-fixed",
+            ndk_root + "/platforms/android-9/arch-" + arch + "/usr/include",
+            toolchain + "/lib/gcc/" + triple + "/4.7/include",
+            toolchain + "/lib/gcc/" + triple + "/4.7/include-fixed",
             ndk_root + "/sources/cxx-stl/system/include",
             ndk_root + "/sources/cxx-stl/gnu-libstdc++/4.7/include",
-            ndk_root + "/sources/cxx-stl/gnu-libstdc++/4.7/libs/x86/include",
-            ctx.attr.real_ndk_root + "/platforms/android-9/arch-x86/usr/include",
-            real_toolchain + "/lib/gcc/i686-linux-android/4.7/include",
-            real_toolchain + "/lib/gcc/i686-linux-android/4.7/include-fixed",
+            ndk_root + "/sources/cxx-stl/gnu-libstdc++/4.7/libs/" + abi + "/include",
+            ctx.attr.real_ndk_root + "/platforms/android-9/arch-" + arch + "/usr/include",
+            real_toolchain + "/lib/gcc/" + triple + "/4.7/include",
+            real_toolchain + "/lib/gcc/" + triple + "/4.7/include-fixed",
             ctx.attr.real_ndk_root + "/sources/cxx-stl/system/include",
             ctx.attr.real_ndk_root + "/sources/cxx-stl/gnu-libstdc++/4.7/include",
-            ctx.attr.real_ndk_root + "/sources/cxx-stl/gnu-libstdc++/4.7/libs/x86/include",
+            ctx.attr.real_ndk_root + "/sources/cxx-stl/gnu-libstdc++/4.7/libs/" + abi + "/include",
         ],
         features = features,
         host_system_name = ctx.attr.host_system_name,
-        target_cpu = "x86_32",
+        target_cpu = "armv7" if arm else "x86_32",
         target_libc = "bionic",
         target_system_name = "android",
         tool_paths = paths,
-        toolchain_identifier = "android-ndk-r8e-x86-api9-" + ctx.attr.host_system_name,
+        toolchain_identifier = "android-ndk-r8e-" + abi + "-api9-" + ctx.attr.host_system_name,
     )
 
 android_cc_toolchain_config = rule(
     implementation = _android_cc_toolchain_config_impl,
     attrs = {
+        "arch": attr.string(default = "x86", values = ["x86", "armv7"]),
         "host_system_name": attr.string(mandatory = True),
         "ndk_marker": attr.label(allow_single_file = True, mandatory = True),
         "real_ndk_root": attr.string(mandatory = True),

--- a/bazel/android_ndk_repository.bzl
+++ b/bazel/android_ndk_repository.bzl
@@ -1,4 +1,4 @@
-"""Repository rule provisioning the legacy Android NDK r8e x86 toolchain."""
+"""Repository rule provisioning legacy Android NDK r8e toolchains."""
 
 _NDK_ARCHIVES = {
     "linux": (
@@ -61,6 +61,37 @@ toolchain(
         "@platforms//os:android",
     ],
     toolchain = ":cc_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+android_cc_toolchain_config(
+    name = "config_armv7",
+    arch = "armv7",
+    host_system_name = "{host_tag}",
+    ndk_marker = "ndk/RELEASE.TXT",
+    real_ndk_root = {real_ndk_root},
+    tool_suffix = "{tool_suffix}",
+)
+
+cc_toolchain(
+    name = "cc_toolchain_armv7",
+    all_files = ":toolchain_files",
+    ar_files = ":toolchain_files",
+    compiler_files = ":toolchain_files",
+    dwp_files = ":toolchain_files",
+    linker_files = ":toolchain_files",
+    objcopy_files = ":toolchain_files",
+    strip_files = ":toolchain_files",
+    supports_param_files = 1,
+    toolchain_config = ":config_armv7",
+)
+
+toolchain(
+    name = "toolchain_armv7",
+    target_compatible_with = [
+        "@platforms//cpu:armv7",
+        "@platforms//os:android",
+    ],
+    toolchain = ":cc_toolchain_armv7",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 )
 """.format(

--- a/bazel/android_per_file_copts.bazelrc
+++ b/bazel/android_per_file_copts.bazelrc
@@ -7,6 +7,14 @@
 # apply only to the corresponding source.
 
 build:target --per_file_copt=^src/batman\.cpp$@-O2
+# Recovered Android entry points; -O2 and -O3 emit the same measured bodies.
+build:target --per_file_copt=^src/java/android\.cpp$@-O2
+# Original OBB lookup uses optimized inlined strlen/strcat and omits leaf frames.
+build:target --per_file_copt=^src/gamelib/util/AndroidOBBUtils\.cpp$@-O3
+# Recovered stub-only device units: -O3 reproduces FileSize exactly and the
+# APK constructor/CreateNuFile and SetCurrentDir bodies apart from relocation.
+build:target --per_file_copt=^src/nu2api/nufile/nufiledevice\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nufile/NuFileDeviceAndroidAPK\.cpp$@-O3
 build:target --per_file_copt=^src/gameapi/ai/aisys/aiscript\.cpp$@-O3
 build:target --per_file_copt=^src/gameapi/ai/aisys/aistate\.cpp$@-O3
 build:target --per_file_copt=^src/gameapi/ai/aisys/aisys\.cpp$@-O3
@@ -201,12 +209,14 @@ build:target --per_file_copt=^src/nu2api/nucore/nupad_interface\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nucore/nunew\.cpp$@-O2
 build:target --per_file_copt=^src/nu2api/nucore/nustring\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nucore/nuios_metrics\.cpp$@-O2
-build:target --per_file_copt=^src/nu2api/nucore/android/NuInputDevice_android\.cpp$@-O2
+# Recovered ClassInitPS and UpdateAllPS require the original vectorization and
+# ten-touch loop unrolling: -O3 reproduces both bodies above 99%.
+build:target --per_file_copt=^src/nu2api/nucore/android/NuInputDevice_android\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nucore/android/NuThread_android\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nucore/android/bgproc_android\.cpp$@-O2
 build:target --per_file_copt=^src/nu2api/nucore/android/numemory_android\.cpp$@-O2
 build:target --per_file_copt=^src/nu2api/nufile/nufile\.c$@-O2
-build:target --per_file_copt=^src/nu2api/nufile/nufile_android\.cpp$@-O2
+build:target --per_file_copt=^src/nu2api/nufile/nufile_android\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nufile/nufilebase\.cpp$@-O2
 build:target --per_file_copt=^src/nu2api/nufile/tmclient\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nufile/android/nufile_android\.cpp$@-O2
@@ -231,6 +241,18 @@ build:target --per_file_copt=^src/nu2api/nusound/nusound_memorymanager\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nusound/nusound_system\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nusound/nusound_voice\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nusound/nusound_weakptr\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nu3d/nuocclusion\.cpp$@-O3
+build:target --per_file_copt=^src/legoapi/render/light/occlusion\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nusound/nusound_bus\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nusound/nusound_clock\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nusound/nusound_effect_doppler\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nusound/nusound_effect_fader\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nusound/nusound_effect_pitchramp\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nusound/nusound_listener\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nusound/nusound_routing\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nusound/nusound_mixer\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nusound/nusound_android\.cpp$@-O3
+build:target --per_file_copt=^src/nu2api/nusound/nusound_voice_android\.cpp$@-O3
 build:target --per_file_copt=^src/MechInputTouch/MechInputTouchButton\.cpp$@-O2
 build:target --per_file_copt=^src/MechInputTouch/MechInputTouchMainController\.cpp$@-O2
 build:target --per_file_copt=^src/MechInputTouch/MechSystems\.cpp$@-O2

--- a/bazel/android_per_file_copts.bazelrc
+++ b/bazel/android_per_file_copts.bazelrc
@@ -172,6 +172,7 @@ build:target --per_file_copt=^src/legoapi/render/light/surfaces\.cpp$@-O3
 build:target --per_file_copt=^src/legoapi/render/fx/parts_control\.cpp$@-O3
 build:target --per_file_copt=^src/legoapi/render/fx/particles\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nu3d/NuRenderDevice\.cpp$@-O2
+build:target --per_file_copt=^src/nu2api/nu3d/android/gles_extensions\.cpp$@-O2
 build:target --per_file_copt=^src/nu2api/nu3d/nuscreen\.cpp$@-O2
 build:target --per_file_copt=^src/nu2api/nu3d/nugscn\.cpp$@-O3
 build:target --per_file_copt=^src/nu2api/nu3d/nuspecial\.cpp$@-O3

--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -1,6 +1,14 @@
 package(default_visibility = ["//visibility:public"])
 
 platform(
+    name = "android_armv7",
+    constraint_values = [
+        "@platforms//cpu:armv7",
+        "@platforms//os:android",
+    ],
+)
+
+platform(
     name = "android_x86",
     constraint_values = [
         "@platforms//cpu:x86_32",

--- a/doc/android-matching.md
+++ b/doc/android-matching.md
@@ -22,6 +22,14 @@ support device execution and do not imply ARM assembly matching.
   selection remains in the toolchain and ABI assertions; host asset/window stubs
   remain under `src/host/platform` and are excluded from the target.
 
+The Android GLES extension-pointer table is also selected only for the target;
+the host adapter uses private pointer names so they cannot collide with GL
+functions exported by Emscripten or a native GL implementation. Native component
+source lists select the JNI stub instead of the Android activity implementation.
+Binary-layout checks use the existing `DECOMP_ASSERT` boundary: Android builds
+retain the checks, while host/WASM builds use their platform's alignment and
+mutex layout.
+
 The original instruction shapes support corrections to per-source optimization
 for Android file access, sound and occlusion. O0 frame/error, wind-group and
 specular-light code now has separate source ownership instead of inheriting O3
@@ -66,6 +74,8 @@ Verified on 2026-09-07:
 - `bazel build --config=target //src:saga_target` passes.
 - `bazel build --config=android-armv7 //src:saga_target` passes, with undefined
   references rejected by the linker.
+- `bazel build --config=wasm //src:saga_wasm` passes through the final HTML,
+  JavaScript and WASM link on Windows.
 - `bazel test //scripts/checks:checks` passes all four checks: optimization map,
   duplicate definitions, host boundaries and Pages tests.
 - The symbol check passes: no unignored missing symbols and no extra-symbol

--- a/doc/android-matching.md
+++ b/doc/android-matching.md
@@ -1,0 +1,76 @@
+# Android native reconstruction
+
+This change restores native interfaces used by the original APK's Java activity
+and adds an NDK r8e ARMv7 build. The intended deployment keeps the original Java
+and replaces `libTTapp.so`. It does not include a replacement Java application.
+
+## Implemented areas
+
+- JNI activity lifecycle, surface handling, input forwarding, device information,
+  package paths, APK assets and expansion-file access.
+- EGL window/context initialization, GLES extension loading and render-state
+  transitions; camera, material, font and occlusion dependencies.
+- OpenSL ES integration and sound source/decoder/voice, streaming, listener,
+  routing, effect, weak-pointer and memory-manager behavior.
+- ARM layout assertions checked against the original ARM library. ARM-specific
+  selection remains in the toolchain and ABI assertions; host asset/window stubs
+  remain under `src/host/platform` and are excluded from the target.
+
+The original instruction shapes support corrections to per-source optimization
+for Android file access, sound and occlusion. O0 frame/error, wind-group and
+specular-light code now has separate source ownership instead of inheriting O3
+from mixed files. No new per-function optimization attributes, injected assembly,
+assertion bypasses or matching-score exceptions are used.
+
+## Matching comparison
+
+Both x86 builds were compared to `res/libTTapp.so` with the ttdecomp fork of
+objdiff-cli 3.8.1. Main was independently built from an archive of
+`90c48f9261ac37d1ec8944d0f00f299774034af4`; its working checkout was not used.
+The committed `matching.json` and README table were regenerated with
+`scripts/generate_bazel_objdiff_report.py`, the generator used by pre-commit.
+
+| Metric | Main | This change |
+|---|---:|---:|
+| Whole-binary fuzzy match | 18.173262% | 19.808786% |
+| Exact function matches | 1,021 | 1,182 |
+| Exact matched code bytes | 40,829 | 44,456 |
+
+The fuzzy increase is **1.635524 percentage points**. No previously exact
+function loses its exact match. Of the initial 126 named score declines, four
+remain; each is below one percentage point. They are reported rather than
+hidden or compensated for with layout padding.
+
+| Function | Main | This change | Original size |
+|---|---:|---:|---:|
+| `NuRenderDevice::SelectEGLConfig()` | 96.884610% | 96.019230% | 247 bytes |
+| `NuHGobjEvalAnim2Root_3` | 99.932205% | 99.677960% | 257 bytes |
+| `NuVisiEvaluate` | 96.850000% | 96.662500% | 312 bytes |
+| `NuHGobjRndrMtxDwa` | 53.963577% | 53.913906% | 1,122 bytes |
+
+These functions total 1,938 original bytes. Their score decreases amount to
+3.933207 fuzzy-weighted byte equivalents, **not** a literal count of changed
+bytes. Disassembly shows register-allocation/scheduling and linked-address
+variation; this is not a zero-regression matching result.
+
+## Validation and device status
+
+Verified on 2026-09-07:
+
+- `bazel build --config=target //src:saga_target` passes.
+- `bazel build --config=android-armv7 //src:saga_target` passes, with undefined
+  references rejected by the linker.
+- `bazel test //scripts/checks:checks` passes all four checks: optimization map,
+  duplicate definitions, host boundaries and Pages tests.
+- The symbol check passes: no unignored missing symbols and no extra-symbol
+  baseline changes.
+- `git diff --check` passes.
+
+The full optional pre-commit pipeline was not run: native/clang-tidy coverage
+remains unverified with the host's missing pkg-config development dependencies.
+The report generator and checks above were run separately.
+
+An earlier ARM build installed in the original APK reached its title/splash on
+a OnePlus N200 running Android 12. Touch did not respond; menu/gameplay is not
+verified. The final matching fixes have not been retested on the device. This
+is native reconstruction progress, not a claim of complete Android playability.

--- a/doc/android-matching.md
+++ b/doc/android-matching.md
@@ -4,6 +4,12 @@ This change restores native interfaces used by the original APK's Java activity
 and adds an NDK r8e ARMv7 build. The intended deployment keeps the original Java
 and replaces `libTTapp.so`. It does not include a replacement Java application.
 
+**ARMv7 is only for runtime testing on real Android hardware. It is not a
+matching target.** Android x86 (`--config=target`) remains the matching target
+against `res/libTTapp.so`; all matching percentages and regression comparisons
+in this document and the generated report refer to x86. ARM ABI/layout checks
+support device execution and do not imply ARM assembly matching.
+
 ## Implemented areas
 
 - JNI activity lifecycle, surface handling, input forwarding, device information,

--- a/matching.json
+++ b/matching.json
@@ -85828,7 +85828,14 @@
           "offset": 1893568,
           "size": 1133,
           "match_percent": 70.347984
-        },
+        }
+      ]
+    },
+    {
+      "name": "nu2api/nu3d/android/gles_extensions.cpp.o",
+      "source": "src/nu2api/nu3d/android/gles_extensions.cpp",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/gles_extensions.o",
+      "functions": [
         {
           "name": "_Z21NuGLES2ExtensionsInitv",
           "demangled_name": "NuGLES2ExtensionsInit()",
@@ -131159,7 +131166,7 @@
     }
   ],
   "summary": {
-    "bazel_units": 502,
+    "bazel_units": 503,
     "functions": 13454,
     "assigned_functions": 12175,
     "ambiguous_functions": 243,

--- a/matching.json
+++ b/matching.json
@@ -1,16 +1,16 @@
 {
   "schema_version": 1,
   "measures": {
-    "fuzzy_match_percent": 18.004868,
+    "fuzzy_match_percent": 19.808786,
     "total_code": "4722419",
-    "matched_code": "40829",
-    "matched_code_percent": 0.8645781,
+    "matched_code": "44456",
+    "matched_code_percent": 0.941382,
     "total_data": "14606528",
     "matched_data": "543696",
     "matched_data_percent": 3.722281,
     "total_functions": 13459,
-    "matched_functions": 1021,
-    "matched_functions_percent": 7.5860014,
+    "matched_functions": 1182,
+    "matched_functions_percent": 8.7822275,
     "total_units": 1
   },
   "text": {
@@ -14347,7 +14347,7 @@
     {
       "name": "MechInputTouch/MechAutoJumpManager.cpp.o",
       "source": "src/MechInputTouch/MechAutoJumpManager.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutoJumpManager.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutoJumpManager.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechAutoJumpManager.cpp",
@@ -14474,7 +14474,7 @@
     {
       "name": "MechInputTouch/MechAutofireAddon.cpp.o",
       "source": "src/MechInputTouch/MechAutofireAddon.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutofireAddon.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutofireAddon.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechAutofireAddon.cpp",
@@ -14537,7 +14537,7 @@
     {
       "name": "MechInputTouch/MechEdgeStopAddon.cpp.o",
       "source": "src/MechInputTouch/MechEdgeStopAddon.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechEdgeStopAddon.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechEdgeStopAddon.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechEdgeStopAddon.cpp",
@@ -14600,7 +14600,7 @@
     {
       "name": "MechInputTouch/MechInputTouch.cpp.o",
       "source": "src/MechInputTouch/MechInputTouch.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouch.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouch.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouch.cpp",
@@ -14871,7 +14871,7 @@
     {
       "name": "MechInputTouch/MechInputTouchBonusCavalryController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchBonusCavalryController.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchBonusCavalryController.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchBonusCavalryController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchBonusCavalryController.cpp",
@@ -14966,7 +14966,7 @@
     {
       "name": "MechInputTouch/MechInputTouchButton.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchButton.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchButton.cpp",
@@ -15245,7 +15245,7 @@
     {
       "name": "MechInputTouch/MechInputTouchButton_stubs.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchButton_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton_stubs.o",
       "functions": [
         {
           "name": "_ZNK29MechInputTouchMainDummyButton9IsPressedEv",
@@ -15260,7 +15260,7 @@
     {
       "name": "MechInputTouch/MechInputTouchContextTasks.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchContextTasks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchContextTasks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchContextTasks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchContextTasks.cpp",
@@ -16107,7 +16107,7 @@
     {
       "name": "MechInputTouch/MechInputTouchDeathStarTurretController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchDeathStarTurretController.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchDeathStarTurretController.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchDeathStarTurretController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchDeathStarTurretController.cpp",
@@ -16210,7 +16210,7 @@
     {
       "name": "MechInputTouch/MechInputTouchGestureBasedController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchGestureBasedController.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureBasedController.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureBasedController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchGestureBasedController.cpp",
@@ -16417,7 +16417,7 @@
     {
       "name": "MechInputTouch/MechInputTouchGestureTracker.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchGestureTracker.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureTracker.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureTracker.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchGestureTracker.cpp",
@@ -16568,7 +16568,7 @@
     {
       "name": "MechInputTouch/MechInputTouchMainController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchMainController.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMainController.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMainController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchMainController.cpp",
@@ -16663,7 +16663,7 @@
     {
       "name": "MechInputTouch/MechInputTouchMenuController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchMenuController.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMenuController.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMenuController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchMenuController.cpp",
@@ -16806,7 +16806,7 @@
     {
       "name": "MechInputTouch/MechInputTouchPodraceController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchPodraceController.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchPodraceController.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchPodraceController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchPodraceController.cpp",
@@ -16901,7 +16901,7 @@
     {
       "name": "MechInputTouch/MechInputTouchSpeederChaseBikeController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchSpeederChaseBikeController.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchSpeederChaseBikeController.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchSpeederChaseBikeController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchSpeederChaseBikeController.cpp",
@@ -17052,7 +17052,7 @@
     {
       "name": "MechInputTouch/MechInputTouchVirtualConsoleController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchVirtualConsoleController.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchVirtualConsoleController.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchVirtualConsoleController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchVirtualConsoleController.cpp",
@@ -17195,7 +17195,7 @@
     {
       "name": "MechInputTouch/MechJumpAutopilotAddon.cpp.o",
       "source": "src/MechInputTouch/MechJumpAutopilotAddon.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechJumpAutopilotAddon.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechJumpAutopilotAddon.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechJumpAutopilotAddon.cpp",
@@ -17330,7 +17330,7 @@
     {
       "name": "MechInputTouch/MechObjectInterface.cpp.o",
       "source": "src/MechInputTouch/MechObjectInterface.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechObjectInterface.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechObjectInterface.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechObjectInterface.cpp",
@@ -17473,7 +17473,7 @@
     {
       "name": "MechInputTouch/MechSystems.cpp.o",
       "source": "src/MechInputTouch/MechSystems.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechSystems.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechSystems.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechSystems.cpp",
@@ -17688,7 +17688,7 @@
     {
       "name": "MechInputTouch/MechTouchUIElements.cpp.o",
       "source": "src/MechInputTouch/MechTouchUIElements.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechTouchUIElements.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechTouchUIElements.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechTouchUIElements.cpp",
@@ -18287,7 +18287,7 @@
     {
       "name": "batman.cpp.o",
       "source": "src/batman.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_root/batman.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_root/batman.o",
       "functions": [
         {
           "name": "_ZL19NuSoundAppTerminatev",
@@ -18303,14 +18303,14 @@
           "address": 1015456,
           "offset": 125488,
           "size": 13465,
-          "match_percent": 61.659435
+          "match_percent": 61.913563
         }
       ]
     },
     {
       "name": "editor/aieditor.cpp.o",
       "source": "src/editor/aieditor.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/aieditor.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_editor/aieditor.o",
       "functions": [
         {
           "name": "aieditor_cbDrawAllToggle",
@@ -18565,7 +18565,7 @@
     {
       "name": "editor/area_editor.cpp.o",
       "source": "src/editor/area_editor.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/area_editor.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_editor/area_editor.o",
       "functions": [
         {
           "name": "_ZL31areaEditor_cbAreaCylinderToggleP10eduimenu_sP10eduiitem_sj",
@@ -18628,7 +18628,7 @@
     {
       "name": "editor/creature_editor.cpp.o",
       "source": "src/editor/creature_editor.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/creature_editor.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_editor/creature_editor.o",
       "functions": [
         {
           "name": "_ZL30creatureEditor_cbSetActivationP10eduimenu_sP10eduiitem_sj",
@@ -19003,7 +19003,7 @@
     {
       "name": "editor/edlevelall.cpp.o",
       "source": "src/editor/edlevelall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edlevelall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_editor/edlevelall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_edlevelall.cpp",
@@ -20290,7 +20290,7 @@
     {
       "name": "editor/edlevelall_stubs.cpp.o",
       "source": "src/editor/edlevelall_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edlevelall_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_editor/edlevelall_stubs.o",
       "functions": [
         {
           "name": "_ZN10BaseEditor10InitialiseER9variptr_uS1_i",
@@ -20401,7 +20401,7 @@
     {
       "name": "editor/edpath.cpp.o",
       "source": "src/editor/edpath.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edpath.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_editor/edpath.o",
       "functions": [
         {
           "name": "_ZL18ParseAIPathCnxFlagPc",
@@ -20800,7 +20800,7 @@
     {
       "name": "editor/edtoolsall.cpp.o",
       "source": "src/editor/edtoolsall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edtoolsall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_editor/edtoolsall.o",
       "functions": [
         {
           "name": "_Z21DumpAttributeBindingsv",
@@ -20935,7 +20935,7 @@
     {
       "name": "editor/locator_editor.cpp.o",
       "source": "src/editor/locator_editor.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/locator_editor.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_editor/locator_editor.o",
       "functions": [
         {
           "name": "_ZL14CreateCreatureiP7nuvec_si",
@@ -21174,7 +21174,7 @@
     {
       "name": "gameapi/ai/aisys/aiscript.cpp.o",
       "source": "src/gameapi/ai/aisys/aiscript.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/aiscript.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/aiscript.o",
       "functions": [
         {
           "name": "_ZL27AiParseExpressionNameLoopupPcPfPi",
@@ -21445,7 +21445,7 @@
     {
       "name": "gameapi/ai/aisys/aistate.cpp.o",
       "source": "src/gameapi/ai/aisys/aistate.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/aistate.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/aistate.o",
       "functions": [
         {
           "name": "AIStateFind",
@@ -21460,7 +21460,7 @@
     {
       "name": "gameapi/ai/aisys/aisys.cpp.o",
       "source": "src/gameapi/ai/aisys/aisys.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/aisys.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/aisys.o",
       "functions": [
         {
           "name": "_ZL18Condition_GlynTestP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPcPv",
@@ -23563,7 +23563,7 @@
     {
       "name": "gameapi/ai/aisys/cc.cpp.o",
       "source": "src/gameapi/ai/aisys/cc.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/cc.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/cc.o",
       "functions": [
         {
           "name": "_ZL10CC_variantP8nufpar_s",
@@ -25194,7 +25194,7 @@
     {
       "name": "gameapi/ai/aisys/gameai_actions.cpp.o",
       "source": "src/gameapi/ai/aisys/gameai_actions.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_actions.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_actions.o",
       "functions": [
         {
           "name": "_ZL25Condition_PrefersBrawlingP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPcPv",
@@ -27305,7 +27305,7 @@
     {
       "name": "gameapi/ai/gameai_bt.cpp.o",
       "source": "src/gameapi/ai/gameai_bt.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_bt.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_bt.o",
       "functions": [
         {
           "name": "_ZL12BT_nodeflectP8nufpar_s",
@@ -27512,7 +27512,7 @@
     {
       "name": "gameapi/ai/gameai_cs.cpp.o",
       "source": "src/gameapi/ai/gameai_cs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_cs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_cs.o",
       "functions": [
         {
           "name": "_ZL9CS_no_fogP8nufpar_s",
@@ -27855,7 +27855,7 @@
     {
       "name": "gameapi/ai/gameai_d.cpp.o",
       "source": "src/gameapi/ai/gameai_d.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_d.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_d.o",
       "functions": [
         {
           "name": "_ZL19D_cam_lookatplayersP8nufpar_s",
@@ -27974,7 +27974,7 @@
     {
       "name": "gameapi/ai/gameai_grab.cpp.o",
       "source": "src/gameapi/ai/gameai_grab.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_grab.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_grab.o",
       "functions": [
         {
           "name": "_ZL13Grab_invert_xP8nufpar_s",
@@ -28045,7 +28045,7 @@
     {
       "name": "gameapi/ai/gameai_sockpar.cpp.o",
       "source": "src/gameapi/ai/gameai_sockpar.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_sockpar.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_sockpar.o",
       "functions": [
         {
           "name": "_ZL14SockParCircuitP8nufpar_sPv",
@@ -28420,7 +28420,7 @@
     {
       "name": "gameapi/ai/gameai_tel.cpp.o",
       "source": "src/gameapi/ai/gameai_tel.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_tel.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_tel.o",
       "functions": [
         {
           "name": "_ZL9Tel_1_wayP8nufpar_s",
@@ -28507,7 +28507,7 @@
     {
       "name": "gameapi/edtools/edanimall.cpp.o",
       "source": "src/gameapi/edtools/edanimall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edanimall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edanimall.o",
       "functions": [
         {
           "name": "_ZL19edanimcbSetSwitchIdP10eduimenu_sP10eduiitem_sj",
@@ -28722,7 +28722,7 @@
     {
       "name": "gameapi/edtools/edanimcallbacks.cpp.o",
       "source": "src/gameapi/edtools/edanimcallbacks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edanimcallbacks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edanimcallbacks.o",
       "functions": [
         {
           "name": "_ZL26edgizforce_ReadAnimSetDataP13GAMEANIMOBJ_sh",
@@ -29009,7 +29009,7 @@
     {
       "name": "gameapi/edtools/edbriall.cpp.o",
       "source": "src/gameapi/edtools/edbriall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edbriall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edbriall.o",
       "functions": [
         {
           "name": "_ZL20edbricbSetPlankCountP10eduimenu_sP10eduiitem_sj",
@@ -29128,7 +29128,7 @@
     {
       "name": "gameapi/edtools/edbricallbacks.cpp.o",
       "source": "src/gameapi/edtools/edbricallbacks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edbricallbacks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edbricallbacks.o",
       "functions": [
         {
           "name": "_ZL26edbricbSetPostInstanceTypeP10eduimenu_sP10eduiitem_sj",
@@ -29279,7 +29279,7 @@
     {
       "name": "gameapi/edtools/edfile.cpp.o",
       "source": "src/gameapi/edtools/edfile.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edfile.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edfile.o",
       "functions": [
         {
           "name": "EdFileSwapEndianess16",
@@ -29446,7 +29446,7 @@
     {
       "name": "gameapi/edtools/edgraall.cpp.o",
       "source": "src/gameapi/edtools/edgraall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edgraall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edgraall.o",
       "functions": [
         {
           "name": "_ZL22edgracbSetInstanceTypeP10eduimenu_sP10eduiitem_sj",
@@ -29709,7 +29709,7 @@
     {
       "name": "gameapi/edtools/edgracallbacks.cpp.o",
       "source": "src/gameapi/edtools/edgracallbacks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edgracallbacks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edgracallbacks.o",
       "functions": [
         {
           "name": "_ZL26edgracbToggleClumpReactiveP10eduimenu_sP10eduiitem_sj",
@@ -29908,7 +29908,7 @@
     {
       "name": "gameapi/edtools/edlevelall.cpp.o",
       "source": "src/gameapi/edtools/edlevelall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edlevelall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edlevelall.o",
       "functions": [
         {
           "name": "_ZN7EdClass15SerialiseObjectER8EdStreamPv",
@@ -30035,7 +30035,7 @@
     {
       "name": "gameapi/edtools/edmenucallbacks.cpp.o",
       "source": "src/gameapi/edtools/edmenucallbacks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edmenucallbacks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edmenucallbacks.o",
       "functions": [
         {
           "name": "_ZL18cbPtlChangeEmitVelP10eduimenu_sP10eduiitem_sj",
@@ -31554,7 +31554,7 @@
     {
       "name": "gameapi/edtools/edpartall.cpp.o",
       "source": "src/gameapi/edtools/edpartall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edpartall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edpartall.o",
       "functions": [
         {
           "name": "_ZL10edppRenderv",
@@ -32137,7 +32137,7 @@
     {
       "name": "gameapi/edtools/edpartcallbacks.cpp.o",
       "source": "src/gameapi/edtools/edpartcallbacks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edpartcallbacks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edpartcallbacks.o",
       "functions": [
         {
           "name": "_ZL24edptlcbApplyBounceOffsetP10eduimenu_sP10eduiitem_sj",
@@ -32968,7 +32968,7 @@
     {
       "name": "gameapi/edtools/edptlall.cpp.o",
       "source": "src/gameapi/edtools/edptlall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edptlall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edptlall.o",
       "functions": [
         {
           "name": "_ZL21edptlcbChangeDistortXP10eduimenu_sP10eduiitem_sj",
@@ -33327,7 +33327,7 @@
     {
       "name": "gameapi/edtools/edrtlall.cpp.o",
       "source": "src/gameapi/edtools/edrtlall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlall.o",
       "functions": [
         {
           "name": "_ZL13edrtlSaveUndov",
@@ -33558,7 +33558,7 @@
     {
       "name": "gameapi/edtools/edrtlcallbacks.cpp.o",
       "source": "src/gameapi/edtools/edrtlcallbacks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlcallbacks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlcallbacks.o",
       "functions": [
         {
           "name": "_ZL9edrtlUndov",
@@ -33853,7 +33853,7 @@
     {
       "name": "gameapi/edtools/edsplines.cpp.o",
       "source": "src/gameapi/edtools/edsplines.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edsplines.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edsplines.o",
       "functions": [
         {
           "name": "_Z12SplineLengthP11nugspline_si",
@@ -34284,7 +34284,7 @@
     {
       "name": "gameapi/edtools/edstubs.cpp.o",
       "source": "src/gameapi/edtools/edstubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edstubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edstubs.o",
       "functions": [
         {
           "name": "edanimRegisterBaseScene",
@@ -34395,7 +34395,7 @@
     {
       "name": "gameapi/edtools/edtoolsall.cpp.o",
       "source": "src/gameapi/edtools/edtoolsall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall.o",
       "functions": [
         {
           "name": "_Z24edanimPlayerAnimDistancei",
@@ -36738,7 +36738,7 @@
     {
       "name": "gameapi/edtools/edtoolsall_plain.cpp.o",
       "source": "src/gameapi/edtools/edtoolsall_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_plain.o",
       "functions": [
         {
           "name": "edanimParticleDestroy",
@@ -38697,7 +38697,7 @@
     {
       "name": "gameapi/edtools/edtoolsall_stubs.cpp.o",
       "source": "src/gameapi/edtools/edtoolsall_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_stubs.o",
       "functions": [
         {
           "name": "_Z24edpartLookupDebrisEffectPc",
@@ -38784,7 +38784,7 @@
     {
       "name": "gameapi/edtools/edui.c.o",
       "source": "src/gameapi/edtools/edui.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edui.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edui.o",
       "functions": [
         {
           "name": "eduicbInteractSel",
@@ -39191,7 +39191,7 @@
     {
       "name": "gameapi/edtools/edui_fnt.cpp.o",
       "source": "src/gameapi/edtools/edui_fnt.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edui_fnt.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/edui_fnt.o",
       "functions": [
         {
           "name": "_ZL14eduiFntPrintExPviiiPcz",
@@ -39214,7 +39214,7 @@
     {
       "name": "gameapi/gui/apimenu.cpp.o",
       "source": "src/gameapi/gui/apimenu.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/apimenu.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameapi/apimenu.o",
       "functions": [
         {
           "name": "_ZL17MenuInitHowToPlayP6MENU_s",
@@ -39509,7 +39509,7 @@
     {
       "name": "gameframework/saveload.cpp.o",
       "source": "src/gameframework/saveload.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameframework/saveload.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameframework/saveload.o",
       "functions": [
         {
           "name": "_Z8slotnamei",
@@ -39620,7 +39620,7 @@
     {
       "name": "gameframework/savesystem.cpp.o",
       "source": "src/gameframework/savesystem.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameframework/savesystem.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gameframework/savesystem.o",
       "functions": [
         {
           "name": "SaveSystemInitialise",
@@ -39659,7 +39659,7 @@
     {
       "name": "gamelib/NewTerrain.cpp.o",
       "source": "src/gamelib/NewTerrain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/NewTerrain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/NewTerrain.o",
       "functions": [
         {
           "name": "_Z18NuVecCheckForSNANsP7nuvec_s",
@@ -39674,7 +39674,7 @@
     {
       "name": "gamelib/crc/crc.cpp.o",
       "source": "src/gamelib/crc/crc.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/crc.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/crc.o",
       "functions": [
         {
           "name": "CRC_Init",
@@ -39697,7 +39697,7 @@
     {
       "name": "gamelib/nuwind/nuwind.cpp.o",
       "source": "src/gamelib/nuwind/nuwind.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/nuwind.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/nuwind.o",
       "functions": [
         {
           "name": "NuWindInitialise",
@@ -39710,9 +39710,80 @@
       ]
     },
     {
+      "name": "gamelib/nuwind/nuwind_groups.cpp.o",
+      "source": "src/gamelib/nuwind/nuwind_groups.cpp",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/nuwind_groups.o",
+      "functions": [
+        {
+          "name": "NuWindRand",
+          "demangled_name": "NuWindRand",
+          "address": 2660766,
+          "offset": 1770798,
+          "size": 52,
+          "match_percent": 99.73333
+        },
+        {
+          "name": "NuWindInit",
+          "demangled_name": "NuWindInit",
+          "address": 3171277,
+          "offset": 2281309,
+          "size": 107,
+          "match_percent": 99.77778
+        },
+        {
+          "name": "_Z17NuWindAllocateGrpv",
+          "demangled_name": "NuWindAllocateGrp()",
+          "address": 3171384,
+          "offset": 2281416,
+          "size": 119,
+          "match_percent": 99.861115
+        },
+        {
+          "name": "NuWindCreateMtx",
+          "demangled_name": "NuWindCreateMtx",
+          "address": 3171523,
+          "offset": 2281555,
+          "size": 918,
+          "match_percent": 92.390625
+        },
+        {
+          "name": "NuWindUpdateArray",
+          "demangled_name": "NuWindUpdateArray",
+          "address": 3172441,
+          "offset": 2282473,
+          "size": 4927,
+          "match_percent": 55.79819
+        },
+        {
+          "name": "NuWindUpdate",
+          "demangled_name": "NuWindUpdate",
+          "address": 3177368,
+          "offset": 2287400,
+          "size": 78,
+          "match_percent": 99.958336
+        },
+        {
+          "name": "NuWindDraw",
+          "demangled_name": "NuWindDraw",
+          "address": 3177446,
+          "offset": 2287478,
+          "size": 589,
+          "match_percent": 84.145454
+        },
+        {
+          "name": "NuWindSetup",
+          "demangled_name": "NuWindSetup",
+          "address": 3178035,
+          "offset": 2288067,
+          "size": 84,
+          "match_percent": 99.85714
+        }
+      ]
+    },
+    {
       "name": "gamelib/util/AndroidOBBUtils.cpp.o",
       "source": "src/gamelib/util/AndroidOBBUtils.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/AndroidOBBUtils.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/AndroidOBBUtils.o",
       "functions": [
         {
           "name": "_ZN15AndroidOBBUtils17LookupPackagePathEPcN26NuFileDeviceAndroidOBBType1TE",
@@ -39720,7 +39791,7 @@
           "address": 984592,
           "offset": 94624,
           "size": 1139,
-          "match_percent": 1.360544
+          "match_percent": 8.17687
         },
         {
           "name": "_ZN15AndroidOBBUtils16InitPackagePathsEv",
@@ -39728,7 +39799,7 @@
           "address": 985744,
           "offset": 95776,
           "size": 77,
-          "match_percent": 20.625
+          "match_percent": 99.875
         },
         {
           "name": "_ZN15AndroidOBBUtils8OpenFileEPKc",
@@ -39736,14 +39807,14 @@
           "address": 985824,
           "offset": 95856,
           "size": 137,
-          "match_percent": 9.268292
+          "match_percent": 39.853657
         }
       ]
     },
     {
       "name": "gamelib/util/CRC16.cpp.o",
       "source": "src/gamelib/util/CRC16.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16.o",
       "functions": [
         {
           "name": "_ZN5CRC16C1Ev",
@@ -39782,7 +39853,7 @@
     {
       "name": "gamelib/util/CRC16_plain.cpp.o",
       "source": "src/gamelib/util/CRC16_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16_plain.o",
       "functions": [
         {
           "name": "CRC_Process",
@@ -39821,7 +39892,7 @@
     {
       "name": "gamelib/util/Ftp.cpp.o",
       "source": "src/gamelib/util/Ftp.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp.o",
       "functions": [
         {
           "name": "_ZN13NetFtpManager7ReceiveE10NetMessagehRK10NetAddress",
@@ -40020,7 +40091,7 @@
     {
       "name": "gamelib/util/Ftp_stubs.cpp.o",
       "source": "src/gamelib/util/Ftp_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp_stubs.o",
       "functions": [
         {
           "name": "_ZN7FtpFile6AcceptEv",
@@ -40035,7 +40106,7 @@
     {
       "name": "gamelib/util/Network.cpp.o",
       "source": "src/gamelib/util/Network.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Network.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/Network.o",
       "functions": [
         {
           "name": "_Z16NetworkSyncPausev",
@@ -40850,7 +40921,7 @@
     {
       "name": "gamelib/util/Network_stubs.cpp.o",
       "source": "src/gamelib/util/Network_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Network_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/Network_stubs.o",
       "functions": [
         {
           "name": "_ZN10NetMessage10RaiseErrorEv",
@@ -40889,7 +40960,7 @@
     {
       "name": "gamelib/util/TouchHacks.cpp.o",
       "source": "src/gamelib/util/TouchHacks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/TouchHacks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/TouchHacks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_TouchHacks.cpp",
@@ -41256,7 +41327,7 @@
     {
       "name": "gamelib/util/Transporter.cpp.o",
       "source": "src/gamelib/util/Transporter.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Transporter.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/Transporter.o",
       "functions": [
         {
           "name": "_ZN14NetTransporter11AddListenerEP20NetListenerInterfacehPc",
@@ -41383,7 +41454,7 @@
     {
       "name": "gamelib/util/V2SessionManager.cpp.o",
       "source": "src/gamelib/util/V2SessionManager.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/V2SessionManager.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/V2SessionManager.o",
       "functions": [
         {
           "name": "_ZN16V2SessionManager13VerifyStringsEPPcS1_iS0_",
@@ -41462,7 +41533,7 @@
     {
       "name": "gamelib/util/VirtualStackAllocator.cpp.o",
       "source": "src/gamelib/util/VirtualStackAllocator.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/VirtualStackAllocator.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/VirtualStackAllocator.o",
       "functions": [
         {
           "name": "_ZN21VirtualStackAllocatorC1Ev",
@@ -41557,7 +41628,7 @@
     {
       "name": "gamelib/util/gamelib_util_misc.cpp.o",
       "source": "src/gamelib/util/gamelib_util_misc.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/gamelib_util_misc.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_gamelib/gamelib_util_misc.o",
       "functions": [
         {
           "name": "_ZN10TouchHacks9TintStackC1Ev",
@@ -41644,13 +41715,13 @@
     {
       "name": "globals.cpp.o",
       "source": "src/globals.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_root/globals.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_root/globals.o",
       "functions": []
     },
     {
-      "name": "java/jni_stub.cpp.o",
-      "source": "src/java/jni_stub.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_root/jni_stub.o",
+      "name": "java/android.cpp.o",
+      "source": "src/java/android.cpp",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_root/android.o",
       "functions": [
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetScreenDimesions",
@@ -41658,7 +41729,15 @@
           "address": 978544,
           "offset": 88576,
           "size": 67,
-          "match_percent": 23.75
+          "match_percent": 99.875
+        },
+        {
+          "name": "_Z11AndroidMainPv",
+          "demangled_name": "AndroidMain(void*)",
+          "address": 978624,
+          "offset": 88656,
+          "size": 394,
+          "match_percent": 82.84694
         },
         {
           "name": "JNI_OnLoad",
@@ -41666,7 +41745,7 @@
           "address": 979024,
           "offset": 89056,
           "size": 119,
-          "match_percent": 10.555555
+          "match_percent": 87.69444
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeCacheJNIVars",
@@ -41674,7 +41753,7 @@
           "address": 979152,
           "offset": 89184,
           "size": 47,
-          "match_percent": 29.23077
+          "match_percent": 99.84615
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetObbInfo",
@@ -41682,7 +41761,7 @@
           "address": 979200,
           "offset": 89232,
           "size": 182,
-          "match_percent": 6.0
+          "match_percent": 99.844444
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetCaps",
@@ -41690,7 +41769,7 @@
           "address": 979392,
           "offset": 89424,
           "size": 24,
-          "match_percent": 21.666666
+          "match_percent": 99.666664
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetPaths",
@@ -41698,7 +41777,7 @@
           "address": 979424,
           "offset": 89456,
           "size": 192,
-          "match_percent": 4.680851
+          "match_percent": 99.93617
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetLanguage",
@@ -41706,7 +41785,7 @@
           "address": 979616,
           "offset": 89648,
           "size": 122,
-          "match_percent": 7.333334
+          "match_percent": 99.933334
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetAndroidVersion",
@@ -41714,7 +41793,7 @@
           "address": 979744,
           "offset": 89776,
           "size": 122,
-          "match_percent": 7.333334
+          "match_percent": 99.933334
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetAssetManager",
@@ -41722,7 +41801,7 @@
           "address": 979872,
           "offset": 89904,
           "size": 76,
-          "match_percent": 11.0
+          "match_percent": 99.9
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnCreate",
@@ -41730,7 +41809,7 @@
           "address": 979952,
           "offset": 89984,
           "size": 43,
-          "match_percent": 34.545456
+          "match_percent": 99.90909
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnStart",
@@ -41738,7 +41817,7 @@
           "address": 980000,
           "offset": 90032,
           "size": 255,
-          "match_percent": 5.20548
+          "match_percent": 99.87671
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnResume",
@@ -41746,7 +41825,7 @@
           "address": 980256,
           "offset": 90288,
           "size": 155,
-          "match_percent": 8.636364
+          "match_percent": 99.86364
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnPause",
@@ -41754,7 +41833,7 @@
           "address": 980416,
           "offset": 90448,
           "size": 155,
-          "match_percent": 8.636364
+          "match_percent": 99.86364
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnStop",
@@ -41762,7 +41841,7 @@
           "address": 980576,
           "offset": 90608,
           "size": 155,
-          "match_percent": 8.636364
+          "match_percent": 99.86364
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnKeyUp",
@@ -41770,7 +41849,7 @@
           "address": 980736,
           "offset": 90768,
           "size": 34,
-          "match_percent": 33.0
+          "match_percent": 99.9
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnKeyDown",
@@ -41778,7 +41857,7 @@
           "address": 980784,
           "offset": 90816,
           "size": 34,
-          "match_percent": 33.0
+          "match_percent": 99.9
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnTouchDown",
@@ -41786,7 +41865,7 @@
           "address": 980832,
           "offset": 90864,
           "size": 74,
-          "match_percent": 19.411764
+          "match_percent": 99.94118
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnTouchUp",
@@ -41794,7 +41873,7 @@
           "address": 980912,
           "offset": 90944,
           "size": 65,
-          "match_percent": 20.625
+          "match_percent": 99.9375
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnTouchMove",
@@ -41802,7 +41881,7 @@
           "address": 980992,
           "offset": 91024,
           "size": 74,
-          "match_percent": 19.411764
+          "match_percent": 99.94118
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeUpdateGamepadAxisValues",
@@ -41810,7 +41889,7 @@
           "address": 981072,
           "offset": 91104,
           "size": 98,
-          "match_percent": 16.5
+          "match_percent": 99.95
         },
         {
           "name": "Java_com_tt_tech_CheckGamepadStatus_nativeSetGamePadConnected",
@@ -41818,7 +41897,7 @@
           "address": 981184,
           "offset": 91216,
           "size": 40,
-          "match_percent": 31.666666
+          "match_percent": 99.916664
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeOnSensorUpdate",
@@ -41826,7 +41905,7 @@
           "address": 981232,
           "offset": 91264,
           "size": 70,
-          "match_percent": 23.75
+          "match_percent": 99.9375
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetSurface",
@@ -41834,7 +41913,7 @@
           "address": 981312,
           "offset": 91344,
           "size": 442,
-          "match_percent": 3.362832
+          "match_percent": 89.74336
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetManufacturer",
@@ -41842,7 +41921,7 @@
           "address": 981760,
           "offset": 91792,
           "size": 122,
-          "match_percent": 7.333334
+          "match_percent": 99.933334
         },
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetModel",
@@ -41850,14 +41929,20 @@
           "address": 981888,
           "offset": 91920,
           "size": 122,
-          "match_percent": 7.333334
+          "match_percent": 99.933334
         }
       ]
     },
     {
+      "name": "java/android_state.cpp.o",
+      "source": "src/java/android_state.cpp",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_root/android_state.o",
+      "functions": []
+    },
+    {
       "name": "legoapi/actions/character/simpletons.cpp.o",
       "source": "src/legoapi/actions/character/simpletons.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/simpletons.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/simpletons.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_simpletons.cpp",
@@ -41968,7 +42053,7 @@
     {
       "name": "legoapi/actions/character/snake.cpp.o",
       "source": "src/legoapi/actions/character/snake.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/snake.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/snake.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_snake.cpp",
@@ -42047,7 +42132,7 @@
     {
       "name": "legoapi/actions/character/specialmoves.cpp.o",
       "source": "src/legoapi/actions/character/specialmoves.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/specialmoves.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/specialmoves.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_specialmoves.cpp",
@@ -42174,7 +42259,7 @@
     {
       "name": "legoapi/actions/character/speederchase.cpp.o",
       "source": "src/legoapi/actions/character/speederchase.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_speederchase.cpp",
@@ -42381,7 +42466,7 @@
     {
       "name": "legoapi/actions/character/speederchase_stubs.cpp.o",
       "source": "src/legoapi/actions/character/speederchase_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase_stubs.o",
       "functions": [
         {
           "name": "_Z10getPodRolli",
@@ -42396,7 +42481,7 @@
     {
       "name": "legoapi/actions/character/starwars.cpp.o",
       "source": "src/legoapi/actions/character/starwars.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/starwars.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/starwars.o",
       "functions": [
         {
           "name": "_ZL24StarWars_PrepareObstacleP10AIPACKET_sP11APIOBJECT_si",
@@ -42515,7 +42600,7 @@
     {
       "name": "legoapi/actions/character/streaks.cpp.o",
       "source": "src/legoapi/actions/character/streaks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/streaks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/streaks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_streaks.cpp",
@@ -42562,7 +42647,7 @@
     {
       "name": "legoapi/actions/character/suit.cpp.o",
       "source": "src/legoapi/actions/character/suit.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/suit.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/suit.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_suit.cpp",
@@ -42641,7 +42726,7 @@
     {
       "name": "legoapi/actions/character/tagging.cpp.o",
       "source": "src/legoapi/actions/character/tagging.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tagging.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/tagging.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_tagging.cpp",
@@ -42736,7 +42821,7 @@
     {
       "name": "legoapi/actions/character/transform.cpp.o",
       "source": "src/legoapi/actions/character/transform.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/transform.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/transform.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_transform.cpp",
@@ -42823,7 +42908,7 @@
     {
       "name": "legoapi/actions/combat/fighting.cpp.o",
       "source": "src/legoapi/actions/combat/fighting.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/fighting.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/fighting.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_fighting.cpp",
@@ -42942,7 +43027,7 @@
     {
       "name": "legoapi/actions/combat/hits.cpp.o",
       "source": "src/legoapi/actions/combat/hits.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hits.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/hits.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_hits.cpp",
@@ -43125,7 +43210,7 @@
     {
       "name": "legoapi/actions/combat/rope.cpp.o",
       "source": "src/legoapi/actions/combat/rope.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/rope.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/rope.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_rope.cpp",
@@ -43156,7 +43241,7 @@
     {
       "name": "legoapi/actions/combat/shovesys.cpp.o",
       "source": "src/legoapi/actions/combat/shovesys.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shovesys.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/shovesys.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shovesys.cpp",
@@ -43195,7 +43280,7 @@
     {
       "name": "legoapi/actions/combat/whip.cpp.o",
       "source": "src/legoapi/actions/combat/whip.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/whip.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/whip.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_whip.cpp",
@@ -43226,7 +43311,7 @@
     {
       "name": "legoapi/actions/movement/carrying.cpp.o",
       "source": "src/legoapi/actions/movement/carrying.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/carrying.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/carrying.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_carrying.cpp",
@@ -43345,7 +43430,7 @@
     {
       "name": "legoapi/actions/movement/climbing.cpp.o",
       "source": "src/legoapi/actions/movement/climbing.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/climbing.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/climbing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_climbing.cpp",
@@ -43432,7 +43517,7 @@
     {
       "name": "legoapi/actions/movement/dropinout.cpp.o",
       "source": "src/legoapi/actions/movement/dropinout.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/dropinout.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/dropinout.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_dropinout.cpp",
@@ -43495,7 +43580,7 @@
     {
       "name": "legoapi/actions/movement/jumping.cpp.o",
       "source": "src/legoapi/actions/movement/jumping.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/jumping.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/jumping.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_jumping.cpp",
@@ -43590,7 +43675,7 @@
     {
       "name": "legoapi/actions/movement/pushblocks.cpp.o",
       "source": "src/legoapi/actions/movement/pushblocks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/pushblocks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/pushblocks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_pushblocks.cpp",
@@ -43693,7 +43778,7 @@
     {
       "name": "legoapi/actions/movement/pushing.cpp.o",
       "source": "src/legoapi/actions/movement/pushing.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/pushing.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/pushing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_pushing.cpp",
@@ -43788,7 +43873,7 @@
     {
       "name": "legoapi/ai/core/ai_sys.cpp.o",
       "source": "src/legoapi/ai/core/ai_sys.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys.o",
       "functions": [
         {
           "name": "_ZL15Collide2ObjectsP11APIOBJECT_sS0_",
@@ -43923,7 +44008,7 @@
     {
       "name": "legoapi/ai/core/ai_sys_stubs.cpp.o",
       "source": "src/legoapi/ai/core/ai_sys_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys_stubs.o",
       "functions": [
         {
           "name": "AiRndrLine3d",
@@ -44067,7 +44152,7 @@
           "address": 4099904,
           "offset": 3209936,
           "size": 6313,
-          "match_percent": 12.587516
+          "match_percent": 14.658301
         },
         {
           "name": "AISysProcess",
@@ -44538,7 +44623,7 @@
     {
       "name": "legoapi/ai/core/aisysall.cpp.o",
       "source": "src/legoapi/ai/core/aisysall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aisysall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/aisysall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_aisysall.cpp",
@@ -44586,7 +44671,7 @@
           "address": 4150864,
           "offset": 3260896,
           "size": 6421,
-          "match_percent": 11.208528
+          "match_percent": 12.647286
         },
         {
           "name": "_Z33AIMoveToDestinationAvoidingCameraP7AISYS_sP10AIPACKET_sP11APIOBJECT_si",
@@ -44657,7 +44742,7 @@
     {
       "name": "legoapi/ai/core/gameai.cpp.o",
       "source": "src/legoapi/ai/core/gameai.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameai.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gameai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameai.cpp",
@@ -44720,7 +44805,7 @@
     {
       "name": "legoapi/ai/core/legoai.cpp.o",
       "source": "src/legoapi/ai/core/legoai.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoai.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/legoai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_legoai.cpp",
@@ -44743,7 +44828,7 @@
     {
       "name": "legoapi/ai/game/aipathcnxhelper.cpp.o",
       "source": "src/legoapi/ai/game/aipathcnxhelper.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aipathcnxhelper.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/aipathcnxhelper.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_aipathcnxhelper.cpp",
@@ -44862,7 +44947,7 @@
     {
       "name": "legoapi/ai/game/aitrigger.cpp.o",
       "source": "src/legoapi/ai/game/aitrigger.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_aitrigger.cpp",
@@ -44909,7 +44994,7 @@
     {
       "name": "legoapi/ai/game/aitrigger_stubs.cpp.o",
       "source": "src/legoapi/ai/game/aitrigger_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger_stubs.o",
       "functions": [
         {
           "name": "_Z18AITriggerSetCreateP17AITRIGGERSETSYS_sP9FLOWBOX_s",
@@ -44924,7 +45009,7 @@
     {
       "name": "legoapi/ai/game/creature.cpp.o",
       "source": "src/legoapi/ai/game/creature.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/creature.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/creature.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_creature.cpp",
@@ -45019,7 +45104,7 @@
     {
       "name": "legoapi/ai/game/gameantinode.cpp.o",
       "source": "src/legoapi/ai/game/gameantinode.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameantinode.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gameantinode.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameantinode.cpp",
@@ -45210,7 +45295,7 @@
     {
       "name": "legoapi/ai/game/lsw_hub_ai.cpp.o",
       "source": "src/legoapi/ai/game/lsw_hub_ai.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_lsw_hub_ai.cpp",
@@ -45297,7 +45382,7 @@
     {
       "name": "legoapi/ai/game/lsw_hub_ai_stubs.cpp.o",
       "source": "src/legoapi/ai/game/lsw_hub_ai_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai_stubs.o",
       "functions": [
         {
           "name": "_Z23Condition_InHubAreaInitP7AISYS_sPcP10AISCRIPT_s",
@@ -45312,7 +45397,7 @@
     {
       "name": "legoapi/ai/game/misc_a_game.cpp.o",
       "source": "src/legoapi/ai/game/misc_a_game.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/misc_a_game.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/misc_a_game.o",
       "functions": [
         {
           "name": "_ZL17CreatePodRaceMineP7nuvec_s",
@@ -45359,7 +45444,7 @@
     {
       "name": "legoapi/ai/game/starwars_gameai.cpp.o",
       "source": "src/legoapi/ai/game/starwars_gameai.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/starwars_gameai.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/starwars_gameai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_starwars_gameai.cpp",
@@ -45414,7 +45499,7 @@
     {
       "name": "legoapi/audio/audio.cpp.o",
       "source": "src/legoapi/audio/audio.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/audio.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/audio.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_audio.cpp",
@@ -45589,7 +45674,7 @@
     {
       "name": "legoapi/audio/gamelib_ogg.cpp.o",
       "source": "src/legoapi/audio/gamelib_ogg.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_ogg.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_ogg.o",
       "functions": [
         {
           "name": "_ZL10RemoveDataP9nuqthdr_sPci",
@@ -45652,7 +45737,7 @@
     {
       "name": "legoapi/audio/radio.cpp.o",
       "source": "src/legoapi/audio/radio.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/radio.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/radio.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_radio.cpp",
@@ -45691,7 +45776,7 @@
     {
       "name": "legoapi/audio/sfx.cpp.o",
       "source": "src/legoapi/audio/sfx.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/sfx.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/sfx.o",
       "functions": [
         {
           "name": "_ZL15CheckMusicOtherv",
@@ -46330,7 +46415,7 @@
     {
       "name": "legoapi/audio/sfx_callbacks.cpp.o",
       "source": "src/legoapi/audio/sfx_callbacks.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/sfx_callbacks.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/sfx_callbacks.o",
       "functions": [
         {
           "name": "SetAPIObjPlaySfxByIdFn",
@@ -46345,7 +46430,7 @@
     {
       "name": "legoapi/audio/specialsfx.cpp.o",
       "source": "src/legoapi/audio/specialsfx.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/specialsfx.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/specialsfx.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_specialsfx.cpp",
@@ -46440,7 +46525,7 @@
     {
       "name": "legoapi/characters/core/character.cpp.o",
       "source": "src/legoapi/characters/core/character.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/character.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/character.o",
       "functions": [
         {
           "name": "_ZL24DrawCharacterAttachmentsP12GameObject_sP7numtx_s",
@@ -46576,7 +46661,7 @@
           "address": 3999075,
           "offset": 3109107,
           "size": 5289,
-          "match_percent": 11.805402
+          "match_percent": 23.10734
         },
         {
           "name": "ConfigureCharacterList",
@@ -46695,7 +46780,7 @@
     {
       "name": "legoapi/characters/core/characters.cpp.o",
       "source": "src/legoapi/characters/core/characters.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/characters.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/characters.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_characters.cpp",
@@ -47070,7 +47155,7 @@
     {
       "name": "legoapi/characters/core/charconfig.cpp.o",
       "source": "src/legoapi/characters/core/charconfig.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charconfig.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/charconfig.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charconfig.cpp",
@@ -47165,7 +47250,7 @@
     {
       "name": "legoapi/characters/core/playeritems.cpp.o",
       "source": "src/legoapi/characters/core/playeritems.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/playeritems.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/playeritems.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_playeritems.cpp",
@@ -47308,7 +47393,7 @@
     {
       "name": "legoapi/characters/core/players.cpp.o",
       "source": "src/legoapi/characters/core/players.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/players.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/players.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_players.cpp",
@@ -47851,7 +47936,7 @@
     {
       "name": "legoapi/characters/motion/animation.cpp.o",
       "source": "src/legoapi/characters/motion/animation.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/animation.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/animation.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_animation.cpp",
@@ -47922,7 +48007,7 @@
     {
       "name": "legoapi/characters/motion/camera.cpp.o",
       "source": "src/legoapi/characters/motion/camera.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/camera.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/camera.o",
       "functions": [
         {
           "name": "_Z12KeepOnScreenP12GameObject_s",
@@ -48201,7 +48286,7 @@
     {
       "name": "legoapi/characters/motion/charpivot.cpp.o",
       "source": "src/legoapi/characters/motion/charpivot.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charpivot.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/charpivot.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charpivot.cpp",
@@ -48232,7 +48317,7 @@
     {
       "name": "legoapi/characters/motion/charplatforms.cpp.o",
       "source": "src/legoapi/characters/motion/charplatforms.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charplatforms.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/charplatforms.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charplatforms.cpp",
@@ -48335,7 +48420,7 @@
     {
       "name": "legoapi/characters/motion/charshadows.cpp.o",
       "source": "src/legoapi/characters/motion/charshadows.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charshadows.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/charshadows.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charshadows.cpp",
@@ -48374,7 +48459,7 @@
     {
       "name": "legoapi/characters/motion/chris.cpp.o",
       "source": "src/legoapi/characters/motion/chris.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/chris.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/chris.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_chris.cpp",
@@ -48565,7 +48650,7 @@
     {
       "name": "legoapi/characters/motion/chris_stubs.cpp.o",
       "source": "src/legoapi/characters/motion/chris_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/chris_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/chris_stubs.o",
       "functions": [
         {
           "name": "_Z18ChrisAnakinAUpdateP11WORLDINFO_s",
@@ -48604,7 +48689,7 @@
     {
       "name": "legoapi/characters/motion/gameanim.cpp.o",
       "source": "src/legoapi/characters/motion/gameanim.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameanim.cpp",
@@ -49515,7 +49600,7 @@
     {
       "name": "legoapi/characters/motion/gameanim_modes.cpp.o",
       "source": "src/legoapi/characters/motion/gameanim_modes.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim_modes.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim_modes.o",
       "functions": [
         {
           "name": "SetAnimBlendMode",
@@ -49538,7 +49623,7 @@
     {
       "name": "legoapi/characters/motion/move.cpp.o",
       "source": "src/legoapi/characters/motion/move.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/move.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/move.o",
       "functions": [
         {
           "name": "_ZL11IsAFallAnimi",
@@ -49570,7 +49655,7 @@
           "address": 1055232,
           "offset": 165264,
           "size": 3219,
-          "match_percent": 13.546512
+          "match_percent": 14.796512
         },
         {
           "name": "_Z14MoveGameCameraP12GAMECAMERA_s",
@@ -49578,7 +49663,7 @@
           "address": 1110000,
           "offset": 220032,
           "size": 23545,
-          "match_percent": 0.0
+          "match_percent": 3.868896
         },
         {
           "name": "_ZL17BigJump_EndOfLandP12GameObject_s",
@@ -49946,7 +50031,7 @@
           "address": 1470672,
           "offset": 580704,
           "size": 14602,
-          "match_percent": 1.033016
+          "match_percent": 4.918413
         },
         {
           "name": "_Z9FloatCodeP12GameObject_s",
@@ -50410,7 +50495,7 @@
           "address": 5171920,
           "offset": 4281952,
           "size": 8829,
-          "match_percent": 40.985065
+          "match_percent": 41.482853
         },
         {
           "name": "_Z13Hang_MoveCodeP12GameObject_s",
@@ -50505,7 +50590,7 @@
     {
       "name": "legoapi/core/config/cheat.cpp.o",
       "source": "src/legoapi/core/config/cheat.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cheat.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/cheat.o",
       "functions": [
         {
           "name": "_Z16Cheat_FindByNamePc",
@@ -50552,7 +50637,7 @@
     {
       "name": "legoapi/core/config/cheats.cpp.o",
       "source": "src/legoapi/core/config/cheats.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cheats.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/cheats.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_cheats.cpp",
@@ -50663,7 +50748,7 @@
     {
       "name": "legoapi/core/config/config.cpp.o",
       "source": "src/legoapi/core/config/config.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/config.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/config.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_config.cpp",
@@ -50686,7 +50771,7 @@
     {
       "name": "legoapi/core/config/saveload.cpp.o",
       "source": "src/legoapi/core/config/saveload.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/saveload.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/saveload.o",
       "functions": [
         {
           "name": "_Z26LevelScriptReStoreProgressP11WORLDINFO_sP20LEVELSCRIPTPROCESS_s",
@@ -51117,7 +51202,7 @@
     {
       "name": "legoapi/core/input/gamepads.cpp.o",
       "source": "src/legoapi/core/input/gamepads.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamepads.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gamepads.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamepads.cpp",
@@ -51436,7 +51521,7 @@
     {
       "name": "legoapi/core/input/input.cpp.o",
       "source": "src/legoapi/core/input/input.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/input.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/input.o",
       "functions": [
         {
           "name": "_ZN31ClickToPressStartGestureTracker7OnClickER12GameObject_sR11TouchHolder",
@@ -51451,7 +51536,7 @@
     {
       "name": "legoapi/core/input/qrand.cpp.o",
       "source": "src/legoapi/core/input/qrand.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/qrand.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/qrand.o",
       "functions": [
         {
           "name": "_Z5qrandv",
@@ -51466,7 +51551,7 @@
     {
       "name": "legoapi/core/input/timer.cpp.o",
       "source": "src/legoapi/core/input/timer.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/timer.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/timer.o",
       "functions": [
         {
           "name": "_Z10ResetTimerP7TIMER_sf",
@@ -51489,7 +51574,7 @@
     {
       "name": "legoapi/core/input/timing.cpp.o",
       "source": "src/legoapi/core/input/timing.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/timing.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/timing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_timing.cpp",
@@ -51505,7 +51590,7 @@
           "address": 2777120,
           "offset": 1887152,
           "size": 86,
-          "match_percent": 19.09091
+          "match_percent": 99.954544
         },
         {
           "name": "_Z10TimingBarsv",
@@ -51544,7 +51629,7 @@
     {
       "name": "legoapi/core/net/netplay.cpp.o",
       "source": "src/legoapi/core/net/netplay.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/netplay.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/netplay.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_netplay.cpp",
@@ -51607,7 +51692,7 @@
     {
       "name": "legoapi/core/net/network.cpp.o",
       "source": "src/legoapi/core/net/network.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/network.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/network.o",
       "functions": [
         {
           "name": "WithinConnection",
@@ -51790,7 +51875,7 @@
     {
       "name": "legoapi/core/startup/game.cpp.o",
       "source": "src/legoapi/core/startup/game.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/game.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/game.o",
       "functions": [
         {
           "name": "_Z7NewGamev",
@@ -51853,7 +51938,7 @@
     {
       "name": "legoapi/core/startup/main.cpp.o",
       "source": "src/legoapi/core/startup/main.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/main.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/main.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_main.cpp",
@@ -51908,7 +51993,7 @@
     {
       "name": "legoapi/core/startup/startup.cpp.o",
       "source": "src/legoapi/core/startup/startup.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/startup.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/startup.o",
       "functions": [
         {
           "name": "_Z16ParseCommandLinev",
@@ -51923,7 +52008,7 @@
     {
       "name": "legoapi/core/startup/virtual.cpp.o",
       "source": "src/legoapi/core/startup/virtual.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/virtual.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/virtual.o",
       "functions": [
         {
           "name": "_ZN29VirtualControlDPad_LockButton7ProcessEf",
@@ -52074,7 +52159,7 @@
     {
       "name": "legoapi/cutscenes/cutscene.cpp.o",
       "source": "src/legoapi/cutscenes/cutscene.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene.o",
       "functions": [
         {
           "name": "_ZL21CutScenePlayer_AcceptP18CUTSCENEPLAYERCLIP",
@@ -52329,7 +52414,7 @@
     {
       "name": "legoapi/cutscenes/cutscene_find.cpp.o",
       "source": "src/legoapi/cutscenes/cutscene_find.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_find.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_find.o",
       "functions": [
         {
           "name": "_Z13CutScene_FindP6CUTSYSPc",
@@ -52344,7 +52429,7 @@
     {
       "name": "legoapi/cutscenes/cutscene_stubs.cpp.o",
       "source": "src/legoapi/cutscenes/cutscene_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_stubs.o",
       "functions": [
         {
           "name": "SetForceScenePlayBack",
@@ -52655,7 +52740,7 @@
     {
       "name": "legoapi/cutscenes/cutscenes.cpp.o",
       "source": "src/legoapi/cutscenes/cutscenes.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscenes.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/cutscenes.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_cutscenes.cpp",
@@ -52934,7 +53019,7 @@
     {
       "name": "legoapi/cutscenes/gcutscn.cpp.o",
       "source": "src/legoapi/cutscenes/gcutscn.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gcutscn.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gcutscn.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gcutscn.cpp",
@@ -53093,7 +53178,7 @@
     {
       "name": "legoapi/cutscenes/minicamcut.cpp.o",
       "source": "src/legoapi/cutscenes/minicamcut.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/minicamcut.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/minicamcut.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_minicamcut.cpp",
@@ -53180,7 +53265,7 @@
     {
       "name": "legoapi/gizmo/base/gizactions.cpp.o",
       "source": "src/legoapi/gizmo/base/gizactions.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizactions.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizactions.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizactions.cpp",
@@ -53227,7 +53312,7 @@
     {
       "name": "legoapi/gizmo/base/gizflow.cpp.o",
       "source": "src/legoapi/gizmo/base/gizflow.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizflow.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizflow.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizflow.cpp",
@@ -53346,7 +53431,7 @@
     {
       "name": "legoapi/gizmo/base/gizmessage.cpp.o",
       "source": "src/legoapi/gizmo/base/gizmessage.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmessage.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmessage.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmessage.cpp",
@@ -53425,7 +53510,7 @@
     {
       "name": "legoapi/gizmo/base/gizmo.cpp.o",
       "source": "src/legoapi/gizmo/base/gizmo.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmo.cpp",
@@ -54504,7 +54589,7 @@
     {
       "name": "legoapi/gizmo/base/gizmo_sys.cpp.o",
       "source": "src/legoapi/gizmo/base/gizmo_sys.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo_sys.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo_sys.o",
       "functions": [
         {
           "name": "_Z24Hub_LoadAndFixUpMiniKitsP11WORLDINFO_sP9variptr_uS2_",
@@ -54631,7 +54716,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizactions.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizactions.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizactions.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizactions.o",
       "functions": [
         {
           "name": "_Z23Action_GameFollowPlayerP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPPciif",
@@ -55038,7 +55123,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizbuildits.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizbuildits.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizbuildits.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizbuildits.o",
       "functions": [
         {
           "name": "_ZL34GizBuildIt_CanStartBuildingFn_GameP12GIZBUILDIT_sP12GameObject_s",
@@ -55221,7 +55306,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizforce.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizforce.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizforce.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizforce.o",
       "functions": [
         {
           "name": "_ZL21GizForceSFX_returnsfxP8nufpar_s",
@@ -55396,7 +55481,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizmopickups.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizmopickups.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizmopickups.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizmopickups.o",
       "functions": [
         {
           "name": "_ZL22GizmoPickups_Collide2DP12GameObject_s",
@@ -55563,7 +55648,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizobstacles.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizobstacles.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizobstacles.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizobstacles.o",
       "functions": [
         {
           "name": "_Z31GizObstacle_SetDefaultSFXFn_LSWPvP13GIZOBSTACLE_s",
@@ -55746,7 +55831,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizpanel.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizpanel.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizpanel.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizpanel.o",
       "functions": [
         {
           "name": "_ZL22GizPanel_CreateTerrainP10GIZPANEL_s",
@@ -55873,7 +55958,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizturrets.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizturrets.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizturrets.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizturrets.o",
       "functions": [
         {
           "name": "_Z16GizTurret_GetTgtP11GIZTURRET_sP7numtx_s",
@@ -55968,7 +56053,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_grabber.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_grabber.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grabber.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grabber.o",
       "functions": [
         {
           "name": "_Z18Grabber_GetGrabPosP9GRABBER_sP7numtx_s",
@@ -56023,7 +56108,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_grapples.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_grapples.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grapples.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grapples.o",
       "functions": [
         {
           "name": "_ZL25Grapple_FindNearestInListP7nuvec_sP9GRAPPLE_siP12GameObject_sPS2_Pf",
@@ -56126,7 +56211,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_hatmachine.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_hatmachine.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_hatmachine.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_hatmachine.o",
       "functions": [
         {
           "name": "_Z23HatMachines_InitTerrainP11WORLDINFO_s",
@@ -56181,7 +56266,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_lever.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_lever.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_lever.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_lever.o",
       "functions": [
         {
           "name": "_Z18Levers_InitTerrainP11WORLDINFO_s",
@@ -56252,7 +56337,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_newblowup.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_newblowup.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_newblowup.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_newblowup.o",
       "functions": [
         {
           "name": "_ZL20GizmoBlowUp_NoTargetP11WORLDINFO_sP12GameObject_s",
@@ -56347,7 +56432,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_spinner.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_spinner.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_spinner.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_spinner.o",
       "functions": [
         {
           "name": "_Z23GizSpinners_InitTerrainP11WORLDINFO_s",
@@ -56450,7 +56535,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_teleport.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_teleport.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_teleport.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_teleport.o",
       "functions": [
         {
           "name": "_ZN10TELEPORT_s22GetMechObjectInterfaceEv",
@@ -56529,7 +56614,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_tubes.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_tubes.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_tubes.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_tubes.o",
       "functions": [
         {
           "name": "_Z21Torpedo_UpdateJobbiesP12GameObject_s",
@@ -56664,7 +56749,7 @@
     {
       "name": "legoapi/gizmo/object/gizbombgen.cpp.o",
       "source": "src/legoapi/gizmo/object/gizbombgen.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizbombgen.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizbombgen.o",
       "functions": [
         {
           "name": "_Z9Mine_KillP6PART_si",
@@ -56687,7 +56772,7 @@
     {
       "name": "legoapi/gizmo/object/gizbuildit.cpp.o",
       "source": "src/legoapi/gizmo/object/gizbuildit.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildit.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildit.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizbuildit.cpp",
@@ -56766,7 +56851,7 @@
     {
       "name": "legoapi/gizmo/object/gizforce.cpp.o",
       "source": "src/legoapi/gizmo/object/gizforce.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizforce.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizforce.o",
       "functions": [
         {
           "name": "_Z8EndForceP12GameObject_si",
@@ -56837,7 +56922,7 @@
     {
       "name": "legoapi/gizmo/object/gizminicut.cpp.o",
       "source": "src/legoapi/gizmo/object/gizminicut.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizminicut.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizminicut.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizminicut.cpp",
@@ -56860,7 +56945,7 @@
     {
       "name": "legoapi/gizmo/object/gizmoblowups.cpp.o",
       "source": "src/legoapi/gizmo/object/gizmoblowups.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmoblowups.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmoblowups.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmoblowups.cpp",
@@ -57163,7 +57248,7 @@
     {
       "name": "legoapi/gizmo/object/gizmopickup.cpp.o",
       "source": "src/legoapi/gizmo/object/gizmopickup.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmopickup.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizmopickup.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmopickup.cpp",
@@ -57258,7 +57343,7 @@
     {
       "name": "legoapi/gizmo/object/gizmopickups.cpp.o",
       "source": "src/legoapi/gizmo/object/gizmopickups.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizmopickups.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizmopickups.o",
       "functions": [
         {
           "name": "_Z17InDoubleScoreZoneP12GameObject_s",
@@ -57313,7 +57398,7 @@
     {
       "name": "legoapi/gizmo/object/gizobstacle.cpp.o",
       "source": "src/legoapi/gizmo/object/gizobstacle.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacle.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacle.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizobstacle.cpp",
@@ -57336,7 +57421,7 @@
     {
       "name": "legoapi/gizmo/object/gizpanel.cpp.o",
       "source": "src/legoapi/gizmo/object/gizpanel.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizpanel.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizpanel.o",
       "functions": [
         {
           "name": "_Z14SetPanelLightsf",
@@ -57351,7 +57436,7 @@
     {
       "name": "legoapi/gizmo/object/gizportal.cpp.o",
       "source": "src/legoapi/gizmo/object/gizportal.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizportal.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizportal.o",
       "functions": [
         {
           "name": "_Z16PortalGameObjectP12GameObject_siisP8nugscn_s",
@@ -57374,7 +57459,7 @@
     {
       "name": "legoapi/gizmo/object/gizrandom.cpp.o",
       "source": "src/legoapi/gizmo/object/gizrandom.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizrandom.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizrandom.o",
       "functions": [
         {
           "name": "_Z10randyfloatv",
@@ -57405,7 +57490,7 @@
     {
       "name": "legoapi/gizmo/object/gizspecial.cpp.o",
       "source": "src/legoapi/gizmo/object/gizspecial.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizspecial.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizspecial.o",
       "functions": [
         {
           "name": "_Z19ReleaseAllTakeOversv",
@@ -57460,7 +57545,7 @@
     {
       "name": "legoapi/gizmo/object/giztimers.cpp.o",
       "source": "src/legoapi/gizmo/object/giztimers.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztimers.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/giztimers.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_giztimers.cpp",
@@ -57483,7 +57568,7 @@
     {
       "name": "legoapi/gizmo/object/giztorpedo.cpp.o",
       "source": "src/legoapi/gizmo/object/giztorpedo.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpedo.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpedo.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_giztorpedo.cpp",
@@ -57506,7 +57591,7 @@
     {
       "name": "legoapi/gizmos/door/door.cpp.o",
       "source": "src/legoapi/gizmos/door/door.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/door.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/door.o",
       "functions": [
         {
           "name": "_ZL17Door_GetMaxGizmosPv",
@@ -57577,7 +57662,7 @@
     {
       "name": "legoapi/gizmos/door/plugs.cpp.o",
       "source": "src/legoapi/gizmos/door/plugs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/plugs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/plugs.o",
       "functions": [
         {
           "name": "_ZL13Plug_ActivateP7GIZMO_si",
@@ -57728,7 +57813,7 @@
     {
       "name": "legoapi/gizmos/door/push.cpp.o",
       "source": "src/legoapi/gizmos/door/push.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/push.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/push.o",
       "functions": [
         {
           "name": "_ZL29PushBlocks_ReserveBufferSpacePv",
@@ -57871,7 +57956,7 @@
     {
       "name": "legoapi/gizmos/door/securitydoors.cpp.o",
       "source": "src/legoapi/gizmos/door/securitydoors.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoors.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoors.o",
       "functions": [
         {
           "name": "_ZL32SecurityDoors_ReserveBufferSpacePv",
@@ -58022,7 +58107,7 @@
     {
       "name": "legoapi/gizmos/door/spinner.cpp.o",
       "source": "src/legoapi/gizmos/door/spinner.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/spinner.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/spinner.o",
       "functions": [
         {
           "name": "_ZL20GizSpinner_PanelDrawPvS_f",
@@ -58213,7 +58298,7 @@
     {
       "name": "legoapi/gizmos/door/zipups.cpp.o",
       "source": "src/legoapi/gizmos/door/zipups.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/zipups.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/zipups.o",
       "functions": [
         {
           "name": "_ZL17ZipUp_ActivateRevP7GIZMO_sii",
@@ -58364,7 +58449,7 @@
     {
       "name": "legoapi/gizmos/fx/edgizshadowmachine.cpp.o",
       "source": "src/legoapi/gizmos/fx/edgizshadowmachine.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/edgizshadowmachine.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/edgizshadowmachine.o",
       "functions": [
         {
           "name": "_ZL24edGizShadow_GetMaxGizmosPv",
@@ -58443,7 +58528,7 @@
     {
       "name": "legoapi/gizmos/fx/gizmopickups.cpp.o",
       "source": "src/legoapi/gizmos/fx/gizmopickups.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizmopickups.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizmopickups.o",
       "functions": [
         {
           "name": "_ZL25GizmoPickups_GetMaxGizmosPv",
@@ -58602,7 +58687,7 @@
     {
       "name": "legoapi/gizmos/fx/guidelines.cpp.o",
       "source": "src/legoapi/gizmos/fx/guidelines.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/guidelines.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/guidelines.o",
       "functions": [
         {
           "name": "_ZL29GuideLines_ReserveBufferSpacePv",
@@ -58737,7 +58822,7 @@
     {
       "name": "legoapi/gizmos/object/gizbuildits.cpp.o",
       "source": "src/legoapi/gizmos/object/gizbuildits.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildits.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildits.o",
       "functions": [
         {
           "name": "_ZL19GizmoBuildit_GetPosP7GIZMO_s",
@@ -58857,7 +58942,7 @@
           "address": 5043648,
           "offset": 4153680,
           "size": 6532,
-          "match_percent": 5.600146
+          "match_percent": 14.059211
         },
         {
           "name": "_ZL26GizmoBuildit_SetVisibilityP7GIZMO_si",
@@ -58904,7 +58989,7 @@
     {
       "name": "legoapi/gizmos/object/gizobstacles.cpp.o",
       "source": "src/legoapi/gizmos/object/gizobstacles.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacles.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacles.o",
       "functions": [
         {
           "name": "_ZL20GizmoObstacle_GetPosP7GIZMO_s",
@@ -59111,7 +59196,7 @@
     {
       "name": "legoapi/gizmos/object/gizpanel.cpp.o",
       "source": "src/legoapi/gizmos/object/gizpanel.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizpanel.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizpanel.o",
       "functions": [
         {
           "name": "_ZL21GizPanel_GetMaxGizmosPv",
@@ -59254,7 +59339,7 @@
     {
       "name": "legoapi/gizmos/object/hatmachine.cpp.o",
       "source": "src/legoapi/gizmos/object/hatmachine.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/hatmachine.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/hatmachine.o",
       "functions": [
         {
           "name": "_ZL23HatMachine_GetMaxGizmosPv",
@@ -59405,7 +59490,7 @@
     {
       "name": "legoapi/gizmos/object/lever.cpp.o",
       "source": "src/legoapi/gizmos/object/lever.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/lever.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/lever.o",
       "functions": [
         {
           "name": "_ZL25Levers_ReserveBufferSpacePv",
@@ -59564,7 +59649,7 @@
     {
       "name": "legoapi/gizmos/object/newblowup.cpp.o",
       "source": "src/legoapi/gizmos/object/newblowup.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/newblowup.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/newblowup.o",
       "functions": [
         {
           "name": "_ZL19Blowup_GetMaxGizmosPv",
@@ -59731,7 +59816,7 @@
     {
       "name": "legoapi/gizmos/object/technos.cpp.o",
       "source": "src/legoapi/gizmos/object/technos.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/technos.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/technos.o",
       "functions": [
         {
           "name": "_ZL26Technos_ReserveBufferSpacePv",
@@ -59898,7 +59983,7 @@
     {
       "name": "legoapi/gizmos/transport/gizportal.cpp.o",
       "source": "src/legoapi/gizmos/transport/gizportal.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizportal.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizportal.o",
       "functions": [
         {
           "name": "_Z17PortalDoors_ResetP11WORLDINFO_s",
@@ -60017,7 +60102,7 @@
     {
       "name": "legoapi/gizmos/transport/grapples.cpp.o",
       "source": "src/legoapi/gizmos/transport/grapples.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/grapples.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/grapples.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_grapples.cpp",
@@ -60184,7 +60269,7 @@
     {
       "name": "legoapi/gizmos/transport/ledges.cpp.o",
       "source": "src/legoapi/gizmos/transport/ledges.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ledges.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/ledges.o",
       "functions": [
         {
           "name": "_ZL25Ledges_ReserveBufferSpacePv",
@@ -60319,7 +60404,7 @@
     {
       "name": "legoapi/gizmos/transport/teleport.cpp.o",
       "source": "src/legoapi/gizmos/transport/teleport.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/teleport.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/teleport.o",
       "functions": [
         {
           "name": "_ZL20Teleport_ActivateRevP7GIZMO_sii",
@@ -60398,7 +60483,7 @@
     {
       "name": "legoapi/gizmos/transport/tightropes.cpp.o",
       "source": "src/legoapi/gizmos/transport/tightropes.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tightropes.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/tightropes.o",
       "functions": [
         {
           "name": "_ZL29TightRopes_ReserveBufferSpacePv",
@@ -60533,7 +60618,7 @@
     {
       "name": "legoapi/gizmos/transport/tubes.cpp.o",
       "source": "src/legoapi/gizmos/transport/tubes.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/tubes.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/0/tubes.o",
       "functions": [
         {
           "name": "_ZL24Tubes_ReserveBufferSpacePv",
@@ -60692,7 +60777,7 @@
     {
       "name": "legoapi/gizmos/traps/attractos.cpp.o",
       "source": "src/legoapi/gizmos/traps/attractos.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/attractos.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/attractos.o",
       "functions": [
         {
           "name": "_ZL28Attractos_ReserveBufferSpacePv",
@@ -60843,7 +60928,7 @@
     {
       "name": "legoapi/gizmos/traps/gizbombgen.cpp.o",
       "source": "src/legoapi/gizmos/traps/gizbombgen.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizbombgen.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizbombgen.o",
       "functions": [
         {
           "name": "_ZL21GizmoBombGen_ActivateP7GIZMO_si",
@@ -60986,7 +61071,7 @@
     {
       "name": "legoapi/gizmos/traps/gizforce.cpp.o",
       "source": "src/legoapi/gizmos/traps/gizforce.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizforce.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizforce.o",
       "functions": [
         {
           "name": "_ZL17GizmoForce_GetPosP7GIZMO_s",
@@ -61170,7 +61255,7 @@
           "address": 1871904,
           "offset": 981936,
           "size": 5493,
-          "match_percent": 3.969905
+          "match_percent": 9.232159
         },
         {
           "name": "_Z22GizForce_RegisterGizmoi",
@@ -61185,7 +61270,7 @@
     {
       "name": "legoapi/gizmos/traps/giztorpmachine.cpp.o",
       "source": "src/legoapi/gizmos/traps/giztorpmachine.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpmachine.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpmachine.o",
       "functions": [
         {
           "name": "_ZL21GizTorp_SetVisibilityP7GIZMO_si",
@@ -61304,7 +61389,7 @@
     {
       "name": "legoapi/gizmos/traps/gizturrets.cpp.o",
       "source": "src/legoapi/gizmos/traps/gizturrets.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizturrets.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizturrets.o",
       "functions": [
         {
           "name": "_ZL20GizmoTurret_ActivateP7GIZMO_si",
@@ -61503,7 +61588,7 @@
     {
       "name": "legoapi/gizmos/traps/shards.cpp.o",
       "source": "src/legoapi/gizmos/traps/shards.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shards.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/shards.o",
       "functions": [
         {
           "name": "_ZL25Shards_ReserveBufferSpacePv",
@@ -61654,7 +61739,7 @@
     {
       "name": "legoapi/gizmos/trigger/ai.cpp.o",
       "source": "src/legoapi/gizmos/trigger/ai.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ai.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/ai.o",
       "functions": [
         {
           "name": "_ZL15AI_GetMaxGizmosPv",
@@ -61725,7 +61810,7 @@
     {
       "name": "legoapi/gizmos/trigger/gizaimessage.cpp.o",
       "source": "src/legoapi/gizmos/trigger/gizaimessage.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizaimessage.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gizaimessage.o",
       "functions": [
         {
           "name": "_ZL25GizAIMessage_GetMaxGizmosPv",
@@ -61788,7 +61873,7 @@
     {
       "name": "legoapi/gizmos/trigger/gizrandom.cpp.o",
       "source": "src/legoapi/gizmos/trigger/gizrandom.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizrandom.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizrandom.o",
       "functions": [
         {
           "name": "_Z22GizRandom_GetMaxGizmosPv",
@@ -61867,7 +61952,7 @@
     {
       "name": "legoapi/gizmos/trigger/gizspecial.cpp.o",
       "source": "src/legoapi/gizmos/trigger/gizspecial.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizspecial.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizspecial.o",
       "functions": [
         {
           "name": "_ZL23GizSpecial_GetMaxGizmosPv",
@@ -62010,7 +62095,7 @@
     {
       "name": "legoapi/gizmos/trigger/giztimer.cpp.o",
       "source": "src/legoapi/gizmos/trigger/giztimer.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztimer.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/giztimer.o",
       "functions": [
         {
           "name": "_Z21GizTimer_GetMaxGizmosPv",
@@ -62105,7 +62190,7 @@
     {
       "name": "legoapi/gizmos/trigger/minicut.cpp.o",
       "source": "src/legoapi/gizmos/trigger/minicut.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/minicut.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/minicut.o",
       "functions": [
         {
           "name": "_ZL23GizMiniCut_GetGizmoNameP7GIZMO_s",
@@ -62216,7 +62301,7 @@
     {
       "name": "legoapi/gizmos/trigger/signals.cpp.o",
       "source": "src/legoapi/gizmos/trigger/signals.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/signals.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/signals.o",
       "functions": [
         {
           "name": "_ZL26Signals_ReserveBufferSpacePv",
@@ -62375,7 +62460,7 @@
     {
       "name": "legoapi/items/base/animpacket.cpp.o",
       "source": "src/legoapi/items/base/animpacket.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/animpacket.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/animpacket.o",
       "functions": [
         {
           "name": "ResetMiniAnimPacket",
@@ -62406,7 +62491,7 @@
     {
       "name": "legoapi/items/base/apiobject.cpp.o",
       "source": "src/legoapi/items/base/apiobject.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/apiobject.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/apiobject.o",
       "functions": [
         {
           "name": "WindShear",
@@ -62525,7 +62610,7 @@
     {
       "name": "legoapi/items/base/collection.cpp.o",
       "source": "src/legoapi/items/base/collection.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/collection.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/collection.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_collection.cpp",
@@ -62732,7 +62817,7 @@
     {
       "name": "legoapi/items/base/game_object.cpp.o",
       "source": "src/legoapi/items/base/game_object.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/game_object.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/game_object.o",
       "functions": [
         {
           "name": "_ZL27Tag_FindGameObject_TRANSFERP12GameObject_s",
@@ -62923,7 +63008,7 @@
     {
       "name": "legoapi/items/base/scene.cpp.o",
       "source": "src/legoapi/items/base/scene.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/scene.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/scene.o",
       "functions": [
         {
           "name": "_ZNK13SceneInstance13GetVisibilityEv",
@@ -63034,7 +63119,7 @@
     {
       "name": "legoapi/items/base/sceneobject.cpp.o",
       "source": "src/legoapi/items/base/sceneobject.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/sceneobject.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/sceneobject.o",
       "functions": [
         {
           "name": "_ZN17SceneObjectHelper10ClearLevelEi",
@@ -63193,7 +63278,7 @@
     {
       "name": "legoapi/items/collect/attracto.cpp.o",
       "source": "src/legoapi/items/collect/attracto.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/attracto.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/attracto.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_attracto.cpp",
@@ -63248,7 +63333,7 @@
     {
       "name": "legoapi/items/collect/batarang.cpp.o",
       "source": "src/legoapi/items/collect/batarang.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/batarang.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/batarang.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_batarang.cpp",
@@ -63375,7 +63460,7 @@
     {
       "name": "legoapi/items/collect/bolt.cpp.o",
       "source": "src/legoapi/items/collect/bolt.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/bolt.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/bolt.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_bolt.cpp",
@@ -63486,7 +63571,7 @@
     {
       "name": "legoapi/items/collect/bolts.cpp.o",
       "source": "src/legoapi/items/collect/bolts.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/bolts.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/bolts.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_bolts.cpp",
@@ -63845,7 +63930,7 @@
     {
       "name": "legoapi/items/collect/bolts_stubs.cpp.o",
       "source": "src/legoapi/items/collect/bolts_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/bolts_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/bolts_stubs.o",
       "functions": [
         {
           "name": "_Z15Bolt_PlayHitSfxP6BOLT_s",
@@ -63860,7 +63945,7 @@
     {
       "name": "legoapi/items/collect/detonator.cpp.o",
       "source": "src/legoapi/items/collect/detonator.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/detonator.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/detonator.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_detonator.cpp",
@@ -63923,7 +64008,7 @@
     {
       "name": "legoapi/items/collect/minikits.cpp.o",
       "source": "src/legoapi/items/collect/minikits.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/minikits.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/minikits.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_minikits.cpp",
@@ -64138,7 +64223,7 @@
     {
       "name": "legoapi/items/collect/shard.cpp.o",
       "source": "src/legoapi/items/collect/shard.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shard.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/shard.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shard.cpp",
@@ -64177,7 +64262,7 @@
     {
       "name": "legoapi/items/collect/thermaldetonators.cpp.o",
       "source": "src/legoapi/items/collect/thermaldetonators.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/thermaldetonators.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/thermaldetonators.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_thermaldetonators.cpp",
@@ -64256,7 +64341,7 @@
     {
       "name": "legoapi/items/collect/torpedo.cpp.o",
       "source": "src/legoapi/items/collect/torpedo.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/torpedo.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/torpedo.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_torpedo.cpp",
@@ -64351,7 +64436,7 @@
     {
       "name": "legoapi/items/fx/explosions.cpp.o",
       "source": "src/legoapi/items/fx/explosions.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/explosions.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/explosions.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_explosions.cpp",
@@ -64406,7 +64491,7 @@
     {
       "name": "legoapi/items/fx/pulses.cpp.o",
       "source": "src/legoapi/items/fx/pulses.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/pulses.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/pulses.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_pulses.cpp",
@@ -64453,7 +64538,7 @@
     {
       "name": "legoapi/items/fx/ripples.cpp.o",
       "source": "src/legoapi/items/fx/ripples.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ripples.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/ripples.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_ripples.cpp",
@@ -64556,7 +64641,7 @@
     {
       "name": "legoapi/items/objects/cable.cpp.o",
       "source": "src/legoapi/items/objects/cable.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cable.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/cable.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_cable.cpp",
@@ -64627,7 +64712,7 @@
     {
       "name": "legoapi/items/objects/gameobjects.cpp.o",
       "source": "src/legoapi/items/objects/gameobjects.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameobjects.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gameobjects.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameobjects.cpp",
@@ -64651,7 +64736,7 @@
           "address": 1079344,
           "offset": 189376,
           "size": 3212,
-          "match_percent": 7.464662
+          "match_percent": 7.619549
         },
         {
           "name": "_ZL20LEGO_AllGoldBricksFnv",
@@ -65019,7 +65104,7 @@
           "address": 1560992,
           "offset": 671024,
           "size": 14477,
-          "match_percent": 2.031968
+          "match_percent": 2.215876
         },
         {
           "name": "_Z18AddDynamicCreatureiP7nuvec_siPcP12AIPATHINFO_sP9AIGROUP_siP11nugspline_sS0_ii",
@@ -66362,7 +66447,7 @@
     {
       "name": "legoapi/items/objects/grabber.cpp.o",
       "source": "src/legoapi/items/objects/grabber.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/grabber.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/grabber.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_grabber.cpp",
@@ -66393,7 +66478,7 @@
     {
       "name": "legoapi/items/objects/objectsall.cpp.o",
       "source": "src/legoapi/items/objects/objectsall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/objectsall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/objectsall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_objectsall.cpp",
@@ -66528,7 +66613,7 @@
     {
       "name": "legoapi/items/objects/placeable.cpp.o",
       "source": "src/legoapi/items/objects/placeable.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/placeable.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/placeable.o",
       "functions": [
         {
           "name": "_ZNK9Placeable18GetInitialPositionEv",
@@ -66743,7 +66828,7 @@
     {
       "name": "legoapi/items/objects/plugs.cpp.o",
       "source": "src/legoapi/items/objects/plugs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/plugs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/plugs.o",
       "functions": [
         {
           "name": "_Z16Plug_FindNearestP9PLUGSYS_sP7nuvec_sPfi",
@@ -66766,7 +66851,7 @@
     {
       "name": "legoapi/items/objects/things.cpp.o",
       "source": "src/legoapi/items/objects/things.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/things.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/things.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_things.cpp",
@@ -66805,7 +66890,7 @@
     {
       "name": "legoapi/items/objects/traffic.cpp.o",
       "source": "src/legoapi/items/objects/traffic.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/traffic.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/traffic.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_traffic.cpp",
@@ -66852,7 +66937,7 @@
     {
       "name": "legoapi/menus/core/gamehint.cpp.o",
       "source": "src/legoapi/menus/core/gamehint.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamehint.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gamehint.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamehint.cpp",
@@ -67107,7 +67192,7 @@
     {
       "name": "legoapi/menus/core/gamemessages.cpp.o",
       "source": "src/legoapi/menus/core/gamemessages.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamemessages.cpp",
@@ -67202,7 +67287,7 @@
     {
       "name": "legoapi/menus/core/gamemessages_stubs.cpp.o",
       "source": "src/legoapi/menus/core/gamemessages_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages_stubs.o",
       "functions": [
         {
           "name": "_Z9numeminitv",
@@ -67225,7 +67310,7 @@
     {
       "name": "legoapi/menus/core/hint.cpp.o",
       "source": "src/legoapi/menus/core/hint.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hint.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/hint.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_hint.cpp",
@@ -67376,7 +67461,7 @@
     {
       "name": "legoapi/menus/core/hud.cpp.o",
       "source": "src/legoapi/menus/core/hud.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hud.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/hud.o",
       "functions": [
         {
           "name": "_ZL13DrawCoinTotalii",
@@ -67471,7 +67556,7 @@
     {
       "name": "legoapi/menus/core/panel.cpp.o",
       "source": "src/legoapi/menus/core/panel.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/panel.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/panel.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_panel.cpp",
@@ -67526,7 +67611,7 @@
     {
       "name": "legoapi/menus/core/text.cpp.o",
       "source": "src/legoapi/menus/core/text.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/text.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/text.o",
       "functions": [
         {
           "name": "_Z18Text_DecodeButtonsPcS_",
@@ -67678,7 +67763,7 @@
           "address": 4371936,
           "offset": 3481968,
           "size": 3480,
-          "match_percent": 8.858681
+          "match_percent": 11.181696
         },
         {
           "name": "Text3D",
@@ -67710,7 +67795,7 @@
           "address": 4381664,
           "offset": 3491696,
           "size": 4373,
-          "match_percent": 14.074074
+          "match_percent": 16.344227
         },
         {
           "name": "SmartText",
@@ -68006,7 +68091,7 @@
           "address": 4778720,
           "offset": 3888752,
           "size": 3008,
-          "match_percent": 8.437299
+          "match_percent": 9.110932
         },
         {
           "name": "_Z25Text_LocaliseDecimalPointPc",
@@ -68037,7 +68122,7 @@
     {
       "name": "legoapi/menus/screens/arcade.cpp.o",
       "source": "src/legoapi/menus/screens/arcade.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/arcade.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/arcade.o",
       "functions": [
         {
           "name": "_Z24Arcade_BothPlayersActivev",
@@ -68140,7 +68225,7 @@
     {
       "name": "legoapi/menus/screens/credits.cpp.o",
       "source": "src/legoapi/menus/screens/credits.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/credits.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/credits.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_credits.cpp",
@@ -68195,7 +68280,7 @@
     {
       "name": "legoapi/menus/screens/customise.cpp.o",
       "source": "src/legoapi/menus/screens/customise.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/customise.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/customise.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_customise.cpp",
@@ -68482,7 +68567,7 @@
     {
       "name": "legoapi/menus/screens/gamemenuall.cpp.o",
       "source": "src/legoapi/menus/screens/gamemenuall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamemenuall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gamemenuall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamemenuall.cpp",
@@ -69961,7 +70046,7 @@
     {
       "name": "legoapi/menus/screens/gamestatus_lsw.cpp.o",
       "source": "src/legoapi/menus/screens/gamestatus_lsw.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamestatus_lsw.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gamestatus_lsw.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamestatus_lsw.cpp",
@@ -70392,7 +70477,7 @@
     {
       "name": "legoapi/menus/screens/menus.cpp.o",
       "source": "src/legoapi/menus/screens/menus.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/menus.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/menus.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_menus.cpp",
@@ -70479,7 +70564,7 @@
     {
       "name": "legoapi/menus/screens/movies.cpp.o",
       "source": "src/legoapi/menus/screens/movies.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/movies.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/movies.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_movies.cpp",
@@ -70518,7 +70603,7 @@
     {
       "name": "legoapi/menus/screens/shop.cpp.o",
       "source": "src/legoapi/menus/screens/shop.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shop.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/shop.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shop.cpp",
@@ -70621,7 +70706,7 @@
     {
       "name": "legoapi/menus/screens/store.cpp.o",
       "source": "src/legoapi/menus/screens/store.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/store.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/store.o",
       "functions": [
         {
           "name": "_Z24StoreProgressAICharacterP16LEVEL_PROGRESS_s",
@@ -70820,7 +70905,7 @@
     {
       "name": "legoapi/misc/androidbatman.cpp.o",
       "source": "src/legoapi/misc/androidbatman.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/androidbatman.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/androidbatman.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_androidbatman.cpp",
@@ -70829,14 +70914,6 @@
           "offset": 10992,
           "size": 93,
           "match_percent": 29.411764
-        },
-        {
-          "name": "_Z11AndroidMainPv",
-          "demangled_name": "AndroidMain(void*)",
-          "address": 978624,
-          "offset": 88656,
-          "size": 394,
-          "match_percent": 3.469388
         },
         {
           "name": "_Z13ObjZappedBlueP12GameObject_s",
@@ -70876,7 +70953,7 @@
           "address": 3641264,
           "offset": 2751296,
           "size": 6787,
-          "match_percent": 2.586366
+          "match_percent": 5.014442
         },
         {
           "name": "_Z17NewScanHandelFullP7nuvec_sS0_fii",
@@ -70915,7 +70992,7 @@
     {
       "name": "legoapi/misc/buffers.cpp.o",
       "source": "src/legoapi/misc/buffers.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/buffers.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/buffers.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_buffers.cpp",
@@ -70946,7 +71023,7 @@
     {
       "name": "legoapi/misc/gamelib_utilities.cpp.o",
       "source": "src/legoapi/misc/gamelib_utilities.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_utilities.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_utilities.o",
       "functions": [
         {
           "name": "VuQuatSlerpFast",
@@ -71065,13 +71142,13 @@
     {
       "name": "legoapi/misc/legoapi_helpers.cpp.o",
       "source": "src/legoapi/misc/legoapi_helpers.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_helpers.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_helpers.o",
       "functions": []
     },
     {
       "name": "legoapi/misc/legoapi_misc.cpp.o",
       "source": "src/legoapi/misc/legoapi_misc.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc.o",
       "functions": [
         {
           "name": "_Z21ClearLastSafeTakeOverP12GameObject_s",
@@ -71222,7 +71299,7 @@
     {
       "name": "legoapi/misc/legoapi_misc_c.c.o",
       "source": "src/legoapi/misc/legoapi_misc_c.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc_c.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc_c.o",
       "functions": [
         {
           "name": "tpentPropOnEnter",
@@ -71245,7 +71322,7 @@
     {
       "name": "legoapi/misc/legoapi_status.cpp.o",
       "source": "src/legoapi/misc/legoapi_status.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_status.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_status.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_legoapi_status.cpp",
@@ -71292,7 +71369,7 @@
     {
       "name": "legoapi/misc/memory.cpp.o",
       "source": "src/legoapi/misc/memory.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/memory.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/memory.o",
       "functions": [
         {
           "name": "DebAlloc",
@@ -71379,7 +71456,7 @@
     {
       "name": "legoapi/misc/stream.cpp.o",
       "source": "src/legoapi/misc/stream.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/stream.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/stream.o",
       "functions": [
         {
           "name": "StreamRead",
@@ -71418,7 +71495,7 @@
     {
       "name": "legoapi/misc/supportall.cpp.o",
       "source": "src/legoapi/misc/supportall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/supportall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/supportall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_supportall.cpp",
@@ -71442,7 +71519,7 @@
           "address": 1176416,
           "offset": 286448,
           "size": 4258,
-          "match_percent": 13.181425
+          "match_percent": 13.320734
         },
         {
           "name": "_Z11CatchUpCodeP12GameObject_sffi",
@@ -71857,7 +71934,7 @@
     {
       "name": "legoapi/misc/supportall_stubs.cpp.o",
       "source": "src/legoapi/misc/supportall_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/supportall_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/supportall_stubs.o",
       "functions": [
         {
           "name": "_Z14bgprocIsFrozenv",
@@ -71920,7 +71997,7 @@
     {
       "name": "legoapi/misc/tm.cpp.o",
       "source": "src/legoapi/misc/tm.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tm.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/tm.o",
       "functions": [
         {
           "name": "_ZN8TMClient11AllocHandleEv",
@@ -72039,7 +72116,7 @@
     {
       "name": "legoapi/misc/utilities.cpp.o",
       "source": "src/legoapi/misc/utilities.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/utilities.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/utilities.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_utilities.cpp",
@@ -72510,7 +72587,7 @@
     {
       "name": "legoapi/props/doors/door.cpp.o",
       "source": "src/legoapi/props/doors/door.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/door.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/door.o",
       "functions": [
         {
           "name": "_ZL23GoThroughDoor_ExtraCodeP11WORLDINFO_sP6DOOR_s",
@@ -72549,7 +72626,7 @@
     {
       "name": "legoapi/props/doors/doors.cpp.o",
       "source": "src/legoapi/props/doors/doors.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/doors.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/doors.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_doors.cpp",
@@ -72628,7 +72705,7 @@
     {
       "name": "legoapi/props/doors/securitydoor.cpp.o",
       "source": "src/legoapi/props/doors/securitydoor.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoor.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoor.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_securitydoor.cpp",
@@ -72667,7 +72744,7 @@
     {
       "name": "legoapi/props/objects/guidelines.cpp.o",
       "source": "src/legoapi/props/objects/guidelines.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/guidelines.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/guidelines.o",
       "functions": [
         {
           "name": "_Z21GuideLine_FindNearestP7nuvec_sP11WORLDINFO_sPiPf",
@@ -72682,7 +72759,7 @@
     {
       "name": "legoapi/props/objects/hatmachine.cpp.o",
       "source": "src/legoapi/props/objects/hatmachine.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/hatmachine.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/hatmachine.o",
       "functions": [
         {
           "name": "_Z19Hat_GetAbsTargetPosP12HATMACHINE_sP7nuvec_s",
@@ -72697,7 +72774,7 @@
     {
       "name": "legoapi/props/objects/ledge.cpp.o",
       "source": "src/legoapi/props/objects/ledge.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ledge.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/ledge.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_ledge.cpp",
@@ -72744,7 +72821,7 @@
     {
       "name": "legoapi/props/objects/lever.cpp.o",
       "source": "src/legoapi/props/objects/lever.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/lever.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/lever.o",
       "functions": [
         {
           "name": "_Z12ReleaseLeverP12GameObject_s",
@@ -72767,7 +72844,7 @@
     {
       "name": "legoapi/props/objects/signal.cpp.o",
       "source": "src/legoapi/props/objects/signal.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/signal.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/signal.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_signal.cpp",
@@ -72814,7 +72891,7 @@
     {
       "name": "legoapi/props/objects/techno.cpp.o",
       "source": "src/legoapi/props/objects/techno.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/techno.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/techno.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_techno.cpp",
@@ -72893,7 +72970,7 @@
     {
       "name": "legoapi/props/objects/teleport.cpp.o",
       "source": "src/legoapi/props/objects/teleport.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/teleport.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/teleport.o",
       "functions": [
         {
           "name": "_Z19Teleports_ConfigureP11WORLDINFO_sPc",
@@ -72916,7 +72993,7 @@
     {
       "name": "legoapi/props/objects/tightrope.cpp.o",
       "source": "src/legoapi/props/objects/tightrope.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tightrope.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/tightrope.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_tightrope.cpp",
@@ -72971,7 +73048,7 @@
     {
       "name": "legoapi/props/objects/tubes.cpp.o",
       "source": "src/legoapi/props/objects/tubes.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/tubes.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/tubes.o",
       "functions": [
         {
           "name": "_Z15TractorBeamCodeP12GameObject_s",
@@ -72994,7 +73071,7 @@
     {
       "name": "legoapi/props/objects/zipup.cpp.o",
       "source": "src/legoapi/props/objects/zipup.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/zipup.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/zipup.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_zipup.cpp",
@@ -73041,7 +73118,7 @@
     {
       "name": "legoapi/props/system/socksysall.cpp.o",
       "source": "src/legoapi/props/system/socksysall.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall.o",
       "functions": [
         {
           "name": "_Z28GoingForwardsAlongNarrowSockP12GameObject_s",
@@ -73113,7 +73190,7 @@
           "address": 3921467,
           "offset": 3031499,
           "size": 3611,
-          "match_percent": 29.212172
+          "match_percent": 47.02536
         },
         {
           "name": "SockSysPointAlongSpline",
@@ -73312,7 +73389,7 @@
     {
       "name": "legoapi/props/system/socksysall_stubs.cpp.o",
       "source": "src/legoapi/props/system/socksysall_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall_stubs.o",
       "functions": [
         {
           "name": "_Z21TurnOffAllSocksExceptP7SOCKSYSi",
@@ -73335,7 +73412,7 @@
     {
       "name": "legoapi/render/core/gameliball.cpp.o",
       "source": "src/legoapi/render/core/gameliball.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameliball.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/gameliball.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameliball.cpp",
@@ -73374,7 +73451,7 @@
     {
       "name": "legoapi/render/core/nugraph.cpp.o",
       "source": "src/legoapi/render/core/nugraph.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/nugraph.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/nugraph.o",
       "functions": [
         {
           "name": "nugraphInit",
@@ -73517,7 +73594,7 @@
     {
       "name": "legoapi/render/core/render.cpp.o",
       "source": "src/legoapi/render/core/render.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/render.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/render.o",
       "functions": [
         {
           "name": "_ZL26DrawWeapon_SetSabreObjectsP12GameObject_siiiiPiS1_",
@@ -73533,7 +73610,7 @@
           "address": 1071808,
           "offset": 181840,
           "size": 7204,
-          "match_percent": 6.157617
+          "match_percent": 6.698341
         },
         {
           "name": "_ZL11DrawWeaponsP12GameObject_sif",
@@ -73701,7 +73778,7 @@
           "address": 1316752,
           "offset": 426784,
           "size": 12845,
-          "match_percent": 2.026722
+          "match_percent": 10.831733
         },
         {
           "name": "_Z19DrawForceBackEffectP12nuhspecial_s",
@@ -74596,7 +74673,7 @@
     {
       "name": "legoapi/render/core/render_stubs.cpp.o",
       "source": "src/legoapi/render/core/render_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/render_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/render_stubs.o",
       "functions": [
         {
           "name": "BoundingBoxToLine",
@@ -74620,7 +74697,7 @@
           "address": 2724356,
           "offset": 1834388,
           "size": 5724,
-          "match_percent": 7.216644
+          "match_percent": 22.336313
         },
         {
           "name": "DisplayListDebugPS",
@@ -74829,22 +74906,6 @@
           "offset": 1871701,
           "size": 95,
           "match_percent": 17.391304
-        },
-        {
-          "name": "glGenVertexArraysOESC",
-          "demangled_name": "glGenVertexArraysOESC",
-          "address": 2784832,
-          "offset": 1894864,
-          "size": 45,
-          "match_percent": 25.384615
-        },
-        {
-          "name": "glDeleteVertexArraysOESC",
-          "demangled_name": "glDeleteVertexArraysOESC",
-          "address": 2784880,
-          "offset": 1894912,
-          "size": 45,
-          "match_percent": 25.384615
         },
         {
           "name": "BuildCamSpaceClipPlanes",
@@ -75083,7 +75144,7 @@
     {
       "name": "legoapi/render/core/rtl.cpp.o",
       "source": "src/legoapi/render/core/rtl.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/rtl.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/rtl.o",
       "functions": [
         {
           "name": "_ZL10ElOverlapsP9nuqtdim_sS0_",
@@ -75578,7 +75639,7 @@
     {
       "name": "legoapi/render/core/screen.cpp.o",
       "source": "src/legoapi/render/core/screen.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/screen.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/screen.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_screen.cpp",
@@ -75753,7 +75814,7 @@
     {
       "name": "legoapi/render/core/shader.cpp.o",
       "source": "src/legoapi/render/core/shader.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shader.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/shader.o",
       "functions": [
         {
           "name": "_ZN19ShaderMtlDescFilter12internalInitEPK17nushadermtldesc_sPK7numtl_sii",
@@ -75896,7 +75957,7 @@
     {
       "name": "legoapi/render/core/terrain.cpp.o",
       "source": "src/legoapi/render/core/terrain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/terrain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/terrain.o",
       "functions": [
         {
           "name": "_Z13TerrainPlayerP12GameObject_s",
@@ -75904,7 +75965,7 @@
           "address": 1058464,
           "offset": 168496,
           "size": 12323,
-          "match_percent": 4.042759
+          "match_percent": 5.962081
         },
         {
           "name": "DebrisSetThinningLevel",
@@ -76048,7 +76109,7 @@
           "address": 3665328,
           "offset": 2775360,
           "size": 8732,
-          "match_percent": 2.886865
+          "match_percent": 12.947572
         },
         {
           "name": "_Z21TerrainMoveImpactDatav",
@@ -76207,7 +76268,7 @@
     {
       "name": "legoapi/render/core/terrain_runtime.cpp.o",
       "source": "src/legoapi/render/core/terrain_runtime.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_runtime.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_runtime.o",
       "functions": [
         {
           "name": "DebrisSetTimeIncrement",
@@ -76230,7 +76291,7 @@
     {
       "name": "legoapi/render/core/terrain_stubs.cpp.o",
       "source": "src/legoapi/render/core/terrain_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_stubs.o",
       "functions": [
         {
           "name": "CreateDmaParticleSet",
@@ -77533,7 +77594,7 @@
     {
       "name": "legoapi/render/fx/edsplines.cpp.o",
       "source": "src/legoapi/render/fx/edsplines.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/edsplines.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/edsplines.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_edsplines.cpp",
@@ -77780,7 +77841,7 @@
     {
       "name": "legoapi/render/fx/game_deb.cpp.o",
       "source": "src/legoapi/render/fx/game_deb.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/game_deb.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/game_deb.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_game_deb.cpp",
@@ -77979,7 +78040,7 @@
     {
       "name": "legoapi/render/fx/inflate.cpp.o",
       "source": "src/legoapi/render/fx/inflate.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/inflate.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/inflate.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_inflate.cpp",
@@ -78138,7 +78199,7 @@
     {
       "name": "legoapi/render/fx/particles.cpp.o",
       "source": "src/legoapi/render/fx/particles.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/particles.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/particles.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_particles.cpp",
@@ -78225,7 +78286,7 @@
     {
       "name": "legoapi/render/fx/parts.cpp.o",
       "source": "src/legoapi/render/fx/parts.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/parts.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/parts.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_parts.cpp",
@@ -78529,7 +78590,7 @@
           "address": 3477408,
           "offset": 2587440,
           "size": 6320,
-          "match_percent": 0.57074
+          "match_percent": 4.381029
         },
         {
           "name": "AddVariableShotDebrisEffectMtx4",
@@ -79208,7 +79269,7 @@
     {
       "name": "legoapi/render/fx/parts_control.cpp.o",
       "source": "src/legoapi/render/fx/parts_control.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/parts_control.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/parts_control.o",
       "functions": [
         {
           "name": "_Z11Parts_StartP11WORLDINFO_s",
@@ -79231,7 +79292,7 @@
     {
       "name": "legoapi/render/fx/parts_stubs.cpp.o",
       "source": "src/legoapi/render/fx/parts_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/parts_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/parts_stubs.o",
       "functions": [
         {
           "name": "ParticlesPerFrame",
@@ -79278,7 +79339,7 @@
     {
       "name": "legoapi/render/light/fade.cpp.o",
       "source": "src/legoapi/render/light/fade.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/fade.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/fade.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_fade.cpp",
@@ -79661,7 +79722,7 @@
     {
       "name": "legoapi/render/light/faders.cpp.o",
       "source": "src/legoapi/render/light/faders.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/faders.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/faders.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_faders.cpp",
@@ -79700,7 +79761,7 @@
     {
       "name": "legoapi/render/light/lighting.cpp.o",
       "source": "src/legoapi/render/light/lighting.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lighting.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/lighting.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_lighting.cpp",
@@ -79843,7 +79904,7 @@
     {
       "name": "legoapi/render/light/occlusion.cpp.o",
       "source": "src/legoapi/render/light/occlusion.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/occlusion.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/occlusion.o",
       "functions": [
         {
           "name": "_ZN11OccluderSet11SortByDepthEPKvS1_",
@@ -79851,7 +79912,7 @@
           "address": 2785056,
           "offset": 1895088,
           "size": 95,
-          "match_percent": 12.692307
+          "match_percent": 99.92308
         },
         {
           "name": "_ZL14BoxTreeRndrRecP15nuvisiboxtree_sPhP19nuvisiboxtreenode_sifP8nugscn_s",
@@ -79859,7 +79920,7 @@
           "address": 2787520,
           "offset": 1897552,
           "size": 365,
-          "match_percent": 3.590909
+          "match_percent": 3.818182
         },
         {
           "name": "_ZN16OcclusionManager10SetEnabledEb",
@@ -79867,7 +79928,7 @@
           "address": 2821232,
           "offset": 1931264,
           "size": 14,
-          "match_percent": 2.166667
+          "match_percent": 100.0
         },
         {
           "name": "_ZN16OcclusionManager8EndFrameEv",
@@ -79875,7 +79936,7 @@
           "address": 2821248,
           "offset": 1931280,
           "size": 9,
-          "match_percent": 24.444445
+          "match_percent": 100.0
         },
         {
           "name": "_ZN11OccluderSetC1Ev",
@@ -79883,7 +79944,7 @@
           "address": 2821264,
           "offset": 1931296,
           "size": 32,
-          "match_percent": 13.333333
+          "match_percent": 100.0
         },
         {
           "name": "_ZN11OccluderSetC2Ev",
@@ -79891,7 +79952,7 @@
           "address": 2821264,
           "offset": 1931296,
           "size": 32,
-          "match_percent": 13.333333
+          "match_percent": 100.0
         },
         {
           "name": "_ZN16OcclusionManagerC1Ev",
@@ -79899,7 +79960,7 @@
           "address": 2821296,
           "offset": 1931328,
           "size": 112,
-          "match_percent": 12.272727
+          "match_percent": 99.954544
         },
         {
           "name": "_ZN16OcclusionManagerC2Ev",
@@ -79907,7 +79968,7 @@
           "address": 2821296,
           "offset": 1931328,
           "size": 112,
-          "match_percent": 12.272727
+          "match_percent": 99.954544
         },
         {
           "name": "_ZN11OccluderSetD1Ev",
@@ -79915,7 +79976,7 @@
           "address": 2821408,
           "offset": 1931440,
           "size": 9,
-          "match_percent": 24.444445
+          "match_percent": 100.0
         },
         {
           "name": "_ZN11OccluderSetD2Ev",
@@ -79923,7 +79984,7 @@
           "address": 2821408,
           "offset": 1931440,
           "size": 9,
-          "match_percent": 24.444445
+          "match_percent": 100.0
         },
         {
           "name": "_ZN16OcclusionManagerD1Ev",
@@ -79931,7 +79992,7 @@
           "address": 2821424,
           "offset": 1931456,
           "size": 74,
-          "match_percent": 14.347826
+          "match_percent": 99.95652
         },
         {
           "name": "_ZN16OcclusionManagerD2Ev",
@@ -79939,7 +80000,7 @@
           "address": 2821424,
           "offset": 1931456,
           "size": 74,
-          "match_percent": 14.347826
+          "match_percent": 99.95652
         },
         {
           "name": "_ZN11OccluderSet5ClearEv",
@@ -79947,7 +80008,7 @@
           "address": 2821504,
           "offset": 1931536,
           "size": 18,
-          "match_percent": 36.666668
+          "match_percent": 100.0
         },
         {
           "name": "_ZN16OcclusionManager10BeginFrameEv",
@@ -79955,7 +80016,7 @@
           "address": 2821536,
           "offset": 1931568,
           "size": 121,
-          "match_percent": 7.857143
+          "match_percent": 99.96429
         },
         {
           "name": "_ZN11OccluderSet11AddOccluderEPK7nuvec_sS2_S2_S2_",
@@ -79963,7 +80024,7 @@
           "address": 2821664,
           "offset": 1931696,
           "size": 258,
-          "match_percent": 3.859649
+          "match_percent": 52.666668
         },
         {
           "name": "_ZN11OccluderSet17PrepareForQueriesEPK7numtx_sS2_",
@@ -79971,7 +80032,7 @@
           "address": 2821936,
           "offset": 1931968,
           "size": 1271,
-          "match_percent": 1.245421
+          "match_percent": 94.611725
         },
         {
           "name": "_ZN11OccluderSet16IsOccludedSphereEPK7nuvec_sf",
@@ -79979,7 +80040,7 @@
           "address": 2823216,
           "offset": 1933248,
           "size": 1514,
-          "match_percent": 1.286174
+          "match_percent": 42.228294
         },
         {
           "name": "_ZN11OccluderSet13IsOccludedOBBEPK7nuvec_sS2_PK7numtx_s",
@@ -79987,7 +80048,7 @@
           "address": 2824736,
           "offset": 1934768,
           "size": 4801,
-          "match_percent": 0.425985
+          "match_percent": 70.10543
         },
         {
           "name": "_ZNK11OccluderSet15RenderOccludersEb",
@@ -79995,7 +80056,7 @@
           "address": 2829552,
           "offset": 1939584,
           "size": 1668,
-          "match_percent": 1.146512
+          "match_percent": 20.469767
         },
         {
           "name": "_ZNK16OcclusionManager11RenderZPassEv",
@@ -80003,7 +80064,7 @@
           "address": 2831232,
           "offset": 1941264,
           "size": 68,
-          "match_percent": 16.5
+          "match_percent": 99.95
         },
         {
           "name": "_ZN11OccluderSet11OnCameraSetEv",
@@ -80011,7 +80072,7 @@
           "address": 2831312,
           "offset": 1941344,
           "size": 13,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN16OcclusionManager11OnCameraSetEv",
@@ -80019,7 +80080,7 @@
           "address": 2831328,
           "offset": 1941360,
           "size": 60,
-          "match_percent": 17.368422
+          "match_percent": 99.947365
         },
         {
           "name": "_ZN16OcclusionManager13IsOccludedOBBEPK7nuvec_sS2_PK7numtx_s",
@@ -80027,7 +80088,7 @@
           "address": 2963568,
           "offset": 2073600,
           "size": 178,
-          "match_percent": 4.888889
+          "match_percent": 99.977776
         },
         {
           "name": "_ZN16OcclusionManager16IsOccludedSphereEPK7nuvec_sf",
@@ -80035,7 +80096,7 @@
           "address": 2963824,
           "offset": 2073856,
           "size": 170,
-          "match_percent": 6.428571
+          "match_percent": 99.97619
         },
         {
           "name": "_ZN16OcclusionManager11AddOccluderEPK7nuvec_sS2_S2_S2_",
@@ -80043,7 +80104,7 @@
           "address": 2964064,
           "offset": 2074096,
           "size": 971,
-          "match_percent": 1.769912
+          "match_percent": 99.21239
         },
         {
           "name": "_ZN16OcclusionManager11AddOccluderEPK7nuvec_sS2_PK7numtx_s",
@@ -80051,7 +80112,7 @@
           "address": 2965120,
           "offset": 2075152,
           "size": 668,
-          "match_percent": 1.788618
+          "match_percent": 91.87805
         },
         {
           "name": "_ZN16OcclusionManager11AddOccluderEPK7nuvec_sf",
@@ -80059,7 +80120,7 @@
           "address": 2965856,
           "offset": 2075888,
           "size": 624,
-          "match_percent": 1.833333
+          "match_percent": 59.075
         },
         {
           "name": "_ZN11OccluderSet4InitEjP9variptr_uS0_",
@@ -80067,7 +80128,7 @@
           "address": 3090976,
           "offset": 2201008,
           "size": 124,
-          "match_percent": 6.285714
+          "match_percent": 99.942856
         },
         {
           "name": "_ZN16OcclusionManager4InitEjP9variptr_uS0_",
@@ -80075,7 +80136,7 @@
           "address": 3091104,
           "offset": 2201136,
           "size": 176,
-          "match_percent": 5.365854
+          "match_percent": 99.97561
         },
         {
           "name": "_ZNK16OcclusionManager11RenderStatsEv",
@@ -80083,14 +80144,14 @@
           "address": 3114240,
           "offset": 2224272,
           "size": 453,
-          "match_percent": 2.268041
+          "match_percent": 4.329897
         }
       ]
     },
     {
       "name": "legoapi/render/light/shadow.cpp.o",
       "source": "src/legoapi/render/light/shadow.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shadow.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/shadow.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shadow.cpp",
@@ -80201,7 +80262,7 @@
     {
       "name": "legoapi/render/light/surfaces.cpp.o",
       "source": "src/legoapi/render/light/surfaces.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/surfaces.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/surfaces.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_surfaces.cpp",
@@ -80328,7 +80389,7 @@
     {
       "name": "legoapi/world/area.cpp.o",
       "source": "src/legoapi/world/area.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/area.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/area.o",
       "functions": [
         {
           "name": "_ZL12LoadAreaDataP12bgprocinfo_s",
@@ -80344,7 +80405,7 @@
           "address": 1213776,
           "offset": 323808,
           "size": 5414,
-          "match_percent": 18.148699
+          "match_percent": 18.363382
         },
         {
           "name": "_Z10FixUpAreasv",
@@ -80407,7 +80468,7 @@
     {
       "name": "legoapi/world/areas.cpp.o",
       "source": "src/legoapi/world/areas.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/areas.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/areas.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_areas.cpp",
@@ -80463,7 +80524,7 @@
           "address": 4683968,
           "offset": 3794000,
           "size": 5236,
-          "match_percent": 7.587102
+          "match_percent": 7.441373
         },
         {
           "name": "_Z25Areas_CompleteAllBuildUpsP10AREASAVE_s",
@@ -80478,7 +80539,7 @@
     {
       "name": "legoapi/world/boss.cpp.o",
       "source": "src/legoapi/world/boss.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/boss.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/boss.o",
       "functions": [
         {
           "name": "_Z8KillBossiif",
@@ -80517,7 +80578,7 @@
     {
       "name": "legoapi/world/level.cpp.o",
       "source": "src/legoapi/world/level.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/level.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/level.o",
       "functions": [
         {
           "name": "_Z18ClearLevelProgressiP11WORLDINFO_s",
@@ -80684,7 +80745,7 @@
     {
       "name": "legoapi/world/levelconfig.cpp.o",
       "source": "src/legoapi/world/levelconfig.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levelconfig.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/levelconfig.o",
       "functions": [
         {
           "name": "_ZL15LC_BL_wind_sizeP8nufpar_s",
@@ -81531,7 +81592,7 @@
     {
       "name": "legoapi/world/leveldata.cpp.o",
       "source": "src/legoapi/world/leveldata.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/leveldata.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/leveldata.o",
       "functions": [
         {
           "name": "_Z12ClearLevDatav",
@@ -81562,7 +81623,7 @@
     {
       "name": "legoapi/world/levelobjects.cpp.o",
       "source": "src/legoapi/world/levelobjects.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levelobjects.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/levelobjects.o",
       "functions": [
         {
           "name": "_Z24LevelObjects_InitForGameP11LEVELOBJECTP9variptr_uS2_ii",
@@ -81593,7 +81654,7 @@
     {
       "name": "legoapi/world/levels.cpp.o",
       "source": "src/legoapi/world/levels.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levels.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/levels.o",
       "functions": [
         {
           "name": "_Z15getSpawnLocatorfPc",
@@ -81640,7 +81701,7 @@
     {
       "name": "legoapi/world/levels/episode.cpp.o",
       "source": "src/legoapi/world/levels/episode.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episode.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/episode.o",
       "functions": [
         {
           "name": "_Z32Episodes_CompleteAllSuperStoriesv",
@@ -81831,7 +81892,7 @@
     {
       "name": "legoapi/world/levels/episodeI.cpp.o",
       "source": "src/legoapi/world/levels/episodeI.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeI.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/episodeI.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeI.cpp",
@@ -82342,7 +82403,7 @@
     {
       "name": "legoapi/world/levels/episodeII.cpp.o",
       "source": "src/legoapi/world/levels/episodeII.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeII.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/episodeII.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeII.cpp",
@@ -82797,7 +82858,7 @@
     {
       "name": "legoapi/world/levels/episodeIII.cpp.o",
       "source": "src/legoapi/world/levels/episodeIII.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIII.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIII.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeIII.cpp",
@@ -83188,7 +83249,7 @@
     {
       "name": "legoapi/world/levels/episodeIV.cpp.o",
       "source": "src/legoapi/world/levels/episodeIV.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIV.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIV.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeIV.cpp",
@@ -83539,7 +83600,7 @@
     {
       "name": "legoapi/world/levels/episodeV.cpp.o",
       "source": "src/legoapi/world/levels/episodeV.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeV.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/episodeV.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeV.cpp",
@@ -84130,7 +84191,7 @@
     {
       "name": "legoapi/world/levels/episodeVI.cpp.o",
       "source": "src/legoapi/world/levels/episodeVI.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeVI.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/episodeVI.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeVI.cpp",
@@ -84441,7 +84502,7 @@
     {
       "name": "legoapi/world/levels/hub.cpp.o",
       "source": "src/legoapi/world/levels/hub.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hub.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/hub.o",
       "functions": [
         {
           "name": "_ZL21Hub_DrawBonusModeMenuif",
@@ -84705,7 +84766,7 @@
           "address": 1795760,
           "offset": 905792,
           "size": 9054,
-          "match_percent": 6.384358
+          "match_percent": 7.18598
         },
         {
           "name": "_Z17Hub_MakeModelListv",
@@ -84736,7 +84797,7 @@
     {
       "name": "legoapi/world/levels/lego_city.cpp.o",
       "source": "src/legoapi/world/levels/lego_city.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lego_city.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/lego_city.o",
       "functions": [
         {
           "name": "_Z13LegoCity_InitP11WORLDINFO_s",
@@ -84767,7 +84828,7 @@
     {
       "name": "legoapi/world/levels/new_town.cpp.o",
       "source": "src/legoapi/world/levels/new_town.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/new_town.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/new_town.o",
       "functions": [
         {
           "name": "_Z12NewTown_InitP11WORLDINFO_s",
@@ -84798,7 +84859,7 @@
     {
       "name": "legoapi/world/levels/senate.cpp.o",
       "source": "src/legoapi/world/levels/senate.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/senate.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/senate.o",
       "functions": [
         {
           "name": "_Z12SenateA_InitP11WORLDINFO_s",
@@ -84813,7 +84874,7 @@
     {
       "name": "legoapi/world/levelstreaming.cpp.o",
       "source": "src/legoapi/world/levelstreaming.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levelstreaming.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/levelstreaming.o",
       "functions": [
         {
           "name": "_Z32LevelProgress_ReserveBufferSpaceP9variptr_uS_",
@@ -84844,7 +84905,7 @@
     {
       "name": "legoapi/world/mission.cpp.o",
       "source": "src/legoapi/world/mission.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/mission.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/mission.o",
       "functions": [
         {
           "name": "_Z18Missions_ConfigurePcP9variptr_uS1_P13MISSIONSAVE_s",
@@ -84859,7 +84920,7 @@
     {
       "name": "legoapi/world/missions.cpp.o",
       "source": "src/legoapi/world/missions.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/missions.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/missions.o",
       "functions": [
         {
           "name": "_Z13InitChallengei",
@@ -84962,7 +85023,7 @@
     {
       "name": "legoapi/world/world.cpp.o",
       "source": "src/legoapi/world/world.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/world.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/world.o",
       "functions": [
         {
           "name": "_Z21MakeFreePlayModelListiiiii",
@@ -84970,7 +85031,7 @@
           "address": 1201040,
           "offset": 311072,
           "size": 3556,
-          "match_percent": 8.905345
+          "match_percent": 9.693764
         },
         {
           "name": "_Z18StoreSceneProgressP8nugscn_sP15SCENEPROGRESS_si",
@@ -85137,7 +85198,7 @@
     {
       "name": "legogame/game.cpp.o",
       "source": "src/legogame/game.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legogame/game.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legogame/game.o",
       "functions": [
         {
           "name": "_Z12MakeSaveHashv",
@@ -85304,7 +85365,7 @@
     {
       "name": "legogame/startup.cpp.o",
       "source": "src/legogame/startup.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legogame/startup.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legogame/startup.o",
       "functions": [
         {
           "name": "_ZL12LoadPermDataP12bgprocinfo_s",
@@ -85343,7 +85404,7 @@
     {
       "name": "legogame/target_android.cpp.o",
       "source": "src/legogame/target_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legogame/target_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legogame/target_android.o",
       "functions": [
         {
           "name": "_ZL29SystemDidBecomeActiveCallbackPK20NuPhoneOSMessageData",
@@ -85382,7 +85443,7 @@
     {
       "name": "nu2api/nu3d/NuRenderDevice.cpp.o",
       "source": "src/nu2api/nu3d/NuRenderDevice.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuRenderDevice.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuRenderDevice.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_NuRenderDevice.cpp",
@@ -85513,6 +85574,22 @@
           "match_percent": 99.978264
         },
         {
+          "name": "_ZN14NuRenderDevice13PreInitializeEv",
+          "demangled_name": "NuRenderDevice::PreInitialize()",
+          "address": 2779408,
+          "offset": 1889440,
+          "size": 9,
+          "match_percent": 100.0
+        },
+        {
+          "name": "_ZNK14NuRenderDevice17MultiThreadRenderEv",
+          "demangled_name": "NuRenderDevice::MultiThreadRender() const",
+          "address": 2779424,
+          "offset": 1889456,
+          "size": 17,
+          "match_percent": 100.0
+        },
+        {
           "name": "_ZN14NuRenderDevice20IsExtensionSupportedEPKc",
           "demangled_name": "NuRenderDevice::IsExtensionSupported(char const*)",
           "address": 2779456,
@@ -85521,12 +85598,20 @@
           "match_percent": 48.24
         },
         {
+          "name": "_ZN14NuRenderDevice19OpenglErrorCallbackEjjjjiPKcPv",
+          "demangled_name": "NuRenderDevice::OpenglErrorCallback(unsigned int, unsigned int, unsigned int, unsigned int, int, char const*, void*)",
+          "address": 2779632,
+          "offset": 1889664,
+          "size": 9,
+          "match_percent": 100.0
+        },
+        {
           "name": "_ZN14NuRenderDevice34CheckForRenderWindowInitialisationEv",
           "demangled_name": "NuRenderDevice::CheckForRenderWindowInitialisation()",
           "address": 2779648,
           "offset": 1889680,
           "size": 96,
-          "match_percent": 71.77778
+          "match_percent": 99.37037
         },
         {
           "name": "_ZN14NuRenderDevice15SelectEGLConfigEv",
@@ -85534,7 +85619,15 @@
           "address": 2779744,
           "offset": 1889776,
           "size": 247,
-          "match_percent": 96.88461
+          "match_percent": 96.01923
+        },
+        {
+          "name": "_ZNK14NuRenderDevice14IsContextValidEv",
+          "demangled_name": "NuRenderDevice::IsContextValid() const",
+          "address": 2780000,
+          "offset": 1890032,
+          "size": 16,
+          "match_percent": 100.0
         },
         {
           "name": "_ZN14NuRenderDevice29DetermineBackBufferResolutionEii",
@@ -85550,7 +85643,15 @@
           "address": 2780176,
           "offset": 1890208,
           "size": 1538,
-          "match_percent": 65.64391
+          "match_percent": 97.23442
+        },
+        {
+          "name": "_ZNK14NuRenderDevice27DetermineNominalAspectRatioEjj",
+          "demangled_name": "NuRenderDevice::DetermineNominalAspectRatio(unsigned int, unsigned int) const",
+          "address": 2781728,
+          "offset": 1891760,
+          "size": 161,
+          "match_percent": 95.190475
         },
         {
           "name": "_ZN14NuRenderDevice15OnWindowCreatedEP13ANativeWindow",
@@ -85559,6 +85660,78 @@
           "offset": 1891936,
           "size": 64,
           "match_percent": 99.9375
+        },
+        {
+          "name": "_ZN14NuRenderDevice15OnWindowDestroyEv",
+          "demangled_name": "NuRenderDevice::OnWindowDestroy()",
+          "address": 2781968,
+          "offset": 1892000,
+          "size": 43,
+          "match_percent": 99.90909
+        },
+        {
+          "name": "_ZN14NuRenderDevice11OnAppResumeEv",
+          "demangled_name": "NuRenderDevice::OnAppResume()",
+          "address": 2782016,
+          "offset": 1892048,
+          "size": 38,
+          "match_percent": 99.90909
+        },
+        {
+          "name": "_ZN14NuRenderDevice11OnAppPausedEv",
+          "demangled_name": "NuRenderDevice::OnAppPaused()",
+          "address": 2782064,
+          "offset": 1892096,
+          "size": 51,
+          "match_percent": 99.92308
+        },
+        {
+          "name": "_ZN14NuRenderDevice13OnGainedFocusEv",
+          "demangled_name": "NuRenderDevice::OnGainedFocus()",
+          "address": 2782128,
+          "offset": 1892160,
+          "size": 38,
+          "match_percent": 99.90909
+        },
+        {
+          "name": "_ZN14NuRenderDevice11OnLostFocusEv",
+          "demangled_name": "NuRenderDevice::OnLostFocus()",
+          "address": 2782176,
+          "offset": 1892208,
+          "size": 51,
+          "match_percent": 99.92308
+        },
+        {
+          "name": "_ZN14NuRenderDevice12OnAppStartedEv",
+          "demangled_name": "NuRenderDevice::OnAppStarted()",
+          "address": 2782240,
+          "offset": 1892272,
+          "size": 9,
+          "match_percent": 100.0
+        },
+        {
+          "name": "_ZN14NuRenderDevice14OnAppRestartedEv",
+          "demangled_name": "NuRenderDevice::OnAppRestarted()",
+          "address": 2782256,
+          "offset": 1892288,
+          "size": 34,
+          "match_percent": 99.9
+        },
+        {
+          "name": "_ZN14NuRenderDevice12OnAppStoppedEv",
+          "demangled_name": "NuRenderDevice::OnAppStopped()",
+          "address": 2782304,
+          "offset": 1892336,
+          "size": 43,
+          "match_percent": 99.90909
+        },
+        {
+          "name": "NuRenderDeviceIsContextValid",
+          "demangled_name": "NuRenderDeviceIsContextValid",
+          "address": 2782352,
+          "offset": 1892384,
+          "size": 39,
+          "match_percent": 99.818184
         },
         {
           "name": "_ZN14NuRenderDevice8FrameEndEv",
@@ -85641,12 +85814,20 @@
           "match_percent": 99.85714
         },
         {
+          "name": "_ZN14NuRenderDevice12ResizeDeviceEiiibbbb",
+          "demangled_name": "NuRenderDevice::ResizeDevice(int, int, int, bool, bool, bool, bool)",
+          "address": 2783264,
+          "offset": 1893296,
+          "size": 266,
+          "match_percent": 96.31035
+        },
+        {
           "name": "_ZN14NuRenderDevice10InitializeEv",
           "demangled_name": "NuRenderDevice::Initialize()",
           "address": 2783536,
           "offset": 1893568,
           "size": 1133,
-          "match_percent": 67.55678
+          "match_percent": 70.347984
         },
         {
           "name": "_Z21NuGLES2ExtensionsInitv",
@@ -85654,14 +85835,30 @@
           "address": 2784672,
           "offset": 1894704,
           "size": 154,
-          "match_percent": 11.351352
+          "match_percent": 99.64865
+        },
+        {
+          "name": "glGenVertexArraysOESC",
+          "demangled_name": "glGenVertexArraysOESC",
+          "address": 2784832,
+          "offset": 1894864,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "glDeleteVertexArraysOESC",
+          "demangled_name": "glDeleteVertexArraysOESC",
+          "address": 2784880,
+          "offset": 1894912,
+          "size": 45,
+          "match_percent": 99.84615
         }
       ]
     },
     {
       "name": "nu2api/nu3d/android/nugscn_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nugscn_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn_android.o",
       "functions": [
         {
           "name": "_ZL5NuMaxii",
@@ -85684,7 +85881,7 @@
     {
       "name": "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
       "source": "src/nu2api/nu3d/android/nuiosdl_gl.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuiosdl_gl.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuiosdl_gl.o",
       "functions": [
         {
           "name": "_Z21NuIOSDLGeom2DCallbackPv",
@@ -85827,7 +86024,7 @@
     {
       "name": "nu2api/nu3d/android/numtl_android.cpp.o",
       "source": "src/nu2api/nu3d/android/numtl_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numtl_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numtl_android.o",
       "functions": [
         {
           "name": "_Z13NuMtlCreatePSP7numtl_si",
@@ -85858,7 +86055,7 @@
     {
       "name": "nu2api/nu3d/android/nuposteffect_plain.cpp.o",
       "source": "src/nu2api/nu3d/android/nuposteffect_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuposteffect_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuposteffect_plain.o",
       "functions": [
         {
           "name": "NuFramebufferSwapBuffers",
@@ -85921,7 +86118,7 @@
     {
       "name": "nu2api/nu3d/android/nuptl_flush.cpp.o",
       "source": "src/nu2api/nu3d/android/nuptl_flush.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuptl_flush.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuptl_flush.o",
       "functions": [
         {
           "name": "NuInitDebrisRenderer",
@@ -85929,7 +86126,7 @@
           "address": 2715013,
           "offset": 1825045,
           "size": 432,
-          "match_percent": 58.126125
+          "match_percent": 68.666664
         },
         {
           "name": "_Z28NuDebrisRendererFlushBuffersv",
@@ -85937,7 +86134,7 @@
           "address": 2715445,
           "offset": 1825477,
           "size": 359,
-          "match_percent": 41.62857
+          "match_percent": 49.95714
         },
         {
           "name": "_Z26NuDebrisRendererNextBufferv",
@@ -85945,14 +86142,14 @@
           "address": 2715804,
           "offset": 1825836,
           "size": 428,
-          "match_percent": 45.065216
+          "match_percent": 52.467392
         }
       ]
     },
     {
       "name": "nu2api/nu3d/android/nuqfnt_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nuqfnt_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt_android.o",
       "functions": [
         {
           "name": "NuQFntSetMtxRS",
@@ -85975,7 +86172,7 @@
     {
       "name": "nu2api/nu3d/android/nurenderthread.cpp.o",
       "source": "src/nu2api/nu3d/android/nurenderthread.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurenderthread.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurenderthread.o",
       "functions": [
         {
           "name": "NuRenderThreadCreate",
@@ -86054,7 +86251,7 @@
     {
       "name": "nu2api/nu3d/android/nurndr_android.c.o",
       "source": "src/nu2api/nu3d/android/nurndr_android.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_android.o",
       "functions": [
         {
           "name": "FaceYDirStream",
@@ -86085,7 +86282,7 @@
     {
       "name": "nu2api/nu3d/android/nutex_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nutex_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_android.o",
       "functions": [
         {
           "name": "_Z13NuTexCreatePSP13nunativetex_sb",
@@ -86196,7 +86393,7 @@
     {
       "name": "nu2api/nu3d/android/nutex_ios_ex.cpp.o",
       "source": "src/nu2api/nu3d/android/nutex_ios_ex.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_ios_ex.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_ios_ex.o",
       "functions": [
         {
           "name": "_Z20GetTextureFormatInfo11NUTEXFORMATRjS0_",
@@ -86323,7 +86520,7 @@
     {
       "name": "nu2api/nu3d/android/nutimebar_plain.cpp.o",
       "source": "src/nu2api/nu3d/android/nutimebar_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutimebar_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nutimebar_plain.o",
       "functions": [
         {
           "name": "NuTimeBarCreateSetEx",
@@ -86386,7 +86583,7 @@
     {
       "name": "nu2api/nu3d/android/nuvertexformat_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nuvertexformat_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvertexformat_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuvertexformat_android.o",
       "functions": [
         {
           "name": "NuGetVertexDeclaration",
@@ -86401,7 +86598,7 @@
     {
       "name": "nu2api/nu3d/generic/nucamera_gen.cpp.o",
       "source": "src/nu2api/nu3d/generic/nucamera_gen.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera_gen.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera_gen.o",
       "functions": [
         {
           "name": "NuCameraCreate",
@@ -86568,7 +86765,7 @@
     {
       "name": "nu2api/nu3d/nucamera.cpp.o",
       "source": "src/nu2api/nu3d/nucamera.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera.o",
       "functions": [
         {
           "name": "NuCameraClipTestExtents",
@@ -86591,7 +86788,7 @@
     {
       "name": "nu2api/nu3d/nucamvu0.c.o",
       "source": "src/nu2api/nu3d/nucamvu0.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucamvu0.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nucamvu0.o",
       "functions": [
         {
           "name": "NuCameraInitClipTestVU0",
@@ -86606,7 +86803,7 @@
     {
       "name": "nu2api/nu3d/nudlist.cpp.o",
       "source": "src/nu2api/nu3d/nudlist.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist.o",
       "functions": [
         {
           "name": "NuDisplayListDrawItems",
@@ -86733,7 +86930,7 @@
     {
       "name": "nu2api/nu3d/nudlist_stubs.cpp.o",
       "source": "src/nu2api/nu3d/nudlist_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist_stubs.o",
       "functions": [
         {
           "name": "NuDisplayListCheckBuffer",
@@ -86812,7 +87009,7 @@
     {
       "name": "nu2api/nu3d/nufogstate.cpp.o",
       "source": "src/nu2api/nu3d/nufogstate.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufogstate.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nufogstate.o",
       "functions": [
         {
           "name": "NuRndrStateSetFogEnabled",
@@ -86835,7 +87032,7 @@
     {
       "name": "nu2api/nu3d/nugscn.cpp.o",
       "source": "src/nu2api/nu3d/nugscn.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn.o",
       "functions": [
         {
           "name": "_Z18NuGScnMtlLayerMaskP8nugscn_sh",
@@ -86930,7 +87127,7 @@
     {
       "name": "nu2api/nu3d/numtl.cpp.o",
       "source": "src/nu2api/nu3d/numtl.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numtl.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numtl.o",
       "functions": [
         {
           "name": "_Z13NuMtlUpdatePSP7numtl_s",
@@ -87010,7 +87207,7 @@
           "address": 3089856,
           "offset": 2199888,
           "size": 769,
-          "match_percent": 10.89441
+          "match_percent": 96.38509
         },
         {
           "name": "NuMtlSetCurrentRenderPlane",
@@ -87033,7 +87230,7 @@
     {
       "name": "nu2api/nu3d/nuocclusion.cpp.o",
       "source": "src/nu2api/nu3d/nuocclusion.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuocclusion.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuocclusion.o",
       "functions": [
         {
           "name": "NuOcclusionManagerBeginFrame",
@@ -87041,14 +87238,14 @@
           "address": 2831584,
           "offset": 1941616,
           "size": 36,
-          "match_percent": 33.0
+          "match_percent": 99.8
         }
       ]
     },
     {
       "name": "nu2api/nu3d/nuportal.cpp.o",
       "source": "src/nu2api/nu3d/nuportal.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuportal.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuportal.o",
       "functions": [
         {
           "name": "_ZL19transposeClipPlanesP10NUFRUSTRUM",
@@ -87111,7 +87308,7 @@
     {
       "name": "nu2api/nu3d/nuprim.cpp.o",
       "source": "src/nu2api/nu3d/nuprim.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuprim.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuprim.o",
       "functions": [
         {
           "name": "NuPrimPushCoordSystem",
@@ -87150,7 +87347,7 @@
     {
       "name": "nu2api/nu3d/nuqfnt.cpp.o",
       "source": "src/nu2api/nu3d/nuqfnt.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt.o",
       "functions": [
         {
           "name": "NuQFntPushPrintMode",
@@ -87413,7 +87610,7 @@
     {
       "name": "nu2api/nu3d/nurndr.cpp.o",
       "source": "src/nu2api/nu3d/nurndr.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr.o",
       "functions": [
         {
           "name": "_Z33NuRndrCreateBlendShapeDWAPointersi",
@@ -87596,7 +87793,7 @@
     {
       "name": "nu2api/nu3d/nurndr_grad.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_grad.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_grad.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_grad.o",
       "functions": [
         {
           "name": "NuRndrGradClear",
@@ -87611,7 +87808,7 @@
     {
       "name": "nu2api/nu3d/nurndr_noops.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_noops.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_noops.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_noops.o",
       "functions": [
         {
           "name": "NuRndrShadowOnOff",
@@ -87634,7 +87831,7 @@
     {
       "name": "nu2api/nu3d/nurndr_plain.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_plain.o",
       "functions": [
         {
           "name": "NuRndrPspDraw",
@@ -87717,20 +87914,12 @@
           "match_percent": 0.0
         },
         {
-          "name": "NuRndrSetSpecularLightPS",
-          "demangled_name": "NuRndrSetSpecularLightPS",
-          "address": 2711531,
-          "offset": 1821563,
-          "size": 2032,
-          "match_percent": 0.969977
-        },
-        {
           "name": "NuRndrSwapScreen",
           "demangled_name": "NuRndrSwapScreen",
           "address": 2713563,
           "offset": 1823595,
           "size": 173,
-          "match_percent": 46.88095
+          "match_percent": 47.0
         },
         {
           "name": "NuRndrSwapScreenEx",
@@ -87738,7 +87927,7 @@
           "address": 2713736,
           "offset": 1823768,
           "size": 48,
-          "match_percent": 42.52941
+          "match_percent": 54.235294
         },
         {
           "name": "NuRndrFx",
@@ -87882,7 +88071,7 @@
           "address": 2756841,
           "offset": 1866873,
           "size": 301,
-          "match_percent": 5.833334
+          "match_percent": 52.51389
         },
         {
           "name": "NuRndrStateUpdateCameraState",
@@ -88641,7 +88830,7 @@
     {
       "name": "nu2api/nu3d/nurndr_shadow.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_shadow.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_shadow.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_shadow.o",
       "functions": [
         {
           "name": "NuRndrAddShadow",
@@ -88654,9 +88843,24 @@
       ]
     },
     {
+      "name": "nu2api/nu3d/nurndr_specular.cpp.o",
+      "source": "src/nu2api/nu3d/nurndr_specular.cpp",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_specular.o",
+      "functions": [
+        {
+          "name": "NuRndrSetSpecularLightPS",
+          "demangled_name": "NuRndrSetSpecularLightPS",
+          "address": 2711531,
+          "offset": 1821563,
+          "size": 2032,
+          "match_percent": 99.34411
+        }
+      ]
+    },
+    {
       "name": "nu2api/nu3d/nuscreen.cpp.o",
       "source": "src/nu2api/nu3d/nuscreen.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuscreen.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuscreen.o",
       "functions": [
         {
           "name": "_ZN8NuScreen6CreateEv",
@@ -88727,7 +88931,7 @@
     {
       "name": "nu2api/nu3d/nushader.cpp.o",
       "source": "src/nu2api/nu3d/nushader.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nushader.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nushader.o",
       "functions": [
         {
           "name": "NuShaderProgramSetVertexParamfv",
@@ -88958,7 +89162,7 @@
     {
       "name": "nu2api/nu3d/nushadermanager_plain.cpp.o",
       "source": "src/nu2api/nu3d/nushadermanager_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nushadermanager_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nushadermanager_plain.o",
       "functions": [
         {
           "name": "NuShaderManagerInit",
@@ -89045,7 +89249,7 @@
     {
       "name": "nu2api/nu3d/nuspecial.cpp.o",
       "source": "src/nu2api/nu3d/nuspecial.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuspecial.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuspecial.o",
       "functions": [
         {
           "name": "NuSpecialGetName",
@@ -89140,7 +89344,7 @@
     {
       "name": "nu2api/nu3d/nuspline.c.o",
       "source": "src/nu2api/nu3d/nuspline.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuspline.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuspline.o",
       "functions": [
         {
           "name": "NuSplineFind",
@@ -89155,7 +89359,7 @@
     {
       "name": "nu2api/nu3d/nutex.cpp.o",
       "source": "src/nu2api/nu3d/nutex.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutex.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nutex.o",
       "functions": [
         {
           "name": "_Z15NuTexReadBitmapPc",
@@ -89362,13 +89566,13 @@
     {
       "name": "nu2api/nu3d/nutexanm.c.o",
       "source": "src/nu2api/nu3d/nutexanm.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanm.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanm.o",
       "functions": []
     },
     {
       "name": "nu2api/nu3d/nuvport.cpp.o",
       "source": "src/nu2api/nu3d/nuvport.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport.o",
       "functions": [
         {
           "name": "_Z16NuPs2GetViewportP12nuviewport_s",
@@ -89471,13 +89675,13 @@
     {
       "name": "nu2api/nu3d/nuvport_ps2.cpp.o",
       "source": "src/nu2api/nu3d/nuvport_ps2.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport_ps2.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport_ps2.o",
       "functions": []
     },
     {
       "name": "nu2api/nu3d/nuwater.cpp.o",
       "source": "src/nu2api/nu3d/nuwater.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater.o",
       "functions": [
         {
           "name": "NuWaterReset",
@@ -89492,7 +89696,7 @@
     {
       "name": "nu2api/nu3d/nuwater_speed.cpp.o",
       "source": "src/nu2api/nu3d/nuwater_speed.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater_speed.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater_speed.o",
       "functions": [
         {
           "name": "NuWaterSpeed",
@@ -89507,7 +89711,7 @@
     {
       "name": "nu2api/nuandroid/ios_graphics.cpp.o",
       "source": "src/nu2api/nuandroid/ios_graphics.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/ios_graphics.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/ios_graphics.o",
       "functions": [
         {
           "name": "NuIOS_ShouldUseMSAA",
@@ -89571,7 +89775,7 @@
           "address": 930896,
           "offset": 40928,
           "size": 86,
-          "match_percent": 11.909091
+          "match_percent": 99.954544
         },
         {
           "name": "NuIOS_WaitForRenderThreadCompletion",
@@ -89634,7 +89838,7 @@
     {
       "name": "nu2api/nuandroid/nuphoneos.cpp.o",
       "source": "src/nu2api/nuandroid/nuphoneos.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuphoneos.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuphoneos.o",
       "functions": [
         {
           "name": "NuPhoneOSRegisterEventCallback",
@@ -89649,7 +89853,7 @@
     {
       "name": "nu2api/nucore/NuInputDevice.cpp.o",
       "source": "src/nu2api/nucore/NuInputDevice.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice.o",
       "functions": [
         {
           "name": "_ZN13NuInputDevice15SetDisconnectedEv",
@@ -89760,7 +89964,7 @@
     {
       "name": "nu2api/nucore/NuInputManager.cpp.o",
       "source": "src/nu2api/nucore/NuInputManager.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputManager.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputManager.o",
       "functions": [
         {
           "name": "_ZN14NuInputManagerD1Ev",
@@ -89831,7 +90035,7 @@
     {
       "name": "nu2api/nucore/NuMemoryManager.cpp.o",
       "source": "src/nu2api/nucore/NuMemoryManager.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryManager.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryManager.o",
       "functions": [
         {
           "name": "_ZN15NuMemoryManager13IErrorHandler11HandleErrorEPS_NS_9ErrorCodeEPKc",
@@ -90182,7 +90386,7 @@
     {
       "name": "nu2api/nucore/NuMemoryPool.cpp.o",
       "source": "src/nu2api/nucore/NuMemoryPool.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryPool.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryPool.o",
       "functions": [
         {
           "name": "_ZN12NuMemoryPool14InterlockedAddEPVjj",
@@ -90213,7 +90417,7 @@
     {
       "name": "nu2api/nucore/NuThreadManager.cpp.o",
       "source": "src/nu2api/nucore/NuThreadManager.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuThreadManager.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuThreadManager.o",
       "functions": [
         {
           "name": "_ZN15NuThreadManagerC1Ev",
@@ -90284,7 +90488,7 @@
     {
       "name": "nu2api/nucore/NuVirtualTouchDevice.cpp.o",
       "source": "src/nu2api/nucore/NuVirtualTouchDevice.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuVirtualTouchDevice.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuVirtualTouchDevice.o",
       "functions": [
         {
           "name": "_ZN20NuVirtualTouchDeviceC1Ej",
@@ -90347,15 +90551,23 @@
     {
       "name": "nu2api/nucore/android/NuInputDevice_android.cpp.o",
       "source": "src/nu2api/nucore/android/NuInputDevice_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice_android.o",
       "functions": [
+        {
+          "name": "_GLOBAL__sub_I_NuInputDevice_android.cpp",
+          "demangled_name": "_GLOBAL__sub_I_NuInputDevice_android.cpp",
+          "address": 892176,
+          "offset": 2208,
+          "size": 313,
+          "match_percent": 10.690909
+        },
         {
           "name": "_ZN15NuInputDevicePS11ClassInitPSEv",
           "demangled_name": "NuInputDevicePS::ClassInitPS()",
           "address": 975360,
           "offset": 85392,
           "size": 115,
-          "match_percent": 14.666667
+          "match_percent": 99.8
         },
         {
           "name": "_ZN15NuInputDevicePS15ClassShutdownPSEv",
@@ -90371,7 +90583,7 @@
           "address": 975504,
           "offset": 85536,
           "size": 997,
-          "match_percent": 2.0
+          "match_percent": 99.46667
         },
         {
           "name": "_ZN15NuInputDevicePS13IsConnectedPSEj",
@@ -90427,7 +90639,7 @@
           "address": 976704,
           "offset": 86736,
           "size": 320,
-          "match_percent": 5.316456
+          "match_percent": 99.93671
         },
         {
           "name": "_ZN15NuInputDevicePS18ReadMotionValuesPSEjPf",
@@ -90435,7 +90647,7 @@
           "address": 977024,
           "offset": 87056,
           "size": 181,
-          "match_percent": 8.235294
+          "match_percent": 99.94118
         },
         {
           "name": "_ZN15NuInputDevicePS15ReadTouchDataPSEjP16NuInputTouchData",
@@ -90443,7 +90655,7 @@
           "address": 977216,
           "offset": 87248,
           "size": 194,
-          "match_percent": 7.241379
+          "match_percent": 99.965515
         },
         {
           "name": "_ZN15NuInputDevicePS15ReadMouseDataPSEjP16NuInputMouseData",
@@ -90451,7 +90663,7 @@
           "address": 977424,
           "offset": 87456,
           "size": 32,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuInputDevicePS11SetMotorsPSEjff",
@@ -90478,12 +90690,20 @@
           "match_percent": 100.0
         },
         {
+          "name": "_ZN15NuInputDevicePS28HandleTouch_ANDROID_SPECIFICEiiiff",
+          "demangled_name": "NuInputDevicePS::HandleTouch_ANDROID_SPECIFIC(int, int, int, float, float)",
+          "address": 977536,
+          "offset": 87568,
+          "size": 135,
+          "match_percent": 99.29412
+        },
+        {
           "name": "_ZN15NuInputDevicePS21GetGamePadButtonIndexEiPi",
           "demangled_name": "NuInputDevicePS::GetGamePadButtonIndex(int, int*)",
           "address": 977680,
           "offset": 87712,
           "size": 148,
-          "match_percent": 11.578947
+          "match_percent": 70.23684
         },
         {
           "name": "_ZN15NuInputDevicePS30HandleKeyDown_ANDROID_SPECIFICEi",
@@ -90502,19 +90722,35 @@
           "match_percent": 99.85714
         },
         {
+          "name": "_ZN15NuInputDevicePS34HandleGamePadAxis_ANDROID_SPECIFICEffffff",
+          "demangled_name": "NuInputDevicePS::HandleGamePadAxis_ANDROID_SPECIFIC(float, float, float, float, float, float)",
+          "address": 978064,
+          "offset": 88096,
+          "size": 129,
+          "match_percent": 99.888885
+        },
+        {
           "name": "_ZN15NuInputDevicePS27HandleGamepPadStatusConnectEb",
           "demangled_name": "NuInputDevicePS::HandleGamepPadStatusConnect(bool)",
           "address": 978208,
           "offset": 88240,
           "size": 24,
           "match_percent": 99.666664
+        },
+        {
+          "name": "_ZN15NuInputDevicePS29HandleSensor_ANDROID_SPECIFICEifff",
+          "demangled_name": "NuInputDevicePS::HandleSensor_ANDROID_SPECIFIC(int, float, float, float)",
+          "address": 978240,
+          "offset": 88272,
+          "size": 9,
+          "match_percent": 100.0
         }
       ]
     },
     {
       "name": "nu2api/nucore/android/NuThread_android.cpp.o",
       "source": "src/nu2api/nucore/android/NuThread_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuThread_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuThread_android.o",
       "functions": [
         {
           "name": "_ZN8NuThreadD1Ev",
@@ -90570,7 +90806,7 @@
           "address": 982800,
           "offset": 92832,
           "size": 193,
-          "match_percent": 87.26786
+          "match_percent": 99.94643
         },
         {
           "name": "_Z24NuThreadGetCurrentThreadv",
@@ -90713,7 +90949,7 @@
     {
       "name": "nu2api/nucore/android/bgproc_android.cpp.o",
       "source": "src/nu2api/nucore/android/bgproc_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/bgproc_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/bgproc_android.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_bgproc_android.cpp",
@@ -90768,7 +91004,7 @@
     {
       "name": "nu2api/nucore/android/nuapi_android.cpp.o",
       "source": "src/nu2api/nucore/android/nuapi_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuapi_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuapi_android.o",
       "functions": [
         {
           "name": "NudxFw_D3DBeginCriticalSection",
@@ -90800,7 +91036,7 @@
           "address": 2555303,
           "offset": 1665335,
           "size": 288,
-          "match_percent": 95.338234
+          "match_percent": 99.838234
         },
         {
           "name": "_Z25NuInitHardwareParseArgsPSiPPc",
@@ -90815,7 +91051,7 @@
     {
       "name": "nu2api/nucore/android/numemory_android.cpp.o",
       "source": "src/nu2api/nucore/android/numemory_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numemory_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numemory_android.o",
       "functions": [
         {
           "name": "_ZN10NuMemoryPS16Mem2EventHandler12AllocatePageEP15NuMemoryManagerjj",
@@ -90886,7 +91122,7 @@
     {
       "name": "nu2api/nucore/android/nupad_android.cpp.o",
       "source": "src/nu2api/nucore/android/nupad_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_android.o",
       "functions": [
         {
           "name": "_Z11NuPadOpenPSP7nupad_s",
@@ -90925,7 +91161,7 @@
     {
       "name": "nu2api/nucore/android/nutime_android.cpp.o",
       "source": "src/nu2api/nucore/android/nutime_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutime_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nutime_android.o",
       "functions": [
         {
           "name": "_Z29NuGetCurrentTimeMilisecondsPSv",
@@ -90964,7 +91200,7 @@
     {
       "name": "nu2api/nucore/android/nuvideo_android.cpp.o",
       "source": "src/nu2api/nucore/android/nuvideo_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo_android.o",
       "functions": [
         {
           "name": "_Z20NuVideoSetSwapModePS16NUVIDEO_SWAPMODE",
@@ -90995,7 +91231,7 @@
     {
       "name": "nu2api/nucore/deflate.cpp.o",
       "source": "src/nu2api/nucore/deflate.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/deflate.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/deflate.o",
       "functions": [
         {
           "name": "_Z16BuildHuffmanTreeP10DEFHUFFMANPhi",
@@ -91066,7 +91302,7 @@
     {
       "name": "nu2api/nucore/implode.cpp.o",
       "source": "src/nu2api/nucore/implode.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/implode.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/implode.o",
       "functions": [
         {
           "name": "_ZL7__sputciP7__sFILE",
@@ -91233,7 +91469,7 @@
     {
       "name": "nu2api/nucore/nu2api_nucore_misc.cpp.o",
       "source": "src/nu2api/nucore/nu2api_nucore_misc.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc.o",
       "functions": [
         {
           "name": "_Z30NuIOS_CateInAppPurchaseManagerv",
@@ -91444,14 +91680,6 @@
           "match_percent": 4.827586
         },
         {
-          "name": "_ZL15NuErrorFunctionPcz",
-          "demangled_name": "NuErrorFunction(char*, ...)",
-          "address": 2546843,
-          "offset": 1656875,
-          "size": 197,
-          "match_percent": 8.4
-        },
-        {
           "name": "_ZL17NuWarningFunctionPcz",
           "demangled_name": "NuWarningFunction(char*, ...)",
           "address": 2547081,
@@ -91481,7 +91709,7 @@
           "address": 2557769,
           "offset": 1667801,
           "size": 47,
-          "match_percent": 28.0
+          "match_percent": 65.4
         },
         {
           "name": "_Z14NuWarningPrintPc",
@@ -91497,7 +91725,7 @@
           "address": 2557863,
           "offset": 1667895,
           "size": 47,
-          "match_percent": 28.0
+          "match_percent": 65.4
         },
         {
           "name": "_Z23NuTimeGetMicrosecondsPSPjS_",
@@ -92052,20 +92280,12 @@
           "match_percent": 3.853211
         },
         {
-          "name": "_Z17NuWindAllocateGrpv",
-          "demangled_name": "NuWindAllocateGrp()",
-          "address": 3171384,
-          "offset": 2281416,
-          "size": 119,
-          "match_percent": 11.666667
-        },
-        {
           "name": "_Z13NuWindFreeGrpP11NuWindGType",
           "demangled_name": "NuWindFreeGrp(NuWindGType*)",
           "address": 3171503,
           "offset": 2281535,
           "size": 20,
-          "match_percent": 35.0
+          "match_percent": 54.875
         },
         {
           "name": "_Z25NuIOS_GetShaderProgramKeyRK15ShaderObjectKey",
@@ -92209,7 +92429,7 @@
           "address": 5420656,
           "offset": 4530688,
           "size": 50,
-          "match_percent": 35.0
+          "match_percent": 99.916664
         },
         {
           "name": "_ZNK8NuNetEmu9PackStats4DrawEffffN13NetSmallStats5eInfoE",
@@ -92264,7 +92484,7 @@
     {
       "name": "nu2api/nucore/nu2api_nucore_misc_stubs.cpp.o",
       "source": "src/nu2api/nucore/nu2api_nucore_misc_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc_stubs.o",
       "functions": [
         {
           "name": "_Z19NuTerminateHardwarev",
@@ -92335,7 +92555,7 @@
     {
       "name": "nu2api/nucore/nuanim.cpp.o",
       "source": "src/nu2api/nucore/nuanim.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuanim.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuanim.o",
       "functions": [
         {
           "name": "NuAnimEndFrame",
@@ -92358,7 +92578,7 @@
     {
       "name": "nu2api/nucore/nuapi.c.o",
       "source": "src/nu2api/nucore/nuapi.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nuapi.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/0/nuapi.o",
       "functions": [
         {
           "name": "NuPrimReset",
@@ -92381,7 +92601,7 @@
     {
       "name": "nu2api/nucore/nuapi.cpp.o",
       "source": "src/nu2api/nucore/nuapi.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nuapi.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/1/nuapi.o",
       "functions": [
         {
           "name": "_Z9NuAPIInitv",
@@ -92420,7 +92640,7 @@
     {
       "name": "nu2api/nucore/nucore.cpp.o",
       "source": "src/nu2api/nucore/nucore.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucore.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nucore.o",
       "functions": [
         {
           "name": "_ZN6NuCore19GetApplicationStateEv",
@@ -92557,134 +92777,6 @@
           "offset": 97872,
           "size": 9,
           "match_percent": 100.0
-        },
-        {
-          "name": "_ZN13NuDeviceSpecsC1Ev",
-          "demangled_name": "NuDeviceSpecs::NuDeviceSpecs()",
-          "address": 988672,
-          "offset": 98704,
-          "size": 40,
-          "match_percent": 38.18182
-        },
-        {
-          "name": "_ZN13NuDeviceSpecsC2Ev",
-          "demangled_name": "NuDeviceSpecs::NuDeviceSpecs()",
-          "address": 988672,
-          "offset": 98704,
-          "size": 40,
-          "match_percent": 38.18182
-        },
-        {
-          "name": "_ZN14NuRenderDevice13PreInitializeEv",
-          "demangled_name": "NuRenderDevice::PreInitialize()",
-          "address": 2779408,
-          "offset": 1889440,
-          "size": 9,
-          "match_percent": 100.0
-        },
-        {
-          "name": "_ZNK14NuRenderDevice17MultiThreadRenderEv",
-          "demangled_name": "NuRenderDevice::MultiThreadRender() const",
-          "address": 2779424,
-          "offset": 1889456,
-          "size": 17,
-          "match_percent": 0.0
-        },
-        {
-          "name": "_ZN14NuRenderDevice19OpenglErrorCallbackEjjjjiPKcPv",
-          "demangled_name": "NuRenderDevice::OpenglErrorCallback(unsigned int, unsigned int, unsigned int, unsigned int, int, char const*, void*)",
-          "address": 2779632,
-          "offset": 1889664,
-          "size": 9,
-          "match_percent": 100.0
-        },
-        {
-          "name": "_ZNK14NuRenderDevice14IsContextValidEv",
-          "demangled_name": "NuRenderDevice::IsContextValid() const",
-          "address": 2780000,
-          "offset": 1890032,
-          "size": 16,
-          "match_percent": 14.285714
-        },
-        {
-          "name": "_ZNK14NuRenderDevice27DetermineNominalAspectRatioEjj",
-          "demangled_name": "NuRenderDevice::DetermineNominalAspectRatio(unsigned int, unsigned int) const",
-          "address": 2781728,
-          "offset": 1891760,
-          "size": 161,
-          "match_percent": 10.0
-        },
-        {
-          "name": "_ZN14NuRenderDevice15OnWindowDestroyEv",
-          "demangled_name": "NuRenderDevice::OnWindowDestroy()",
-          "address": 2781968,
-          "offset": 1892000,
-          "size": 43,
-          "match_percent": 38.18182
-        },
-        {
-          "name": "_ZN14NuRenderDevice11OnAppResumeEv",
-          "demangled_name": "NuRenderDevice::OnAppResume()",
-          "address": 2782016,
-          "offset": 1892048,
-          "size": 38,
-          "match_percent": 38.18182
-        },
-        {
-          "name": "_ZN14NuRenderDevice11OnAppPausedEv",
-          "demangled_name": "NuRenderDevice::OnAppPaused()",
-          "address": 2782064,
-          "offset": 1892096,
-          "size": 51,
-          "match_percent": 32.307693
-        },
-        {
-          "name": "_ZN14NuRenderDevice13OnGainedFocusEv",
-          "demangled_name": "NuRenderDevice::OnGainedFocus()",
-          "address": 2782128,
-          "offset": 1892160,
-          "size": 38,
-          "match_percent": 38.18182
-        },
-        {
-          "name": "_ZN14NuRenderDevice11OnLostFocusEv",
-          "demangled_name": "NuRenderDevice::OnLostFocus()",
-          "address": 2782176,
-          "offset": 1892208,
-          "size": 51,
-          "match_percent": 32.307693
-        },
-        {
-          "name": "_ZN14NuRenderDevice12OnAppStartedEv",
-          "demangled_name": "NuRenderDevice::OnAppStarted()",
-          "address": 2782240,
-          "offset": 1892272,
-          "size": 9,
-          "match_percent": 100.0
-        },
-        {
-          "name": "_ZN14NuRenderDevice14OnAppRestartedEv",
-          "demangled_name": "NuRenderDevice::OnAppRestarted()",
-          "address": 2782256,
-          "offset": 1892288,
-          "size": 34,
-          "match_percent": 42.0
-        },
-        {
-          "name": "_ZN14NuRenderDevice12OnAppStoppedEv",
-          "demangled_name": "NuRenderDevice::OnAppStopped()",
-          "address": 2782304,
-          "offset": 1892336,
-          "size": 43,
-          "match_percent": 38.18182
-        },
-        {
-          "name": "_ZN14NuRenderDevice12ResizeDeviceEiiibbbb",
-          "demangled_name": "NuRenderDevice::ResizeDevice(int, int, int, bool, bool, bool, bool)",
-          "address": 2783264,
-          "offset": 1893296,
-          "size": 266,
-          "match_percent": 7.241379
         },
         {
           "name": "_ZN15NuMainFilterGen23destroyTextureResourcesEv",
@@ -93513,9 +93605,32 @@
       ]
     },
     {
+      "name": "nu2api/nucore/nucore_frame.cpp.o",
+      "source": "src/nu2api/nucore/nucore_frame.cpp",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nucore_frame.o",
+      "functions": [
+        {
+          "name": "NuFrameSetMinDelay",
+          "demangled_name": "NuFrameSetMinDelay",
+          "address": 2530718,
+          "offset": 1640750,
+          "size": 26,
+          "match_percent": 99.75
+        },
+        {
+          "name": "NuFrameEnd",
+          "demangled_name": "NuFrameEnd",
+          "address": 2531300,
+          "offset": 1641332,
+          "size": 730,
+          "match_percent": 95.61326
+        }
+      ]
+    },
+    {
       "name": "nu2api/nucore/nucore_plain.cpp.o",
       "source": "src/nu2api/nucore/nucore_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucore_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nucore_plain.o",
       "functions": [
         {
           "name": "NuIOS_DeallocateSystemRenderbuffer",
@@ -93571,7 +93686,7 @@
           "address": 932880,
           "offset": 42912,
           "size": 202,
-          "match_percent": 97.05357
+          "match_percent": 99.91071
         },
         {
           "name": "_ZN7_JNIEnv20CallStaticVoidMethodEP7_jclassP10_jmethodIDz",
@@ -94574,28 +94689,12 @@
           "match_percent": 0.0
         },
         {
-          "name": "NuFrameSetMinDelay",
-          "demangled_name": "NuFrameSetMinDelay",
-          "address": 2530718,
-          "offset": 1640750,
-          "size": 26,
-          "match_percent": 35.0
-        },
-        {
           "name": "NuErrorSleep",
           "demangled_name": "NuErrorSleep",
           "address": 2530744,
           "offset": 1640776,
           "size": 556,
           "match_percent": 3.181818
-        },
-        {
-          "name": "NuFrameEnd",
-          "demangled_name": "NuFrameEnd",
-          "address": 2531300,
-          "offset": 1641332,
-          "size": 730,
-          "match_percent": 6.331492
         },
         {
           "name": "NuRegisterEndFrameCallBackFn",
@@ -94830,14 +94929,6 @@
           "match_percent": 46.666668
         },
         {
-          "name": "NuErrorProlog",
-          "demangled_name": "NuErrorProlog",
-          "address": 2547040,
-          "offset": 1657072,
-          "size": 41,
-          "match_percent": 38.18182
-        },
-        {
           "name": "NuWarningProlog",
           "demangled_name": "NuWarningProlog",
           "address": 2547294,
@@ -94876,46 +94967,6 @@
           "offset": 1657762,
           "size": 87,
           "match_percent": 17.5
-        },
-        {
-          "name": "NuGetErrN",
-          "demangled_name": "NuGetErrN",
-          "address": 2547817,
-          "offset": 1657849,
-          "size": 114,
-          "match_percent": 12.352942
-        },
-        {
-          "name": "NuGetError",
-          "demangled_name": "NuGetError",
-          "address": 2547931,
-          "offset": 1657963,
-          "size": 39,
-          "match_percent": 35.0
-        },
-        {
-          "name": "NuSevereWarning",
-          "demangled_name": "NuSevereWarning",
-          "address": 2547970,
-          "offset": 1658002,
-          "size": 282,
-          "match_percent": 5.833334
-        },
-        {
-          "name": "NuHasError",
-          "demangled_name": "NuHasError",
-          "address": 2548252,
-          "offset": 1658284,
-          "size": 22,
-          "match_percent": 20.0
-        },
-        {
-          "name": "NuClearError",
-          "demangled_name": "NuClearError",
-          "address": 2548274,
-          "offset": 1658306,
-          "size": 26,
-          "match_percent": 20.0
         },
         {
           "name": "_Z14NuXboxLiveInitv",
@@ -95444,14 +95495,6 @@
           "offset": 1770273,
           "size": 236,
           "match_percent": 6.176471
-        },
-        {
-          "name": "NuWindRand",
-          "demangled_name": "NuWindRand",
-          "address": 2660766,
-          "offset": 1770798,
-          "size": 52,
-          "match_percent": 28.0
         },
         {
           "name": "NuCubicToBez3",
@@ -96198,14 +96241,6 @@
           "match_percent": 30.0
         },
         {
-          "name": "NuRenderDeviceIsContextValid",
-          "demangled_name": "NuRenderDeviceIsContextValid",
-          "address": 2782352,
-          "offset": 1892384,
-          "size": 39,
-          "match_percent": 38.18182
-        },
-        {
           "name": "NuPostEffectEnable",
           "demangled_name": "NuPostEffectEnable",
           "address": 2800096,
@@ -96339,7 +96374,7 @@
           "address": 2831392,
           "offset": 1941424,
           "size": 23,
-          "match_percent": 0.0
+          "match_percent": 99.71429
         },
         {
           "name": "NuOcclusionManagerIsEnabled",
@@ -96347,7 +96382,7 @@
           "address": 2831424,
           "offset": 1941456,
           "size": 29,
-          "match_percent": 35.0
+          "match_percent": 99.75
         },
         {
           "name": "NuOcclusionManagerSetEnabled",
@@ -96355,7 +96390,7 @@
           "address": 2831456,
           "offset": 1941488,
           "size": 51,
-          "match_percent": 28.0
+          "match_percent": 99.86667
         },
         {
           "name": "NuOcclusionManagerSetOccluderDotProductThreshold",
@@ -96363,7 +96398,7 @@
           "address": 2831520,
           "offset": 1941552,
           "size": 32,
-          "match_percent": 0.0
+          "match_percent": 99.666664
         },
         {
           "name": "NuOcclusionManagerSetOccluderScreenSpaceThreshold",
@@ -96371,7 +96406,7 @@
           "address": 2831552,
           "offset": 1941584,
           "size": 32,
-          "match_percent": 0.0
+          "match_percent": 99.666664
         },
         {
           "name": "NuOcclusionManagerEndFrame",
@@ -96379,7 +96414,7 @@
           "address": 2831632,
           "offset": 1941664,
           "size": 36,
-          "match_percent": 42.0
+          "match_percent": 99.8
         },
         {
           "name": "NuOcclusionManagerOnCameraSet",
@@ -96387,7 +96422,7 @@
           "address": 2831680,
           "offset": 1941712,
           "size": 36,
-          "match_percent": 42.0
+          "match_percent": 99.8
         },
         {
           "name": "NuOcclusionManagerRenderZPass",
@@ -96395,7 +96430,7 @@
           "address": 2831728,
           "offset": 1941760,
           "size": 36,
-          "match_percent": 42.0
+          "match_percent": 99.8
         },
         {
           "name": "NuDynamicLightSetDirectional",
@@ -97347,7 +97382,7 @@
           "address": 2923360,
           "offset": 2033392,
           "size": 22,
-          "match_percent": 0.0
+          "match_percent": 99.71429
         },
         {
           "name": "NuQFntHeightScale",
@@ -97355,7 +97390,7 @@
           "address": 2923392,
           "offset": 2033424,
           "size": 22,
-          "match_percent": 0.0
+          "match_percent": 99.71429
         },
         {
           "name": "NuQFntPushCoordinateSystem",
@@ -97363,7 +97398,7 @@
           "address": 2923792,
           "offset": 2033824,
           "size": 83,
-          "match_percent": 19.09091
+          "match_percent": 99.818184
         },
         {
           "name": "NuQFntPopCoordinateSystem",
@@ -97371,7 +97406,7 @@
           "address": 2923888,
           "offset": 2033920,
           "size": 56,
-          "match_percent": 24.705883
+          "match_percent": 99.82353
         },
         {
           "name": "NuQFntGetCoordinateSystem",
@@ -97379,7 +97414,7 @@
           "address": 2923952,
           "offset": 2033984,
           "size": 22,
-          "match_percent": 0.0
+          "match_percent": 99.71429
         },
         {
           "name": "NuQFntEncodeUnicodeString",
@@ -97443,7 +97478,7 @@
           "address": 2928304,
           "offset": 2038336,
           "size": 59,
-          "match_percent": 28.0
+          "match_percent": 99.933334
         },
         {
           "name": "NuQFntMove2d",
@@ -97451,7 +97486,7 @@
           "address": 2928432,
           "offset": 2038464,
           "size": 87,
-          "match_percent": 22.105263
+          "match_percent": 99.947365
         },
         {
           "name": "NuFntInit",
@@ -97651,7 +97686,7 @@
           "address": 2937168,
           "offset": 2047200,
           "size": 257,
-          "match_percent": 99.932205
+          "match_percent": 99.67796
         },
         {
           "name": "NuHGobjEvalAnim2Root",
@@ -97907,7 +97942,7 @@
           "address": 2963376,
           "offset": 2073408,
           "size": 22,
-          "match_percent": 12.5
+          "match_percent": 99.75
         },
         {
           "name": "NuCameraGetVPCSMtx",
@@ -97915,7 +97950,7 @@
           "address": 2963440,
           "offset": 2073472,
           "size": 22,
-          "match_percent": 12.5
+          "match_percent": 99.75
         },
         {
           "name": "NuCameraGetPCSMtx",
@@ -97923,7 +97958,7 @@
           "address": 2963472,
           "offset": 2073504,
           "size": 22,
-          "match_percent": 12.5
+          "match_percent": 99.75
         },
         {
           "name": "NuOcclusionManagerIsOccludedOBB",
@@ -97931,7 +97966,7 @@
           "address": 2963760,
           "offset": 2073792,
           "size": 63,
-          "match_percent": 24.705883
+          "match_percent": 99.882355
         },
         {
           "name": "NuOcclusionManagerIsOccludedSphere",
@@ -97939,7 +97974,7 @@
           "address": 2964000,
           "offset": 2074032,
           "size": 59,
-          "match_percent": 28.0
+          "match_percent": 99.86667
         },
         {
           "name": "NuOcclusionManagerAddOccluderQuad",
@@ -97947,7 +97982,7 @@
           "address": 2965040,
           "offset": 2075072,
           "size": 68,
-          "match_percent": 23.333334
+          "match_percent": 99.888885
         },
         {
           "name": "NuOcclusionManagerAddOccluderOBB",
@@ -97955,7 +97990,7 @@
           "address": 2965792,
           "offset": 2075824,
           "size": 60,
-          "match_percent": 26.25
+          "match_percent": 99.875
         },
         {
           "name": "NuOcclusionManagerAddOccluderSphere",
@@ -97963,7 +97998,7 @@
           "address": 2966480,
           "offset": 2076512,
           "size": 56,
-          "match_percent": 30.0
+          "match_percent": 99.85714
         },
         {
           "name": "NuCameraGetPCMtx",
@@ -97971,7 +98006,7 @@
           "address": 2966544,
           "offset": 2076576,
           "size": 22,
-          "match_percent": 12.5
+          "match_percent": 99.75
         },
         {
           "name": "NuCameraClearStateBuffer",
@@ -98531,7 +98566,7 @@
           "address": 2995456,
           "offset": 2105488,
           "size": 1509,
-          "match_percent": 16.788343
+          "match_percent": 69.04601
         },
         {
           "name": "NuCameraSet",
@@ -98547,7 +98582,7 @@
           "address": 2997024,
           "offset": 2107056,
           "size": 60,
-          "match_percent": 24.705883
+          "match_percent": 99.82353
         },
         {
           "name": "NuCameraUnlock",
@@ -98555,7 +98590,7 @@
           "address": 2997088,
           "offset": 2107120,
           "size": 60,
-          "match_percent": 24.705883
+          "match_percent": 99.82353
         },
         {
           "name": "NuCameraLock",
@@ -98563,7 +98598,7 @@
           "address": 2997152,
           "offset": 2107184,
           "size": 142,
-          "match_percent": 10.769231
+          "match_percent": 99.84615
         },
         {
           "name": "NuCameraSetReflect",
@@ -98571,7 +98606,7 @@
           "address": 2997296,
           "offset": 2107328,
           "size": 90,
-          "match_percent": 19.09091
+          "match_percent": 99.86364
         },
         {
           "name": "NuViewPortSet",
@@ -98595,7 +98630,7 @@
           "address": 3017648,
           "offset": 2127680,
           "size": 312,
-          "match_percent": 96.85
+          "match_percent": 96.6625
         },
         {
           "name": "NuVisiOctree",
@@ -98611,7 +98646,7 @@
           "address": 3032480,
           "offset": 2142512,
           "size": 62,
-          "match_percent": 0.0
+          "match_percent": 99.833336
         },
         {
           "name": "NuWindSetWorldSize",
@@ -98619,7 +98654,7 @@
           "address": 3032544,
           "offset": 2142576,
           "size": 56,
-          "match_percent": 30.0
+          "match_percent": 82.0
         },
         {
           "name": "NuWindSetSpeed",
@@ -98627,7 +98662,7 @@
           "address": 3032608,
           "offset": 2142640,
           "size": 56,
-          "match_percent": 30.0
+          "match_percent": 82.0
         },
         {
           "name": "NuWindCurrent",
@@ -98635,7 +98670,7 @@
           "address": 3032672,
           "offset": 2142704,
           "size": 30,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "NuWindAnimate",
@@ -98643,7 +98678,7 @@
           "address": 3032704,
           "offset": 2142736,
           "size": 153,
-          "match_percent": 12.727273
+          "match_percent": 91.242424
         },
         {
           "name": "NuLgtLaser",
@@ -98923,7 +98958,7 @@
           "address": 3091280,
           "offset": 2201312,
           "size": 60,
-          "match_percent": 26.25
+          "match_percent": 99.875
         },
         {
           "name": "NuDisplayListRndrSpecial",
@@ -98979,7 +99014,7 @@
           "address": 3102368,
           "offset": 2212400,
           "size": 1122,
-          "match_percent": 53.963577
+          "match_percent": 53.913906
         },
         {
           "name": "NuQFntPrint3DU",
@@ -98995,7 +99030,7 @@
           "address": 3114176,
           "offset": 2224208,
           "size": 59,
-          "match_percent": 28.0
+          "match_percent": 99.933334
         },
         {
           "name": "NuOcclusionManagerRenderStats",
@@ -99067,7 +99102,7 @@
           "address": 3127184,
           "offset": 2237216,
           "size": 135,
-          "match_percent": 10.769231
+          "match_percent": 73.92308
         },
         {
           "name": "NuWindUnload",
@@ -99075,7 +99110,7 @@
           "address": 3127328,
           "offset": 2237360,
           "size": 78,
-          "match_percent": 20.0
+          "match_percent": 99.95238
         },
         {
           "name": "NuHGobjDestroy",
@@ -99404,54 +99439,6 @@
           "offset": 2280548,
           "size": 315,
           "match_percent": 4.421053
-        },
-        {
-          "name": "NuWindInit",
-          "demangled_name": "NuWindInit",
-          "address": 3171277,
-          "offset": 2281309,
-          "size": 107,
-          "match_percent": 15.555555
-        },
-        {
-          "name": "NuWindCreateMtx",
-          "demangled_name": "NuWindCreateMtx",
-          "address": 3171523,
-          "offset": 2281555,
-          "size": 918,
-          "match_percent": 1.640625
-        },
-        {
-          "name": "NuWindUpdateArray",
-          "demangled_name": "NuWindUpdateArray",
-          "address": 3172441,
-          "offset": 2282473,
-          "size": 4927,
-          "match_percent": 0.361446
-        },
-        {
-          "name": "NuWindUpdate",
-          "demangled_name": "NuWindUpdate",
-          "address": 3177368,
-          "offset": 2287400,
-          "size": 78,
-          "match_percent": 17.5
-        },
-        {
-          "name": "NuWindDraw",
-          "demangled_name": "NuWindDraw",
-          "address": 3177446,
-          "offset": 2287478,
-          "size": 589,
-          "match_percent": 2.545454
-        },
-        {
-          "name": "NuWindSetup",
-          "demangled_name": "NuWindSetup",
-          "address": 3178035,
-          "offset": 2288067,
-          "size": 84,
-          "match_percent": 15.0
         },
         {
           "name": "_Z29NuShaderObject360LoadPackFilePcP9variptr_uS0_",
@@ -100008,9 +99995,64 @@
       ]
     },
     {
+      "name": "nu2api/nucore/nuerror.cpp.o",
+      "source": "src/nu2api/nucore/nuerror.cpp",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuerror.o",
+      "functions": [
+        {
+          "name": "NuErrorProlog",
+          "demangled_name": "NuErrorProlog",
+          "address": 2547040,
+          "offset": 1657072,
+          "size": 41,
+          "match_percent": 99.63636
+        },
+        {
+          "name": "NuGetErrN",
+          "demangled_name": "NuGetErrN",
+          "address": 2547817,
+          "offset": 1657849,
+          "size": 114,
+          "match_percent": 93.882355
+        },
+        {
+          "name": "NuGetError",
+          "demangled_name": "NuGetError",
+          "address": 2547931,
+          "offset": 1657963,
+          "size": 39,
+          "match_percent": 99.75
+        },
+        {
+          "name": "NuSevereWarning",
+          "demangled_name": "NuSevereWarning",
+          "address": 2547970,
+          "offset": 1658002,
+          "size": 282,
+          "match_percent": 93.361115
+        },
+        {
+          "name": "NuHasError",
+          "demangled_name": "NuHasError",
+          "address": 2548252,
+          "offset": 1658284,
+          "size": 22,
+          "match_percent": 99.71429
+        },
+        {
+          "name": "NuClearError",
+          "demangled_name": "NuClearError",
+          "address": 2548274,
+          "offset": 1658306,
+          "size": 26,
+          "match_percent": 99.71429
+        }
+      ]
+    },
+    {
       "name": "nu2api/nucore/nuhgobj.cpp.o",
       "source": "src/nu2api/nucore/nuhgobj.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuhgobj.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuhgobj.o",
       "functions": [
         {
           "name": "NuHGobjGetLayerIndex",
@@ -100025,7 +100067,7 @@
     {
       "name": "nu2api/nucore/nuios_metrics.cpp.o",
       "source": "src/nu2api/nucore/nuios_metrics.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuios_metrics.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuios_metrics.o",
       "functions": [
         {
           "name": "NuIOS_GetAspectRatio",
@@ -100048,7 +100090,7 @@
     {
       "name": "nu2api/nucore/nukeyboard.cpp.o",
       "source": "src/nu2api/nucore/nukeyboard.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nukeyboard.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nukeyboard.o",
       "functions": [
         {
           "name": "NuKeyboardRead",
@@ -100063,7 +100105,7 @@
     {
       "name": "nu2api/nucore/nulanguage.cpp.o",
       "source": "src/nu2api/nucore/nulanguage.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nulanguage.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nulanguage.o",
       "functions": [
         {
           "name": "NuLanguageGet",
@@ -100086,7 +100128,7 @@
     {
       "name": "nu2api/nucore/nulist.cpp.o",
       "source": "src/nu2api/nucore/nulist.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nulist.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nulist.o",
       "functions": [
         {
           "name": "NuLinkedListAppend",
@@ -100149,7 +100191,7 @@
     {
       "name": "nu2api/nucore/nulst.cpp.o",
       "source": "src/nu2api/nucore/nulst.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nulst.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nulst.o",
       "functions": [
         {
           "name": "NuLstCreate",
@@ -100228,7 +100270,7 @@
     {
       "name": "nu2api/nucore/numem.c.o",
       "source": "src/nu2api/nucore/numem.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numem.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numem.o",
       "functions": [
         {
           "name": "NuMemSet128",
@@ -100243,7 +100285,7 @@
     {
       "name": "nu2api/nucore/numemory.cpp.o",
       "source": "src/nu2api/nucore/numemory.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numemory.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numemory.o",
       "functions": [
         {
           "name": "_ZN8NuMemory21FixedPoolEventHandler12AllocatePageEP12NuMemoryPooljjPKc",
@@ -101002,7 +101044,7 @@
     {
       "name": "nu2api/nucore/numouse.cpp.o",
       "source": "src/nu2api/nucore/numouse.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numouse.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numouse.o",
       "functions": [
         {
           "name": "NuMouseRead",
@@ -101017,7 +101059,7 @@
     {
       "name": "nu2api/nucore/nunew.cpp.o",
       "source": "src/nu2api/nucore/nunew.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nunew.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nunew.o",
       "functions": [
         {
           "name": "_Znwj",
@@ -101120,7 +101162,7 @@
     {
       "name": "nu2api/nucore/nupad.cpp.o",
       "source": "src/nu2api/nucore/nupad.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nupad.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nupad.o",
       "functions": [
         {
           "name": "_ZL21DeadZoneValueXYProperPiS_i",
@@ -101255,7 +101297,7 @@
     {
       "name": "nu2api/nucore/nupad_interface.cpp.o",
       "source": "src/nu2api/nucore/nupad_interface.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_interface.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_interface.o",
       "functions": [
         {
           "name": "_ZN15NuInputDevicePS15GetIdentifierPSEj",
@@ -101278,30 +101320,6 @@
           "demangled_name": "NuInputDevicePS::DisableDPDPS(unsigned int)",
           "address": 977488,
           "offset": 87520,
-          "size": 9,
-          "match_percent": 100.0
-        },
-        {
-          "name": "_ZN15NuInputDevicePS28HandleTouch_ANDROID_SPECIFICEiiiff",
-          "demangled_name": "NuInputDevicePS::HandleTouch_ANDROID_SPECIFIC(int, int, int, float, float)",
-          "address": 977536,
-          "offset": 87568,
-          "size": 135,
-          "match_percent": 12.352942
-        },
-        {
-          "name": "_ZN15NuInputDevicePS34HandleGamePadAxis_ANDROID_SPECIFICEffffff",
-          "demangled_name": "NuInputDevicePS::HandleGamePadAxis_ANDROID_SPECIFIC(float, float, float, float, float, float)",
-          "address": 978064,
-          "offset": 88096,
-          "size": 129,
-          "match_percent": 15.555555
-        },
-        {
-          "name": "_ZN15NuInputDevicePS29HandleSensor_ANDROID_SPECIFICEifff",
-          "demangled_name": "NuInputDevicePS::HandleSensor_ANDROID_SPECIFIC(int, float, float, float)",
-          "address": 978240,
-          "offset": 88272,
           "size": 9,
           "match_percent": 100.0
         },
@@ -101870,7 +101888,7 @@
     {
       "name": "nu2api/nucore/nuptrblock.cpp.o",
       "source": "src/nu2api/nucore/nuptrblock.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuptrblock.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuptrblock.o",
       "functions": [
         {
           "name": "NuPtrBlockFix",
@@ -101885,7 +101903,7 @@
     {
       "name": "nu2api/nucore/nurdpf.cpp.o",
       "source": "src/nu2api/nucore/nurdpf.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpf.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpf.o",
       "functions": [
         {
           "name": "_ZL10isnumordotc",
@@ -101948,7 +101966,7 @@
     {
       "name": "nu2api/nucore/nurdpi.cpp.o",
       "source": "src/nu2api/nucore/nurdpi.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpi.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpi.o",
       "functions": [
         {
           "name": "_ZL5isnumc",
@@ -102027,7 +102045,7 @@
     {
       "name": "nu2api/nucore/nustring.cpp.o",
       "source": "src/nu2api/nucore/nustring.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nustring.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nustring.o",
       "functions": [
         {
           "name": "_ZL17NuStringCharEquivtt",
@@ -102082,7 +102100,7 @@
     {
       "name": "nu2api/nucore/nustring_c.cpp.o",
       "source": "src/nu2api/nucore/nustring_c.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nustring_c.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nustring_c.o",
       "functions": [
         {
           "name": "NuStrCat",
@@ -102353,7 +102371,7 @@
     {
       "name": "nu2api/nucore/nutexanim.cpp.o",
       "source": "src/nu2api/nucore/nutexanim.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanim.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanim.o",
       "functions": [
         {
           "name": "_ZL7pftaRetP8nufpar_s",
@@ -102752,7 +102770,7 @@
     {
       "name": "nu2api/nucore/nuthread.cpp.o",
       "source": "src/nu2api/nucore/nuthread.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuthread.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuthread.o",
       "functions": [
         {
           "name": "_ZN8NuThread12SetDebugNameEPKc",
@@ -102847,7 +102865,7 @@
     {
       "name": "nu2api/nucore/nutime.cpp.o",
       "source": "src/nu2api/nucore/nutime.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutime.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nutime.o",
       "functions": [
         {
           "name": "NuTimeGetFrameTime",
@@ -102902,7 +102920,7 @@
     {
       "name": "nu2api/nucore/nuvideo.cpp.o",
       "source": "src/nu2api/nucore/nuvideo.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo.o",
       "functions": [
         {
           "name": "NuVideoGetMode",
@@ -102973,7 +102991,7 @@
     {
       "name": "nu2api/nucore/pending_stubs.cpp.o",
       "source": "src/nu2api/nucore/pending_stubs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/pending_stubs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/pending_stubs.o",
       "functions": [
         {
           "name": "_Z26DisplayListLinkDynamicMtlsv",
@@ -103156,7 +103174,7 @@
     {
       "name": "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
       "source": "src/nu2api/nufile/NuFileDeviceAndroidAPK.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileDeviceAndroidAPK.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileDeviceAndroidAPK.o",
       "functions": [
         {
           "name": "_ZN22NuFileDeviceAndroidAPKD1Ev",
@@ -103164,7 +103182,7 @@
           "address": 3242272,
           "offset": 2352304,
           "size": 45,
-          "match_percent": 19.307692
+          "match_percent": 99.84615
         },
         {
           "name": "_ZN22NuFileDeviceAndroidAPKD2Ev",
@@ -103172,7 +103190,7 @@
           "address": 3242272,
           "offset": 2352304,
           "size": 45,
-          "match_percent": 19.307692
+          "match_percent": 99.84615
         },
         {
           "name": "_ZN22NuFileDeviceAndroidAPKD0Ev",
@@ -103180,7 +103198,7 @@
           "address": 3242320,
           "offset": 2352352,
           "size": 56,
-          "match_percent": 24.428572
+          "match_percent": 99.92857
         },
         {
           "name": "_ZNK22NuFileDeviceAndroidAPK12CreateNuFileEPKcN6NuFile8OpenMode1TE",
@@ -103188,7 +103206,7 @@
           "address": 3243824,
           "offset": 2353856,
           "size": 42,
-          "match_percent": 27.5
+          "match_percent": 99.916664
         },
         {
           "name": "_ZN22NuFileDeviceAndroidAPKC1EPKcRKN6NuFile8InitDataE",
@@ -103196,7 +103214,7 @@
           "address": 3243872,
           "offset": 2353904,
           "size": 98,
-          "match_percent": 25.52174
+          "match_percent": 99.82609
         },
         {
           "name": "_ZN22NuFileDeviceAndroidAPKC2EPKcRKN6NuFile8InitDataE",
@@ -103204,69 +103222,21 @@
           "address": 3243872,
           "offset": 2353904,
           "size": 98,
-          "match_percent": 25.52174
+          "match_percent": 99.82609
         }
       ]
     },
     {
       "name": "nu2api/nufile/android/NuFileAndroidDeviceAPK.cpp.o",
       "source": "src/nu2api/nufile/android/NuFileAndroidDeviceAPK.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileAndroidDeviceAPK.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileAndroidDeviceAPK.o",
       "functions": []
     },
     {
       "name": "nu2api/nufile/android/nufile_android.cpp.o",
       "source": "src/nu2api/nufile/android/nufile_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile_android.o",
       "functions": [
-        {
-          "name": "_ZN16NuFileAndroidAPK11GetFileSizeEi",
-          "demangled_name": "NuFileAndroidAPK::GetFileSize(int)",
-          "address": 2554746,
-          "offset": 1664778,
-          "size": 49,
-          "match_percent": 18.88889
-        },
-        {
-          "name": "_ZN16NuFileAndroidAPK10GetFilePosEi",
-          "demangled_name": "NuFileAndroidAPK::GetFilePos(int)",
-          "address": 2554796,
-          "offset": 1664828,
-          "size": 49,
-          "match_percent": 18.88889
-        },
-        {
-          "name": "_ZN16NuFileAndroidAPK8ReadFileEiPvj",
-          "demangled_name": "NuFileAndroidAPK::ReadFile(int, void*, unsigned int)",
-          "address": 2554846,
-          "offset": 1664878,
-          "size": 63,
-          "match_percent": 17.272728
-        },
-        {
-          "name": "_ZN16NuFileAndroidAPK8SeekFileEixN6NuFile10SeekOrigin1TE",
-          "demangled_name": "NuFileAndroidAPK::SeekFile(int, long long, NuFile::SeekOrigin::T)",
-          "address": 2554910,
-          "offset": 1664942,
-          "size": 86,
-          "match_percent": 10.967742
-        },
-        {
-          "name": "_ZN16NuFileAndroidAPK8OpenFileEPKcN6NuFile8OpenMode1TE",
-          "demangled_name": "NuFileAndroidAPK::OpenFile(char const*, NuFile::OpenMode::T)",
-          "address": 2554996,
-          "offset": 1665028,
-          "size": 64,
-          "match_percent": 18.095238
-        },
-        {
-          "name": "_ZN16NuFileAndroidAPK9CloseFileEi",
-          "demangled_name": "NuFileAndroidAPK::CloseFile(int)",
-          "address": 2555060,
-          "offset": 1665092,
-          "size": 93,
-          "match_percent": 11.515152
-        },
         {
           "name": "NuGetFileHandlePS",
           "demangled_name": "NuGetFileHandlePS",
@@ -103337,7 +103307,7 @@
           "address": 3242176,
           "offset": 2352208,
           "size": 94,
-          "match_percent": 13.333333
+          "match_percent": 89.5
         },
         {
           "name": "_ZN16NuFileAndroidAPK5CloseEv",
@@ -103345,7 +103315,7 @@
           "address": 3242384,
           "offset": 2352416,
           "size": 68,
-          "match_percent": 26.25
+          "match_percent": 99.9375
         },
         {
           "name": "_ZN16NuFileAndroidAPK4ReadEPvj",
@@ -103353,7 +103323,7 @@
           "address": 3242464,
           "offset": 2352496,
           "size": 537,
-          "match_percent": 3.62963
+          "match_percent": 99.97037
         },
         {
           "name": "_ZN16NuFileAndroidAPKD1Ev",
@@ -103400,7 +103370,7 @@
     {
       "name": "nu2api/nufile/nudatfile.cpp.o",
       "source": "src/nu2api/nufile/nudatfile.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudatfile.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nudatfile.o",
       "functions": [
         {
           "name": "_Z12NuDatCalcPosP10nudathdr_si",
@@ -103447,7 +103417,7 @@
     {
       "name": "nu2api/nufile/nufile.c.o",
       "source": "src/nu2api/nufile/nufile.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile.o",
       "functions": [
         {
           "name": "DEVHOST_Interrogate",
@@ -103486,7 +103456,7 @@
     {
       "name": "nu2api/nufile/nufile.cpp.o",
       "source": "src/nu2api/nufile/nufile.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile.o",
       "functions": [
         {
           "name": "_ZL19NuDatFileDecodeInitv",
@@ -103977,19 +103947,83 @@
           "match_percent": 89.28571
         },
         {
+          "name": "NuFileExtGetExt",
+          "demangled_name": "NuFileExtGetExt",
+          "address": 2484851,
+          "offset": 1594883,
+          "size": 197,
+          "match_percent": 97.258064
+        },
+        {
           "name": "NuPPLoadBuffer",
           "demangled_name": "NuPPLoadBuffer",
           "address": 2519111,
           "offset": 1629143,
           "size": 466,
           "match_percent": 3.211679
+        },
+        {
+          "name": "_ZN16NuFileAndroidAPK7GetFileEi",
+          "demangled_name": "NuFileAndroidAPK::GetFile(int)",
+          "address": 2554710,
+          "offset": 1664742,
+          "size": 35,
+          "match_percent": 99.8
+        },
+        {
+          "name": "_ZN16NuFileAndroidAPK11GetFileSizeEi",
+          "demangled_name": "NuFileAndroidAPK::GetFileSize(int)",
+          "address": 2554746,
+          "offset": 1664778,
+          "size": 49,
+          "match_percent": 99.94444
+        },
+        {
+          "name": "_ZN16NuFileAndroidAPK10GetFilePosEi",
+          "demangled_name": "NuFileAndroidAPK::GetFilePos(int)",
+          "address": 2554796,
+          "offset": 1664828,
+          "size": 49,
+          "match_percent": 99.94444
+        },
+        {
+          "name": "_ZN16NuFileAndroidAPK8ReadFileEiPvj",
+          "demangled_name": "NuFileAndroidAPK::ReadFile(int, void*, unsigned int)",
+          "address": 2554846,
+          "offset": 1664878,
+          "size": 63,
+          "match_percent": 99.954544
+        },
+        {
+          "name": "_ZN16NuFileAndroidAPK8SeekFileEixN6NuFile10SeekOrigin1TE",
+          "demangled_name": "NuFileAndroidAPK::SeekFile(int, long long, NuFile::SeekOrigin::T)",
+          "address": 2554910,
+          "offset": 1664942,
+          "size": 86,
+          "match_percent": 99.96774
+        },
+        {
+          "name": "_ZN16NuFileAndroidAPK8OpenFileEPKcN6NuFile8OpenMode1TE",
+          "demangled_name": "NuFileAndroidAPK::OpenFile(char const*, NuFile::OpenMode::T)",
+          "address": 2554996,
+          "offset": 1665028,
+          "size": 64,
+          "match_percent": 99.95238
+        },
+        {
+          "name": "_ZN16NuFileAndroidAPK9CloseFileEi",
+          "demangled_name": "NuFileAndroidAPK::CloseFile(int)",
+          "address": 2555060,
+          "offset": 1665092,
+          "size": 93,
+          "match_percent": 99.969696
         }
       ]
     },
     {
       "name": "nu2api/nufile/nufile_android.cpp.o",
       "source": "src/nu2api/nufile/nufile_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile_android.o",
       "functions": [
         {
           "name": "_ZN16NuFileAndroidAPK4InitEv",
@@ -103997,7 +104031,7 @@
           "address": 3243152,
           "offset": 2353184,
           "size": 45,
-          "match_percent": 30.0
+          "match_percent": 99.85714
         },
         {
           "name": "_ZN16NuFileAndroidAPK9SetFileIdEPS_",
@@ -104021,14 +104055,14 @@
           "address": 3243408,
           "offset": 2353440,
           "size": 408,
-          "match_percent": 4.158416
+          "match_percent": 99.960396
         }
       ]
     },
     {
       "name": "nu2api/nufile/nufile_plain.cpp.o",
       "source": "src/nu2api/nufile/nufile_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufile_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nufile_plain.o",
       "functions": [
         {
           "name": "NuFileSwapEndianOnWrite",
@@ -104423,14 +104457,6 @@
           "match_percent": 15.555555
         },
         {
-          "name": "NuFileExtGetExt",
-          "demangled_name": "NuFileExtGetExt",
-          "address": 2484851,
-          "offset": 1594883,
-          "size": 197,
-          "match_percent": 5.483871
-        },
-        {
           "name": "NuFileExtRemove",
           "demangled_name": "NuFileExtRemove",
           "address": 2485048,
@@ -104547,7 +104573,7 @@
     {
       "name": "nu2api/nufile/nufilebase.cpp.o",
       "source": "src/nu2api/nufile/nufilebase.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufilebase.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nufilebase.o",
       "functions": [
         {
           "name": "_ZN10NuFileBaseD1Ev",
@@ -104746,7 +104772,7 @@
     {
       "name": "nu2api/nufile/nufiledevice.cpp.o",
       "source": "src/nu2api/nufile/nufiledevice.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufiledevice.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nufiledevice.o",
       "functions": [
         {
           "name": "_ZN12NuFileDeviceD1Ev",
@@ -104754,7 +104780,7 @@
           "address": 3244864,
           "offset": 2354896,
           "size": 88,
-          "match_percent": 31.423077
+          "match_percent": 99.80769
         },
         {
           "name": "_ZN12NuFileDeviceD2Ev",
@@ -104762,7 +104788,7 @@
           "address": 3244864,
           "offset": 2354896,
           "size": 88,
-          "match_percent": 31.423077
+          "match_percent": 99.80769
         },
         {
           "name": "_ZNK12NuFileDevice8FileOpenEPKcN6NuFile8OpenMode1TE",
@@ -104770,7 +104796,7 @@
           "address": 3244960,
           "offset": 2354992,
           "size": 121,
-          "match_percent": 7.857143
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuFileDevice8FileSizeEPKc",
@@ -104778,7 +104804,7 @@
           "address": 3245088,
           "offset": 2355120,
           "size": 136,
-          "match_percent": 9.365853
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuFileDevice11InterrogateEv",
@@ -104786,7 +104812,7 @@
           "address": 3245232,
           "offset": 2355264,
           "size": 16,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuFileDevice20QueryInstallProgressEv",
@@ -104794,7 +104820,7 @@
           "address": 3245248,
           "offset": 2355280,
           "size": 12,
-          "match_percent": 16.75
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuFileDeviceD0Ev",
@@ -104802,7 +104828,7 @@
           "address": 3245264,
           "offset": 2355296,
           "size": 56,
-          "match_percent": 24.428572
+          "match_percent": 99.92857
         },
         {
           "name": "_ZNK12NuFileDevice10FormatNameEPciPKc",
@@ -104810,7 +104836,7 @@
           "address": 3245328,
           "offset": 2355360,
           "size": 874,
-          "match_percent": 1.382114
+          "match_percent": 26.658537
         },
         {
           "name": "_ZN12NuFileDevice13SetCurrentDirEPKc",
@@ -104818,7 +104844,7 @@
           "address": 3246208,
           "offset": 2356240,
           "size": 146,
-          "match_percent": 8.695652
+          "match_percent": 99.978264
         },
         {
           "name": "_ZN12NuFileDeviceC1Ev",
@@ -104826,7 +104852,7 @@
           "address": 3246368,
           "offset": 2356400,
           "size": 77,
-          "match_percent": 33.25
+          "match_percent": 99.75
         },
         {
           "name": "_ZN12NuFileDeviceC2Ev",
@@ -104834,7 +104860,7 @@
           "address": 3246368,
           "offset": 2356400,
           "size": 77,
-          "match_percent": 33.25
+          "match_percent": 99.75
         },
         {
           "name": "_ZN12NuFileDevice20AllocDirectoryHandleEPKc",
@@ -104842,7 +104868,7 @@
           "address": 3246448,
           "offset": 2356480,
           "size": 623,
-          "match_percent": 1.517241
+          "match_percent": 2.896552
         },
         {
           "name": "_ZN12NuFileDevice19FreeDirectoryHandleEi",
@@ -104850,7 +104876,7 @@
           "address": 3247072,
           "offset": 2357104,
           "size": 146,
-          "match_percent": 6.666666
+          "match_percent": 12.727273
         },
         {
           "name": "_ZN12NuFileDevice16SetDefaultDeviceE16NuFileDeviceType",
@@ -104858,7 +104884,7 @@
           "address": 3247232,
           "offset": 2357264,
           "size": 84,
-          "match_percent": 10.0
+          "match_percent": 99.878784
         },
         {
           "name": "_ZN12NuFileDevice28GetDeviceFromDirectoryHandleEi",
@@ -104866,7 +104892,7 @@
           "address": 3247328,
           "offset": 2357360,
           "size": 25,
-          "match_percent": 13.333333
+          "match_percent": 99.666664
         },
         {
           "name": "_ZN12NuFileDevice15GetDeviceByTypeE16NuFileDeviceType",
@@ -104874,7 +104900,7 @@
           "address": 3247360,
           "offset": 2357392,
           "size": 84,
-          "match_percent": 9.705882
+          "match_percent": 12.352942
         },
         {
           "name": "_ZN12NuFileDevice17GetDeviceFromPathEPKc",
@@ -104882,7 +104908,7 @@
           "address": 3247456,
           "offset": 2357488,
           "size": 518,
-          "match_percent": 2.297297
+          "match_percent": 3.243243
         },
         {
           "name": "_ZN12NuFileDevice9AddDeviceEPS_",
@@ -104890,7 +104916,7 @@
           "address": 3247984,
           "offset": 2358016,
           "size": 63,
-          "match_percent": 12.941176
+          "match_percent": 99.82353
         },
         {
           "name": "_ZN12NuFileDevice14ClearPathRulesEv",
@@ -104898,7 +104924,7 @@
           "address": 3248048,
           "offset": 2358080,
           "size": 26,
-          "match_percent": 31.428572
+          "match_percent": 99.71429
         },
         {
           "name": "_ZN12NuFileDevice11AddPathRuleE16NuFileDeviceTypePKc",
@@ -104906,7 +104932,7 @@
           "address": 3248080,
           "offset": 2358112,
           "size": 244,
-          "match_percent": 3.606557
+          "match_percent": 6.885246
         },
         {
           "name": "_ZN12NuFileDevice12SetMountNameEPc",
@@ -104914,7 +104940,7 @@
           "address": 3248336,
           "offset": 2358368,
           "size": 14,
-          "match_percent": 36.666668
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuFileDevice8SetLabelEPc",
@@ -104922,14 +104948,14 @@
           "address": 3248352,
           "offset": 2358384,
           "size": 14,
-          "match_percent": 36.666668
+          "match_percent": 100.0
         }
       ]
     },
     {
       "name": "nu2api/nufile/nufilepak.cpp.o",
       "source": "src/nu2api/nufile/nufilepak.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufilepak.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nufilepak.o",
       "functions": [
         {
           "name": "_ZL8GetItemsP16nufilepakhdrv2_s",
@@ -105008,7 +105034,7 @@
     {
       "name": "nu2api/nufile/nufpar.cpp.o",
       "source": "src/nu2api/nufile/nufpar.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufpar.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nufpar.o",
       "functions": [
         {
           "name": "_ZL15Traffic_tfactorP8nufpar_s",
@@ -105655,7 +105681,7 @@
     {
       "name": "nu2api/nufile/numc.cpp.o",
       "source": "src/nu2api/nufile/numc.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numc.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numc.o",
       "functions": [
         {
           "name": "_Z16NuMcFileOpenSizei",
@@ -105718,7 +105744,7 @@
     {
       "name": "nu2api/nufile/tmclient.cpp.o",
       "source": "src/nu2api/nufile/tmclient.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/tmclient.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/tmclient.o",
       "functions": [
         {
           "name": "_ZN8TMClientC1EiPc",
@@ -105741,7 +105767,7 @@
     {
       "name": "nu2api/numath/nufloat.c.o",
       "source": "src/nu2api/numath/nufloat.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufloat.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nufloat.o",
       "functions": [
         {
           "name": "NuFsel",
@@ -105852,7 +105878,7 @@
     {
       "name": "nu2api/numath/numaths.cpp.o",
       "source": "src/nu2api/numath/numaths.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numaths.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numaths.o",
       "functions": [
         {
           "name": "_Z21NuVecClipTestPointVU0P7nuvec_sP7numtx_s",
@@ -105883,7 +105909,7 @@
     {
       "name": "nu2api/numath/numaths_plain.cpp.o",
       "source": "src/nu2api/numath/numaths_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numaths_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numaths_plain.o",
       "functions": [
         {
           "name": "NuVecMtxRotateValX",
@@ -106186,7 +106212,7 @@
     {
       "name": "nu2api/numath/numtx.cpp.o",
       "source": "src/nu2api/numath/numtx.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numtx.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numtx.o",
       "functions": [
         {
           "name": "NuMtxSetZero",
@@ -106889,7 +106915,7 @@
     {
       "name": "nu2api/numath/nuplane.cpp.o",
       "source": "src/nu2api/numath/nuplane.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuplane.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuplane.o",
       "functions": [
         {
           "name": "NuPlnEqn",
@@ -106984,7 +107010,7 @@
     {
       "name": "nu2api/numath/nuquat.cpp.o",
       "source": "src/nu2api/numath/nuquat.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuquat.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuquat.o",
       "functions": [
         {
           "name": "_ZL16NuQTUnfixAddressP9nuqthdr_s",
@@ -107175,7 +107201,7 @@
     {
       "name": "nu2api/numath/nurand.cpp.o",
       "source": "src/nu2api/numath/nurand.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurand.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nurand.o",
       "functions": [
         {
           "name": "NuRandSeed",
@@ -107254,7 +107280,7 @@
     {
       "name": "nu2api/numath/nutrig.c.o",
       "source": "src/nu2api/numath/nutrig.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nutrig.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/0/nutrig.o",
       "functions": [
         {
           "name": "NuASin",
@@ -107349,7 +107375,7 @@
     {
       "name": "nu2api/numath/nutrig.cpp.o",
       "source": "src/nu2api/numath/nutrig.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nutrig.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/1/nutrig.o",
       "functions": [
         {
           "name": "_ZL12NuSinApprox3i",
@@ -107420,7 +107446,7 @@
     {
       "name": "nu2api/numath/nutrig_gen.cpp.o",
       "source": "src/nu2api/numath/nutrig_gen.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutrig_gen.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nutrig_gen.o",
       "functions": [
         {
           "name": "NuTrigInit",
@@ -107435,7 +107461,7 @@
     {
       "name": "nu2api/numath/nuvec.cpp.o",
       "source": "src/nu2api/numath/nuvec.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec.o",
       "functions": [
         {
           "name": "NuVecMtxTransform",
@@ -107730,7 +107756,7 @@
     {
       "name": "nu2api/numath/nuvec4.c.o",
       "source": "src/nu2api/numath/nuvec4.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec4.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec4.o",
       "functions": [
         {
           "name": "NuVec4Add",
@@ -107777,7 +107803,7 @@
     {
       "name": "nu2api/numath/vumath.c.o",
       "source": "src/nu2api/numath/vumath.c",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/vumath.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/vumath.o",
       "functions": [
         {
           "name": "VuQuatBlend",
@@ -107840,7 +107866,7 @@
     {
       "name": "nu2api/numusic/numusic.cpp.o",
       "source": "src/nu2api/numusic/numusic.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numusic.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/numusic.o",
       "functions": [
         {
           "name": "_ZN7NuMusic18GlobalParseErrorFnEP8nufpar_s",
@@ -108615,7 +108641,7 @@
     {
       "name": "nu2api/numusic/sfx.cpp.o",
       "source": "src/nu2api/numusic/sfx.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/sfx.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/sfx.o",
       "functions": [
         {
           "name": "_ZL12fnAudioAudioP8nufpar_s",
@@ -108678,7 +108704,7 @@
     {
       "name": "nu2api/nuplatform/nudevicespecs.cpp.o",
       "source": "src/nu2api/nuplatform/nudevicespecs.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudevicespecs.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nudevicespecs.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nudevicespecs.cpp",
@@ -108705,6 +108731,22 @@
           "match_percent": 0.0
         },
         {
+          "name": "_ZN13NuDeviceSpecsC1Ev",
+          "demangled_name": "NuDeviceSpecs::NuDeviceSpecs()",
+          "address": 988672,
+          "offset": 98704,
+          "size": 40,
+          "match_percent": 38.81818
+        },
+        {
+          "name": "_ZN13NuDeviceSpecsC2Ev",
+          "demangled_name": "NuDeviceSpecs::NuDeviceSpecs()",
+          "address": 988672,
+          "offset": 98704,
+          "size": 40,
+          "match_percent": 38.81818
+        },
+        {
           "name": "_ZN13NuDeviceSpecs6CreateEv",
           "demangled_name": "NuDeviceSpecs::Create()",
           "address": 988720,
@@ -108717,7 +108759,7 @@
     {
       "name": "nu2api/nuplatform/nuplatform.cpp.o",
       "source": "src/nu2api/nuplatform/nuplatform.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuplatform.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nuplatform.o",
       "functions": [
         {
           "name": "_ZN10NuPlatform6CreateEv",
@@ -108740,24 +108782,8 @@
     {
       "name": "nu2api/nusound/nu2api_nusound_misc.cpp.o",
       "source": "src/nu2api/nusound/nu2api_nusound_misc.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_misc.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_misc.o",
       "functions": [
-        {
-          "name": "_ZN13NuSoundSystem22GetNearestRealListenerERK7NuEListI15NuSoundListener12DefaultElistERK5VuVec",
-          "demangled_name": "NuSoundSystem::GetNearestRealListener(NuEList<NuSoundListener, DefaultElist> const&, VuVec const&)",
-          "address": 3258816,
-          "offset": 2368848,
-          "size": 242,
-          "match_percent": 5.428571
-        },
-        {
-          "name": "_ZN13NuSoundSystem23GetNearestFocusListenerERK7NuEListI15NuSoundListener12DefaultElistERK5VuVecRf",
-          "demangled_name": "NuSoundSystem::GetNearestFocusListener(NuEList<NuSoundListener, DefaultElist> const&, VuVec const&, float&)",
-          "address": 3259072,
-          "offset": 2369104,
-          "size": 237,
-          "match_percent": 6.515151
-        },
         {
           "name": "_Z16edanimSoundPlaceiP7nuvec_s",
           "demangled_name": "edanimSoundPlace(int, nuvec_s*)",
@@ -108795,7 +108821,7 @@
     {
       "name": "nu2api/nusound/nu2api_nusound_plain.cpp.o",
       "source": "src/nu2api/nusound/nu2api_nusound_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_plain.o",
       "functions": [
         {
           "name": "PrepareSounds",
@@ -108898,19 +108924,19 @@
     {
       "name": "nu2api/nusound/nu2api_nusound_types.cpp.o",
       "source": "src/nu2api/nusound/nu2api_nusound_types.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_types.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_types.o",
       "functions": []
     },
     {
       "name": "nu2api/nusound/nusound.cpp.o",
       "source": "src/nu2api/nusound/nusound.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound.o",
       "functions": []
     },
     {
       "name": "nu2api/nusound/nusound3_include.cpp.o",
       "source": "src/nu2api/nusound/nusound3_include.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound3_include.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound3_include.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound3_include.cpp",
@@ -108918,7 +108944,7 @@
           "address": 908112,
           "offset": 18144,
           "size": 721,
-          "match_percent": 50.271427
+          "match_percent": 76.74286
         },
         {
           "name": "_Z24NuSound3SampleLoadThreadPv",
@@ -108926,7 +108952,7 @@
           "address": 3205168,
           "offset": 2315200,
           "size": 621,
-          "match_percent": 49.953487
+          "match_percent": 59.994186
         },
         {
           "name": "_Z17PS2VolumeToScalari",
@@ -108942,7 +108968,7 @@
           "address": 3213680,
           "offset": 2323712,
           "size": 446,
-          "match_percent": 91.01053
+          "match_percent": 99.88421
         },
         {
           "name": "NuSound3InitV",
@@ -108958,7 +108984,47 @@
           "address": 3214256,
           "offset": 2324288,
           "size": 580,
-          "match_percent": 20.703947
+          "match_percent": 42.07237
+        },
+        {
+          "name": "NuSound3IsSampleLoaded",
+          "demangled_name": "NuSound3IsSampleLoaded",
+          "address": 3214960,
+          "offset": 2324992,
+          "size": 52,
+          "match_percent": 99.86667
+        },
+        {
+          "name": "NuSound3CountVoices",
+          "demangled_name": "NuSound3CountVoices",
+          "address": 3215024,
+          "offset": 2325056,
+          "size": 94,
+          "match_percent": 99.314285
+        },
+        {
+          "name": "NuSound3FindOldestVoice",
+          "demangled_name": "NuSound3FindOldestVoice",
+          "address": 3215120,
+          "offset": 2325152,
+          "size": 76,
+          "match_percent": 99.86364
+        },
+        {
+          "name": "NuSound3FindQuietestVoice",
+          "demangled_name": "NuSound3FindQuietestVoice",
+          "address": 3215200,
+          "offset": 2325232,
+          "size": 76,
+          "match_percent": 99.86364
+        },
+        {
+          "name": "NuSound3StopVoice",
+          "demangled_name": "NuSound3StopVoice",
+          "address": 3215280,
+          "offset": 2325312,
+          "size": 195,
+          "match_percent": 57.677418
         },
         {
           "name": "_Z19NuSound3CreateVoiceP7nuvec_siffiifb",
@@ -108966,7 +109032,63 @@
           "address": 3215488,
           "offset": 2325520,
           "size": 465,
-          "match_percent": 0.0
+          "match_percent": 50.646152
+        },
+        {
+          "name": "NuSound3Play3dLoopSfx",
+          "demangled_name": "NuSound3Play3dLoopSfx",
+          "address": 3215968,
+          "offset": 2326000,
+          "size": 296,
+          "match_percent": 37.68
+        },
+        {
+          "name": "NuSound3Play3d",
+          "demangled_name": "NuSound3Play3d",
+          "address": 3216272,
+          "offset": 2326304,
+          "size": 102,
+          "match_percent": 99.95652
+        },
+        {
+          "name": "NuSound3Play3dPri",
+          "demangled_name": "NuSound3Play3dPri",
+          "address": 3216384,
+          "offset": 2326416,
+          "size": 93,
+          "match_percent": 99.954544
+        },
+        {
+          "name": "NuSound3PlayPri",
+          "demangled_name": "NuSound3PlayPri",
+          "address": 3216480,
+          "offset": 2326512,
+          "size": 93,
+          "match_percent": 99.95238
+        },
+        {
+          "name": "NuSound3Play",
+          "demangled_name": "NuSound3Play",
+          "address": 3216576,
+          "offset": 2326608,
+          "size": 93,
+          "match_percent": 99.95238
+        },
+        {
+          "name": "NuSound3Listener",
+          "demangled_name": "NuSound3Listener",
+          "address": 3216672,
+          "offset": 2326704,
+          "size": 44,
+          "match_percent": 99.833336
+        },
+        {
+          "name": "NuSound3GetListener",
+          "demangled_name": "NuSound3GetListener",
+          "address": 3216720,
+          "offset": 2326752,
+          "size": 36,
+          "match_percent": 99.8
         },
         {
           "name": "NuSound3PauseStereoStream",
@@ -108990,7 +109112,7 @@
           "address": 3218112,
           "offset": 2328144,
           "size": 100,
-          "match_percent": 79.44444
+          "match_percent": 99.888885
         },
         {
           "name": "NuSound3GetStereoStreamStatus",
@@ -108999,6 +109121,14 @@
           "offset": 2328304,
           "size": 122,
           "match_percent": 86.2381
+        },
+        {
+          "name": "NuSound3GetStreamPlaybackTime",
+          "demangled_name": "NuSound3GetStreamPlaybackTime",
+          "address": 3218400,
+          "offset": 2328432,
+          "size": 72,
+          "match_percent": 99.86364
         },
         {
           "name": "NuSound3StreamKeyStatus",
@@ -109017,12 +109147,20 @@
           "match_percent": 0.0
         },
         {
+          "name": "NuSound3AmplitudeTodB",
+          "demangled_name": "NuSound3AmplitudeTodB",
+          "address": 3219216,
+          "offset": 2329248,
+          "size": 38,
+          "match_percent": 99.9
+        },
+        {
           "name": "NuSound3StopStereoStream",
           "demangled_name": "NuSound3StopStereoStream",
           "address": 3222016,
           "offset": 2332048,
           "size": 314,
-          "match_percent": 82.318184
+          "match_percent": 87.420456
         },
         {
           "name": "NuSound3PlayStereoV",
@@ -109038,7 +109176,7 @@
           "address": 3228928,
           "offset": 2338960,
           "size": 2933,
-          "match_percent": 17.767979
+          "match_percent": 30.934872
         },
         {
           "name": "_ZN14NuSoundWeakPtrI12NuSoundVoiceE5ClearEv",
@@ -109054,7 +109192,7 @@
           "address": 3232032,
           "offset": 2342064,
           "size": 114,
-          "match_percent": 28.821428
+          "match_percent": 99.96429
         },
         {
           "name": "_ZN8NuVectorI23nusound_filename_info_sED2Ev",
@@ -109062,7 +109200,7 @@
           "address": 3232032,
           "offset": 2342064,
           "size": 114,
-          "match_percent": 28.821428
+          "match_percent": 99.96429
         },
         {
           "name": "_ZN14NuSoundWeakPtrI12NuSoundVoiceED1Ev",
@@ -109070,7 +109208,7 @@
           "address": 3232752,
           "offset": 2342784,
           "size": 202,
-          "match_percent": 77.929825
+          "match_percent": 80.807014
         },
         {
           "name": "_ZN14NuSoundWeakPtrI12NuSoundVoiceED2Ev",
@@ -109078,7 +109216,7 @@
           "address": 3232752,
           "offset": 2342784,
           "size": 202,
-          "match_percent": 77.929825
+          "match_percent": 80.807014
         },
         {
           "name": "_ZN7NuEListI13NuSound3Voice12DefaultElistED1Ev",
@@ -109086,7 +109224,7 @@
           "address": 3232960,
           "offset": 2342992,
           "size": 278,
-          "match_percent": 17.941177
+          "match_percent": 80.08235
         },
         {
           "name": "_ZN7NuEListI13NuSound3Voice12DefaultElistED2Ev",
@@ -109094,7 +109232,7 @@
           "address": 3232960,
           "offset": 2342992,
           "size": 278,
-          "match_percent": 17.941177
+          "match_percent": 80.08235
         },
         {
           "name": "_ZN14NuSoundWeakPtrI12NuSoundVoiceED0Ev",
@@ -109102,7 +109240,7 @@
           "address": 3233248,
           "offset": 2343280,
           "size": 210,
-          "match_percent": 78.67796
+          "match_percent": 81.45763
         },
         {
           "name": "_ZN13NuSoundSystem16CreateFileLoaderENS_8FileTypeE",
@@ -109125,7 +109263,7 @@
     {
       "name": "nu2api/nusound/nusound_android.cpp.o",
       "source": "src/nu2api/nusound/nusound_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_android.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_android.cpp",
@@ -109133,7 +109271,7 @@
           "address": 912848,
           "offset": 22880,
           "size": 271,
-          "match_percent": 12.25
+          "match_percent": 98.65909
         },
         {
           "name": "_ZN14NuSoundAndroid19ShutdownAudioDeviceEv",
@@ -109141,7 +109279,7 @@
           "address": 3321536,
           "offset": 2431568,
           "size": 29,
-          "match_percent": 7.0
+          "match_percent": 93.111115
         },
         {
           "name": "_ZN14NuSoundAndroid12CreateEffectEN13NuSoundEffect10EffectTypeE",
@@ -109149,7 +109287,7 @@
           "address": 3321568,
           "offset": 2431600,
           "size": 9,
-          "match_percent": 27.5
+          "match_percent": 100.0
         },
         {
           "name": "_ZN14NuSoundAndroid11CreateVoiceEP13NuSoundSourceb",
@@ -109157,7 +109295,7 @@
           "address": 3321712,
           "offset": 2431744,
           "size": 51,
-          "match_percent": 53.785713
+          "match_percent": 99.92857
         },
         {
           "name": "_ZN14NuSoundAndroid17UpdateAudioDeviceEv",
@@ -109165,7 +109303,7 @@
           "address": 3321776,
           "offset": 2431808,
           "size": 35,
-          "match_percent": 23.3
+          "match_percent": 99.9
         },
         {
           "name": "_ZN14NuSoundAndroid25AndroidNuSoundClockThreadEPv",
@@ -109173,7 +109311,7 @@
           "address": 3321824,
           "offset": 2431856,
           "size": 73,
-          "match_percent": 53.304348
+          "match_percent": 99.91304
         },
         {
           "name": "_ZN14NuSoundAndroidD1Ev",
@@ -109181,7 +109319,7 @@
           "address": 3321904,
           "offset": 2431936,
           "size": 45,
-          "match_percent": 0.0
+          "match_percent": 99.84615
         },
         {
           "name": "_ZN14NuSoundAndroidD2Ev",
@@ -109189,7 +109327,7 @@
           "address": 3321904,
           "offset": 2431936,
           "size": 45,
-          "match_percent": 0.0
+          "match_percent": 99.84615
         },
         {
           "name": "_ZN14NuSoundAndroidD0Ev",
@@ -109197,7 +109335,7 @@
           "address": 3321952,
           "offset": 2431984,
           "size": 81,
-          "match_percent": 30.842106
+          "match_percent": 76.52631
         },
         {
           "name": "_ZN14NuSoundAndroidC1Ev",
@@ -109205,7 +109343,7 @@
           "address": 3322048,
           "offset": 2432080,
           "size": 105,
-          "match_percent": 19.76
+          "match_percent": 99.88
         },
         {
           "name": "_ZN14NuSoundAndroidC2Ev",
@@ -109213,7 +109351,7 @@
           "address": 3322048,
           "offset": 2432080,
           "size": 105,
-          "match_percent": 19.76
+          "match_percent": 99.88
         },
         {
           "name": "_ZN14NuSoundAndroid17IsValidSampleRateEj",
@@ -109221,7 +109359,7 @@
           "address": 3322160,
           "offset": 2432192,
           "size": 110,
-          "match_percent": 40.870968
+          "match_percent": 99.6129
         },
         {
           "name": "_ZN14NuSoundAndroid14IsValidBitRateEj",
@@ -109229,7 +109367,7 @@
           "address": 3322272,
           "offset": 2432304,
           "size": 22,
-          "match_percent": 0.0
+          "match_percent": 64.75
         },
         {
           "name": "_ZN14NuSoundAndroid15ReportErrorCodeEjPKc",
@@ -109237,7 +109375,7 @@
           "address": 3322304,
           "offset": 2432336,
           "size": 11,
-          "match_percent": 4.25
+          "match_percent": 100.0
         },
         {
           "name": "_ZN14NuSoundAndroid15InitAudioDeviceEv",
@@ -109245,14 +109383,14 @@
           "address": 3322320,
           "offset": 2432352,
           "size": 1129,
-          "match_percent": 0.0
+          "match_percent": 94.09055
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_buffer.cpp.o",
       "source": "src/nu2api/nusound/nusound_buffer.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_buffer.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_buffer.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_buffer.cpp",
@@ -109268,7 +109406,7 @@
           "address": 3268800,
           "offset": 2378832,
           "size": 106,
-          "match_percent": 74.76471
+          "match_percent": 100.0
         },
         {
           "name": "_ZN13NuSoundBufferC2Ev",
@@ -109276,7 +109414,7 @@
           "address": 3268800,
           "offset": 2378832,
           "size": 106,
-          "match_percent": 74.76471
+          "match_percent": 100.0
         },
         {
           "name": "_ZN13NuSoundBufferD1Ev",
@@ -109308,7 +109446,7 @@
           "address": 3268976,
           "offset": 2379008,
           "size": 132,
-          "match_percent": 76.62963
+          "match_percent": 77.03704
         },
         {
           "name": "_ZN13NuSoundBufferC2EPcy",
@@ -109316,7 +109454,7 @@
           "address": 3268976,
           "offset": 2379008,
           "size": 132,
-          "match_percent": 76.62963
+          "match_percent": 77.03704
         },
         {
           "name": "_ZN13NuSoundBuffer4FreeEv",
@@ -109324,7 +109462,7 @@
           "address": 3269120,
           "offset": 2379152,
           "size": 148,
-          "match_percent": 99.58064
+          "match_percent": 99.741936
         },
         {
           "name": "_ZNK13NuSoundBuffer10GetAddressEv",
@@ -109419,7 +109557,7 @@
     {
       "name": "nu2api/nusound/nusound_bus.cpp.o",
       "source": "src/nu2api/nusound/nusound_bus.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_bus.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_bus.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_bus.cpp",
@@ -109427,7 +109565,7 @@
           "address": 909776,
           "offset": 19808,
           "size": 93,
-          "match_percent": 29.411764
+          "match_percent": 92.35294
         },
         {
           "name": "_ZN13NuSoundSystem6GetBusEPKc",
@@ -109435,7 +109573,7 @@
           "address": 3248368,
           "offset": 2358400,
           "size": 109,
-          "match_percent": 10.609756
+          "match_percent": 90.19512
         },
         {
           "name": "_ZN10NuSoundBusC1EPKcb",
@@ -109443,7 +109581,7 @@
           "address": 3267216,
           "offset": 2377248,
           "size": 203,
-          "match_percent": 17.704546
+          "match_percent": 88.204544
         },
         {
           "name": "_ZN10NuSoundBusC2EPKcb",
@@ -109451,7 +109589,7 @@
           "address": 3267216,
           "offset": 2377248,
           "size": 203,
-          "match_percent": 17.704546
+          "match_percent": 88.204544
         },
         {
           "name": "_ZN10NuSoundBusC1EPKcPS_",
@@ -109459,7 +109597,7 @@
           "address": 3267424,
           "offset": 2377456,
           "size": 205,
-          "match_percent": 5.422222
+          "match_percent": 88.35555
         },
         {
           "name": "_ZN10NuSoundBusC2EPKcPS_",
@@ -109467,7 +109605,7 @@
           "address": 3267424,
           "offset": 2377456,
           "size": 205,
-          "match_percent": 5.422222
+          "match_percent": 88.35555
         },
         {
           "name": "_ZN10NuSoundBusD1Ev",
@@ -109475,7 +109613,7 @@
           "address": 3267632,
           "offset": 2377664,
           "size": 122,
-          "match_percent": 8.25
+          "match_percent": 91.05
         },
         {
           "name": "_ZN10NuSoundBusD2Ev",
@@ -109483,7 +109621,7 @@
           "address": 3267632,
           "offset": 2377664,
           "size": 122,
-          "match_percent": 8.25
+          "match_percent": 91.05
         },
         {
           "name": "_ZN10NuSoundBus12SetOutputBusEPS_",
@@ -109491,7 +109629,7 @@
           "address": 3267760,
           "offset": 2377792,
           "size": 48,
-          "match_percent": 5.333334
+          "match_percent": 99.86667
         },
         {
           "name": "_ZN10NuSoundBus7GetNameEv",
@@ -109499,7 +109637,7 @@
           "address": 3267808,
           "offset": 2377840,
           "size": 12,
-          "match_percent": 19.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN10NuSoundBus12SetOutputMixEPf",
@@ -109507,7 +109645,7 @@
           "address": 3267824,
           "offset": 2377856,
           "size": 53,
-          "match_percent": 23.571428
+          "match_percent": 99.92857
         },
         {
           "name": "_ZN10NuSoundBus12SetOutputMixEf",
@@ -109515,7 +109653,7 @@
           "address": 3267888,
           "offset": 2377920,
           "size": 37,
-          "match_percent": 23.333334
+          "match_percent": 100.0
         },
         {
           "name": "_ZN10NuSoundBus12GetOutputMixEPf",
@@ -109523,7 +109661,7 @@
           "address": 3267936,
           "offset": 2377968,
           "size": 53,
-          "match_percent": 27.142857
+          "match_percent": 99.92857
         },
         {
           "name": "_ZN10NuSoundBus13ApplyFinalMixEPf",
@@ -109531,7 +109669,7 @@
           "address": 3268000,
           "offset": 2378032,
           "size": 314,
-          "match_percent": 4.473684
+          "match_percent": 99.697365
         },
         {
           "name": "_ZN10NuSoundBus12RemoveEffectEP13NuSoundEffect",
@@ -109539,7 +109677,7 @@
           "address": 3268320,
           "offset": 2378352,
           "size": 308,
-          "match_percent": 3.4
+          "match_percent": 39.39
         },
         {
           "name": "_ZN10NuSoundBus9AddEffectEP13NuSoundEffect",
@@ -109547,14 +109685,14 @@
           "address": 3268640,
           "offset": 2378672,
           "size": 158,
-          "match_percent": 6.0
+          "match_percent": 48.036366
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_clock.cpp.o",
       "source": "src/nu2api/nusound/nusound_clock.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_clock.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_clock.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_clock.cpp",
@@ -109562,7 +109700,7 @@
           "address": 910512,
           "offset": 20544,
           "size": 93,
-          "match_percent": 29.411764
+          "match_percent": 92.35294
         },
         {
           "name": "_ZN12NuSoundClockC1Ev",
@@ -109570,7 +109708,7 @@
           "address": 3270384,
           "offset": 2380416,
           "size": 57,
-          "match_percent": 6.153846
+          "match_percent": 75.46154
         },
         {
           "name": "_ZN12NuSoundClockC2Ev",
@@ -109578,7 +109716,7 @@
           "address": 3270384,
           "offset": 2380416,
           "size": 57,
-          "match_percent": 6.153846
+          "match_percent": 75.46154
         },
         {
           "name": "_ZN12NuSoundClockD1Ev",
@@ -109586,7 +109724,7 @@
           "address": 3270448,
           "offset": 2380480,
           "size": 118,
-          "match_percent": 7.906977
+          "match_percent": 28.186047
         },
         {
           "name": "_ZN12NuSoundClockD2Ev",
@@ -109594,7 +109732,7 @@
           "address": 3270448,
           "offset": 2380480,
           "size": 118,
-          "match_percent": 7.906977
+          "match_percent": 28.186047
         },
         {
           "name": "_ZNK12NuSoundClock8GetTicksEv",
@@ -109602,7 +109740,7 @@
           "address": 3270576,
           "offset": 2380608,
           "size": 9,
-          "match_percent": 31.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundClock17GetClockFrequencyEv",
@@ -109610,7 +109748,7 @@
           "address": 3270592,
           "offset": 2380624,
           "size": 13,
-          "match_percent": 36.666668
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundClock11AddCallbackEPNS_8CallbackE",
@@ -109618,7 +109756,7 @@
           "address": 3270608,
           "offset": 2380640,
           "size": 153,
-          "match_percent": 5.510204
+          "match_percent": 16.714285
         },
         {
           "name": "_ZN12NuSoundClock14RemoveCallbackEPNS_8CallbackE",
@@ -109626,7 +109764,7 @@
           "address": 3270768,
           "offset": 2380800,
           "size": 82,
-          "match_percent": 11.785714
+          "match_percent": 63.214287
         },
         {
           "name": "_ZN12NuSoundClock15HandleCallbacksEv",
@@ -109634,14 +109772,14 @@
           "address": 3270864,
           "offset": 2380896,
           "size": 222,
-          "match_percent": 4.657534
+          "match_percent": 52.260273
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_decoder.cpp.o",
       "source": "src/nu2api/nusound/nusound_decoder.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_decoder.cpp",
@@ -109649,7 +109787,7 @@
           "address": 910608,
           "offset": 20640,
           "size": 279,
-          "match_percent": 12.955556
+          "match_percent": 98.68889
         },
         {
           "name": "_ZNK14NuSoundDecoder12IsStreamOpenEv",
@@ -109657,7 +109795,7 @@
           "address": 3271104,
           "offset": 2381136,
           "size": 41,
-          "match_percent": 16.6
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK14NuSoundDecoder8IsLockedEv",
@@ -109665,7 +109803,7 @@
           "address": 3271152,
           "offset": 2381184,
           "size": 24,
-          "match_percent": 7.5
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK14NuSoundDecoder20GetNumInitialBuffersEv",
@@ -109673,7 +109811,7 @@
           "address": 3271184,
           "offset": 2381216,
           "size": 41,
-          "match_percent": 58.166668
+          "match_percent": 91.916664
         },
         {
           "name": "_ZN14NuSoundDecoder12VoiceReleaseEv",
@@ -109681,7 +109819,7 @@
           "address": 3271232,
           "offset": 2381264,
           "size": 97,
-          "match_percent": 33.045456
+          "match_percent": 99.954544
         },
         {
           "name": "_ZN14NuSoundDecoder14VoiceReferenceEv",
@@ -109689,7 +109827,7 @@
           "address": 3271344,
           "offset": 2381376,
           "size": 59,
-          "match_percent": 52.9375
+          "match_percent": 99.9375
         },
         {
           "name": "_ZN14NuSoundDecoder6UnlockEv",
@@ -109697,7 +109835,7 @@
           "address": 3271408,
           "offset": 2381440,
           "size": 83,
-          "match_percent": 10.6
+          "match_percent": 76.03333
         },
         {
           "name": "_ZN14NuSoundDecoder4LockEv",
@@ -109705,7 +109843,7 @@
           "address": 3271504,
           "offset": 2381536,
           "size": 83,
-          "match_percent": 9.433333
+          "match_percent": 76.03333
         },
         {
           "name": "_ZN14NuSoundDecoder11CloseStreamEv",
@@ -109713,7 +109851,7 @@
           "address": 3271600,
           "offset": 2381632,
           "size": 213,
-          "match_percent": 4.985714
+          "match_percent": 95.11429
         },
         {
           "name": "_ZN14NuSoundDecoder10OpenStreamEb",
@@ -109721,7 +109859,7 @@
           "address": 3271824,
           "offset": 2381856,
           "size": 321,
-          "match_percent": 15.255555
+          "match_percent": 84.81111
         },
         {
           "name": "_ZN14NuSoundDecoderD1Ev",
@@ -109729,7 +109867,7 @@
           "address": 3272160,
           "offset": 2382192,
           "size": 140,
-          "match_percent": 30.588236
+          "match_percent": 99.94118
         },
         {
           "name": "_ZN14NuSoundDecoderD2Ev",
@@ -109737,7 +109875,7 @@
           "address": 3272160,
           "offset": 2382192,
           "size": 140,
-          "match_percent": 30.588236
+          "match_percent": 99.94118
         },
         {
           "name": "_ZN14NuSoundDecoderD0Ev",
@@ -109753,7 +109891,7 @@
           "address": 3272400,
           "offset": 2382432,
           "size": 299,
-          "match_percent": 37.563637
+          "match_percent": 97.454544
         },
         {
           "name": "_ZN14NuSoundDecoderC2EPKcP13NuSoundSource",
@@ -109761,7 +109899,7 @@
           "address": 3272400,
           "offset": 2382432,
           "size": 299,
-          "match_percent": 37.563637
+          "match_percent": 97.454544
         },
         {
           "name": "_ZNK14NuSoundDecoder17GetNumRingBuffersEv",
@@ -109769,7 +109907,7 @@
           "address": 3272704,
           "offset": 2382736,
           "size": 15,
-          "match_percent": 99.85714
+          "match_percent": 100.0
         },
         {
           "name": "_ZN19NuSoundDecodeThreadC1Ev",
@@ -109777,7 +109915,7 @@
           "address": 3272720,
           "offset": 2382752,
           "size": 197,
-          "match_percent": 0.0
+          "match_percent": 67.025
         },
         {
           "name": "_ZN19NuSoundDecodeThreadC2Ev",
@@ -109785,7 +109923,7 @@
           "address": 3272720,
           "offset": 2382752,
           "size": 197,
-          "match_percent": 0.0
+          "match_percent": 67.025
         },
         {
           "name": "_ZN14NuSoundDecoder10InitialiseEv",
@@ -109793,7 +109931,7 @@
           "address": 3272928,
           "offset": 2382960,
           "size": 121,
-          "match_percent": 69.888885
+          "match_percent": 99.888885
         },
         {
           "name": "_ZN19NuSoundDecodeThreadD1Ev",
@@ -109801,7 +109939,7 @@
           "address": 3273056,
           "offset": 2383088,
           "size": 39,
-          "match_percent": 0.0
+          "match_percent": 99.90909
         },
         {
           "name": "_ZN19NuSoundDecodeThreadD2Ev",
@@ -109809,7 +109947,7 @@
           "address": 3273056,
           "offset": 2383088,
           "size": 39,
-          "match_percent": 0.0
+          "match_percent": 99.90909
         },
         {
           "name": "_ZN19NuSoundDecodeThread10ThreadFuncEPv",
@@ -109817,7 +109955,7 @@
           "address": 3273104,
           "offset": 2383136,
           "size": 1243,
-          "match_percent": 15.120915
+          "match_percent": 39.31046
         },
         {
           "name": "_ZN19NuSoundDecodeThread13RequestDecodeER14NuSoundDecoderR13NuSoundBuffer14NuSoundWeakPtrI21NuSoundBufferCallbackEb",
@@ -109825,7 +109963,7 @@
           "address": 3274352,
           "offset": 2384384,
           "size": 1051,
-          "match_percent": 21.51673
+          "match_percent": 31.386618
         },
         {
           "name": "_ZN14NuSoundDecoder13RequestBufferEb14NuSoundWeakPtrI21NuSoundBufferCallbackE",
@@ -109833,7 +109971,7 @@
           "address": 3275408,
           "offset": 2385440,
           "size": 501,
-          "match_percent": 0.0
+          "match_percent": 75.76613
         },
         {
           "name": "_ZN19NuSoundDecodeThread8ShutdownEv",
@@ -109841,7 +109979,7 @@
           "address": 3275920,
           "offset": 2385952,
           "size": 356,
-          "match_percent": 4.883721
+          "match_percent": 50.453487
         },
         {
           "name": "_ZN14NuSoundDecoder8ShutdownEv",
@@ -109849,7 +109987,7 @@
           "address": 3276288,
           "offset": 2386320,
           "size": 117,
-          "match_percent": 14.0
+          "match_percent": 99.933334
         },
         {
           "name": "_ZN14NuSoundDecoder16GetMaxBufferSizeEv",
@@ -109857,7 +109995,7 @@
           "address": 3276416,
           "offset": 2386448,
           "size": 15,
-          "match_percent": 99.85714
+          "match_percent": 100.0
         },
         {
           "name": "_ZN14NuSoundDecoder5ResetEv",
@@ -109872,7 +110010,7 @@
     {
       "name": "nu2api/nusound/nusound_decoder_ogg.cpp.o",
       "source": "src/nu2api/nusound/nusound_decoder_ogg.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder_ogg.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder_ogg.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_decoder_ogg.cpp",
@@ -109920,7 +110058,7 @@
           "address": 3334624,
           "offset": 2444656,
           "size": 45,
-          "match_percent": 50.333332
+          "match_percent": 100.0
         },
         {
           "name": "_ZThn232_N17NuSoundDecoderOGG12SubmitBufferEP13NuSoundBuffer",
@@ -109936,7 +110074,7 @@
           "address": 3334688,
           "offset": 2444720,
           "size": 103,
-          "match_percent": 42.25
+          "match_percent": 87.333336
         },
         {
           "name": "_ZN17NuSoundDecoderOGGD2Ev",
@@ -109944,7 +110082,7 @@
           "address": 3334688,
           "offset": 2444720,
           "size": 103,
-          "match_percent": 42.25
+          "match_percent": 87.333336
         },
         {
           "name": "_ZThn232_N17NuSoundDecoderOGGD1Ev",
@@ -109976,7 +110114,7 @@
           "address": 3334928,
           "offset": 2444960,
           "size": 724,
-          "match_percent": 23.927927
+          "match_percent": 69.64414
         },
         {
           "name": "_ZN17NuSoundDecoderOGG23OGGReadCallbacksDecoderC1Ev",
@@ -109984,7 +110122,7 @@
           "address": 3335664,
           "offset": 2445696,
           "size": 34,
-          "match_percent": 87.125
+          "match_percent": 99.75
         },
         {
           "name": "_ZN17NuSoundDecoderOGG23OGGReadCallbacksDecoderC2Ev",
@@ -109992,7 +110130,7 @@
           "address": 3335664,
           "offset": 2445696,
           "size": 34,
-          "match_percent": 87.125
+          "match_percent": 99.75
         },
         {
           "name": "_ZN17NuSoundDecoderOGG23OGGReadCallbacksDecoder10SetDecoderEPS_",
@@ -110000,7 +110138,7 @@
           "address": 3335712,
           "offset": 2445744,
           "size": 14,
-          "match_percent": 99.833336
+          "match_percent": 100.0
         },
         {
           "name": "_ZN17NuSoundDecoderOGGC1EPKcP13NuSoundSource",
@@ -110008,7 +110146,7 @@
           "address": 3335728,
           "offset": 2445760,
           "size": 243,
-          "match_percent": 46.555557
+          "match_percent": 99.95556
         },
         {
           "name": "_ZN17NuSoundDecoderOGGC2EPKcP13NuSoundSource",
@@ -110016,7 +110154,7 @@
           "address": 3335728,
           "offset": 2445760,
           "size": 243,
-          "match_percent": 46.555557
+          "match_percent": 99.95556
         },
         {
           "name": "_ZN17NuSoundDecoderOGG6DecodeER13NuSoundSourceR13NuSoundBufferb",
@@ -110024,7 +110162,7 @@
           "address": 3335984,
           "offset": 2446016,
           "size": 1235,
-          "match_percent": 30.159235
+          "match_percent": 41.11465
         },
         {
           "name": "_ZN17NuSoundDecoderOGG23OGGReadCallbacksDecoder4ReadEPvj",
@@ -110032,14 +110170,14 @@
           "address": 3337232,
           "offset": 2447264,
           "size": 1227,
-          "match_percent": 31.511328
+          "match_percent": 41.50809
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_effect.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect.cpp",
@@ -110063,7 +110201,7 @@
           "address": 3277312,
           "offset": 2387344,
           "size": 296,
-          "match_percent": 7.581395
+          "match_percent": 84.976746
         },
         {
           "name": "_ZN13NuSoundEffectD2Ev",
@@ -110071,7 +110209,7 @@
           "address": 3277312,
           "offset": 2387344,
           "size": 296,
-          "match_percent": 7.581395
+          "match_percent": 84.976746
         },
         {
           "name": "_ZN13NuSoundEffectD0Ev",
@@ -110086,7 +110224,7 @@
     {
       "name": "nu2api/nusound/nusound_effect_doppler.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect_doppler.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_doppler.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_doppler.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect_doppler.cpp",
@@ -110094,7 +110232,7 @@
           "address": 910992,
           "offset": 21024,
           "size": 93,
-          "match_percent": 29.411764
+          "match_percent": 92.35294
         },
         {
           "name": "_ZN20NuSoundEffectDopplerD1Ev",
@@ -110102,7 +110240,7 @@
           "address": 3277712,
           "offset": 2387744,
           "size": 45,
-          "match_percent": 19.307692
+          "match_percent": 99.84615
         },
         {
           "name": "_ZN20NuSoundEffectDopplerD2Ev",
@@ -110110,7 +110248,7 @@
           "address": 3277712,
           "offset": 2387744,
           "size": 45,
-          "match_percent": 19.307692
+          "match_percent": 99.84615
         },
         {
           "name": "_ZN20NuSoundEffectDopplerD0Ev",
@@ -110118,7 +110256,7 @@
           "address": 3277760,
           "offset": 2387792,
           "size": 81,
-          "match_percent": 30.842106
+          "match_percent": 70.47369
         },
         {
           "name": "_ZN20NuSoundEffectDoppler12ProcessVoiceEP12NuSoundVoicef",
@@ -110126,7 +110264,7 @@
           "address": 3277856,
           "offset": 2387888,
           "size": 413,
-          "match_percent": 3.809524
+          "match_percent": 79.52381
         },
         {
           "name": "_ZN20NuSoundEffectDopplerC1Ev",
@@ -110134,7 +110272,7 @@
           "address": 3278272,
           "offset": 2388304,
           "size": 148,
-          "match_percent": 22.806452
+          "match_percent": 81.064514
         },
         {
           "name": "_ZN20NuSoundEffectDopplerC2Ev",
@@ -110142,7 +110280,7 @@
           "address": 3278272,
           "offset": 2388304,
           "size": 148,
-          "match_percent": 22.806452
+          "match_percent": 81.064514
         },
         {
           "name": "_ZN20NuSoundEffectDoppler13SetParametersEffPK7NuEListI15NuSoundListener12DefaultElistE",
@@ -110150,14 +110288,14 @@
           "address": 3278432,
           "offset": 2388464,
           "size": 34,
-          "match_percent": 10.0
+          "match_percent": 100.0
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_effect_fader.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect_fader.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_fader.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_fader.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect_fader.cpp",
@@ -110165,7 +110303,7 @@
           "address": 911088,
           "offset": 21120,
           "size": 93,
-          "match_percent": 29.411764
+          "match_percent": 92.35294
         },
         {
           "name": "_ZN18NuSoundEffectFader6EnableEv",
@@ -110173,7 +110311,7 @@
           "address": 3278480,
           "offset": 2388512,
           "size": 40,
-          "match_percent": 22.0
+          "match_percent": 99.8
         },
         {
           "name": "_ZN18NuSoundEffectFader7DisableEv",
@@ -110181,7 +110319,7 @@
           "address": 3278528,
           "offset": 2388560,
           "size": 13,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN18NuSoundEffectFader11AttachVoiceEP12NuSoundVoice",
@@ -110189,7 +110327,7 @@
           "address": 3278544,
           "offset": 2388576,
           "size": 12,
-          "match_percent": 16.75
+          "match_percent": 100.0
         },
         {
           "name": "_ZN18NuSoundEffectFader9AttachBusEP10NuSoundBus",
@@ -110197,7 +110335,7 @@
           "address": 3278560,
           "offset": 2388592,
           "size": 12,
-          "match_percent": 16.75
+          "match_percent": 100.0
         },
         {
           "name": "_ZN18NuSoundEffectFader10ProcessBusEP10NuSoundBusf",
@@ -110205,7 +110343,7 @@
           "address": 3278576,
           "offset": 2388608,
           "size": 9,
-          "match_percent": 24.444445
+          "match_percent": 100.0
         },
         {
           "name": "_ZN18NuSoundEffectFaderD1Ev",
@@ -110213,7 +110351,7 @@
           "address": 3278592,
           "offset": 2388624,
           "size": 45,
-          "match_percent": 19.307692
+          "match_percent": 99.84615
         },
         {
           "name": "_ZN18NuSoundEffectFaderD2Ev",
@@ -110221,7 +110359,7 @@
           "address": 3278592,
           "offset": 2388624,
           "size": 45,
-          "match_percent": 19.307692
+          "match_percent": 99.84615
         },
         {
           "name": "_ZN18NuSoundEffectFaderD0Ev",
@@ -110229,7 +110367,7 @@
           "address": 3278640,
           "offset": 2388672,
           "size": 81,
-          "match_percent": 30.842106
+          "match_percent": 70.47369
         },
         {
           "name": "_ZN18NuSoundEffectFader12ProcessVoiceEP12NuSoundVoicef",
@@ -110237,7 +110375,7 @@
           "address": 3278736,
           "offset": 2388768,
           "size": 120,
-          "match_percent": 6.111111
+          "match_percent": 99.97222
         },
         {
           "name": "_ZN18NuSoundEffectFader7ProcessEf",
@@ -110245,7 +110383,7 @@
           "address": 3278864,
           "offset": 2388896,
           "size": 370,
-          "match_percent": 2.31579
+          "match_percent": 16.768421
         },
         {
           "name": "_ZN18NuSoundEffectFaderC1Ev",
@@ -110253,7 +110391,7 @@
           "address": 3279248,
           "offset": 2389280,
           "size": 190,
-          "match_percent": 18.605263
+          "match_percent": 82.63158
         },
         {
           "name": "_ZN18NuSoundEffectFaderC2Ev",
@@ -110261,7 +110399,7 @@
           "address": 3279248,
           "offset": 2389280,
           "size": 190,
-          "match_percent": 18.605263
+          "match_percent": 82.63158
         },
         {
           "name": "_ZN18NuSoundEffectFader13SetParametersEffNS_11FinishStateE",
@@ -110269,7 +110407,7 @@
           "address": 3279440,
           "offset": 2389472,
           "size": 161,
-          "match_percent": 5.238095
+          "match_percent": 44.714287
         },
         {
           "name": "_ZN18NuSoundEffectFader14SetCurveParamsERKNS_5CurveE",
@@ -110277,14 +110415,14 @@
           "address": 3279616,
           "offset": 2389648,
           "size": 20,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect_pitchramp.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_pitchramp.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_pitchramp.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect_pitchramp.cpp",
@@ -110292,7 +110430,7 @@
           "address": 911184,
           "offset": 21216,
           "size": 93,
-          "match_percent": 29.411764
+          "match_percent": 92.35294
         },
         {
           "name": "_ZN22NuSoundEffectPitchRamp11AttachVoiceEP12NuSoundVoice",
@@ -110300,7 +110438,7 @@
           "address": 3279648,
           "offset": 2389680,
           "size": 12,
-          "match_percent": 16.75
+          "match_percent": 100.0
         },
         {
           "name": "_ZN22NuSoundEffectPitchRampD1Ev",
@@ -110308,7 +110446,7 @@
           "address": 3279664,
           "offset": 2389696,
           "size": 45,
-          "match_percent": 19.307692
+          "match_percent": 99.84615
         },
         {
           "name": "_ZN22NuSoundEffectPitchRampD2Ev",
@@ -110316,7 +110454,7 @@
           "address": 3279664,
           "offset": 2389696,
           "size": 45,
-          "match_percent": 19.307692
+          "match_percent": 99.84615
         },
         {
           "name": "_ZN22NuSoundEffectPitchRampD0Ev",
@@ -110324,7 +110462,7 @@
           "address": 3279712,
           "offset": 2389744,
           "size": 81,
-          "match_percent": 30.842106
+          "match_percent": 70.47369
         },
         {
           "name": "_ZN22NuSoundEffectPitchRamp7ProcessEf",
@@ -110332,7 +110470,7 @@
           "address": 3279808,
           "offset": 2389840,
           "size": 172,
-          "match_percent": 4.230769
+          "match_percent": 46.923077
         },
         {
           "name": "_ZN22NuSoundEffectPitchRamp12ProcessVoiceEP12NuSoundVoicef",
@@ -110340,7 +110478,7 @@
           "address": 3279984,
           "offset": 2390016,
           "size": 78,
-          "match_percent": 11.0
+          "match_percent": 99.95
         },
         {
           "name": "_ZN22NuSoundEffectPitchRampC1Ev",
@@ -110348,7 +110486,7 @@
           "address": 3280064,
           "offset": 2390096,
           "size": 152,
-          "match_percent": 22.09375
+          "match_percent": 79.625
         },
         {
           "name": "_ZN22NuSoundEffectPitchRampC2Ev",
@@ -110356,7 +110494,7 @@
           "address": 3280064,
           "offset": 2390096,
           "size": 152,
-          "match_percent": 22.09375
+          "match_percent": 79.625
         },
         {
           "name": "_ZN22NuSoundEffectPitchRamp13SetParametersEffNS_11FinishStateE",
@@ -110364,14 +110502,14 @@
           "address": 3280224,
           "offset": 2390256,
           "size": 79,
-          "match_percent": 12.222222
+          "match_percent": 99.833336
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_handle.cpp.o",
       "source": "src/nu2api/nusound/nusound_handle.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_handle.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_handle.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_handle.cpp",
@@ -110675,7 +110813,7 @@
           "address": 3340384,
           "offset": 2450416,
           "size": 62,
-          "match_percent": 70.32
+          "match_percent": 99.6
         },
         {
           "name": "_ZN13NuSoundHandle15InvalidateVoiceEv",
@@ -110730,7 +110868,7 @@
     {
       "name": "nu2api/nusound/nusound_listener.cpp.o",
       "source": "src/nu2api/nusound/nusound_listener.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_listener.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_listener.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_listener.cpp",
@@ -110738,7 +110876,7 @@
           "address": 911280,
           "offset": 21312,
           "size": 93,
-          "match_percent": 29.411764
+          "match_percent": 92.35294
         },
         {
           "name": "_ZN15NuSoundListenerC1Ev",
@@ -110746,7 +110884,7 @@
           "address": 3280304,
           "offset": 2390336,
           "size": 61,
-          "match_percent": 7.272728
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListenerC2Ev",
@@ -110754,7 +110892,7 @@
           "address": 3280304,
           "offset": 2390336,
           "size": 61,
-          "match_percent": 7.272728
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListenerD1Ev",
@@ -110762,7 +110900,7 @@
           "address": 3280368,
           "offset": 2390400,
           "size": 78,
-          "match_percent": 15.714286
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListenerD2Ev",
@@ -110770,7 +110908,7 @@
           "address": 3280368,
           "offset": 2390400,
           "size": 78,
-          "match_percent": 15.714286
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListener13SetHeadMatrixEPK5VuMtx",
@@ -110778,7 +110916,7 @@
           "address": 3280448,
           "offset": 2390480,
           "size": 14,
-          "match_percent": 36.666668
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK15NuSoundListener13GetHeadMatrixEv",
@@ -110786,7 +110924,7 @@
           "address": 3280464,
           "offset": 2390496,
           "size": 12,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListener16SetFocusPositionEPK5VuVec",
@@ -110794,7 +110932,7 @@
           "address": 3280480,
           "offset": 2390512,
           "size": 14,
-          "match_percent": 36.666668
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK15NuSoundListener16GetFocusPositionEv",
@@ -110802,7 +110940,7 @@
           "address": 3280496,
           "offset": 2390528,
           "size": 49,
-          "match_percent": 5.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK15NuSoundListener15GetHeadDistanceERK5VuVec",
@@ -110810,7 +110948,7 @@
           "address": 3280560,
           "offset": 2390592,
           "size": 76,
-          "match_percent": 15.0
+          "match_percent": 99.90909
         },
         {
           "name": "_ZNK15NuSoundListener22GetAttenuationPositionERK5VuVec",
@@ -110818,7 +110956,7 @@
           "address": 3280640,
           "offset": 2390672,
           "size": 157,
-          "match_percent": 5.365854
+          "match_percent": 86.31707
         },
         {
           "name": "_ZNK15NuSoundListener22GetAttenuationDistanceERK5VuVec",
@@ -110826,7 +110964,7 @@
           "address": 3280800,
           "offset": 2390832,
           "size": 76,
-          "match_percent": 12.222222
+          "match_percent": 99.94444
         },
         {
           "name": "_ZN15NuSoundListener11SetVelocityERK5VuVec",
@@ -110834,7 +110972,7 @@
           "address": 3280880,
           "offset": 2390912,
           "size": 33,
-          "match_percent": 23.333334
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK15NuSoundListener11GetVelocityEv",
@@ -110842,7 +110980,7 @@
           "address": 3280928,
           "offset": 2390960,
           "size": 12,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListener6EnableEv",
@@ -110850,7 +110988,7 @@
           "address": 3280944,
           "offset": 2390976,
           "size": 13,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListener7DisableEv",
@@ -110858,7 +110996,7 @@
           "address": 3280960,
           "offset": 2390992,
           "size": 13,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK15NuSoundListener9IsEnabledEv",
@@ -110866,7 +111004,7 @@
           "address": 3280976,
           "offset": 2391008,
           "size": 13,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListener19EnableFocusPositionEv",
@@ -110874,7 +111012,7 @@
           "address": 3280992,
           "offset": 2391024,
           "size": 13,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListener20DisableFocusPositionEv",
@@ -110882,7 +111020,7 @@
           "address": 3281008,
           "offset": 2391040,
           "size": 13,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK15NuSoundListener22IsFocusPositionEnabledEv",
@@ -110890,7 +111028,7 @@
           "address": 3281024,
           "offset": 2391056,
           "size": 13,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListener14SetSensitivityEf",
@@ -110898,7 +111036,7 @@
           "address": 3281040,
           "offset": 2391072,
           "size": 36,
-          "match_percent": 27.5
+          "match_percent": 99.75
         },
         {
           "name": "_ZNK15NuSoundListener14GetSensitivityEv",
@@ -110906,7 +111044,7 @@
           "address": 3281088,
           "offset": 2391120,
           "size": 12,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListener19Set2DScreenPositionEPK5VuVec",
@@ -110914,7 +111052,7 @@
           "address": 3281104,
           "offset": 2391136,
           "size": 14,
-          "match_percent": 36.666668
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK15NuSoundListener19Get2DScreenPositionEv",
@@ -110922,7 +111060,7 @@
           "address": 3281120,
           "offset": 2391152,
           "size": 12,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN15NuSoundListener16SetOutputDevicesEi",
@@ -110930,7 +111068,7 @@
           "address": 3281136,
           "offset": 2391168,
           "size": 14,
-          "match_percent": 36.666668
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK15NuSoundListener16GetOutputDevicesEv",
@@ -110938,14 +111076,14 @@
           "address": 3281152,
           "offset": 2391184,
           "size": 12,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_loader.cpp.o",
       "source": "src/nu2api/nusound/nusound_loader.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_loader.cpp",
@@ -111001,7 +111139,7 @@
           "address": 3341392,
           "offset": 2451424,
           "size": 408,
-          "match_percent": 33.42857
+          "match_percent": 99.992065
         },
         {
           "name": "_ZN13NuSoundLoader20OpenFileForStreamingEPKcb",
@@ -111049,7 +111187,7 @@
           "address": 3342368,
           "offset": 2452400,
           "size": 704,
-          "match_percent": 64.25
+          "match_percent": 85.07222
         },
         {
           "name": "_ZN13NuSoundLoader12LoadFromFileEPKcP17NuSoundStreamDescP13NuSoundBufferP23NuSoundOutOfMemCallback",
@@ -111065,7 +111203,7 @@
           "address": 3343200,
           "offset": 2453232,
           "size": 21,
-          "match_percent": 34.285713
+          "match_percent": 100.0
         },
         {
           "name": "_ZN13NuSoundLoader13ReleaseHeaderEP17NuSoundStreamDesc",
@@ -111081,7 +111219,7 @@
           "address": 3343312,
           "offset": 2453344,
           "size": 112,
-          "match_percent": 13.548388
+          "match_percent": 50.225807
         },
         {
           "name": "_ZN13NuSoundLoader12DeinterleaveEPciPS0_iN13NuSoundSystem13ChannelConfigE",
@@ -111089,14 +111227,14 @@
           "address": 3343424,
           "offset": 2453456,
           "size": 226,
-          "match_percent": 8.607594
+          "match_percent": 73.98734
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_loader_ogg.cpp.o",
       "source": "src/nu2api/nusound/nusound_loader_ogg.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_ogg.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_ogg.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_loader_ogg.cpp",
@@ -111112,7 +111250,7 @@
           "address": 3331968,
           "offset": 2442000,
           "size": 42,
-          "match_percent": 95.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN16NuSoundLoaderOGG15OggCallbackSeekEPvxi",
@@ -111120,7 +111258,7 @@
           "address": 3332016,
           "offset": 2442048,
           "size": 37,
-          "match_percent": 90.63636
+          "match_percent": 90.72727
         },
         {
           "name": "_ZN16NuSoundLoaderOGG15OggCallbackTellEPv",
@@ -111128,7 +111266,7 @@
           "address": 3332064,
           "offset": 2442096,
           "size": 21,
-          "match_percent": 99.85714
+          "match_percent": 100.0
         },
         {
           "name": "_ZN16NuSoundLoaderOGG16OGGFileCallbacks7SetFileEi",
@@ -111280,7 +111418,7 @@
           "address": 3333424,
           "offset": 2443456,
           "size": 472,
-          "match_percent": 51.289257
+          "match_percent": 94.29752
         },
         {
           "name": "_ZN16NuSoundLoaderOGG5CloseEv",
@@ -111288,7 +111426,7 @@
           "address": 3333904,
           "offset": 2443936,
           "size": 101,
-          "match_percent": 75.81481
+          "match_percent": 99.96296
         },
         {
           "name": "_ZNK16NuSoundHeaderOGG20GetEncodedDataFormatEv",
@@ -111439,7 +111577,7 @@
     {
       "name": "nu2api/nusound/nusound_loader_wav.cpp.o",
       "source": "src/nu2api/nusound/nusound_loader_wav.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_wav.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_wav.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_loader_wav.cpp",
@@ -111631,7 +111769,7 @@
           "address": 3331344,
           "offset": 2441376,
           "size": 116,
-          "match_percent": 87.76471
+          "match_percent": 99.97059
         },
         {
           "name": "_ZNK16NuSoundHeaderWAV16GetLengthSecondsEv",
@@ -111670,7 +111808,7 @@
     {
       "name": "nu2api/nusound/nusound_memorymanager.cpp.o",
       "source": "src/nu2api/nusound/nusound_memorymanager.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_memorymanager.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_memorymanager.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_memorymanager.cpp",
@@ -111870,7 +112008,7 @@
           "address": 3282112,
           "offset": 2392144,
           "size": 78,
-          "match_percent": 23.333334
+          "match_percent": 99.94444
         },
         {
           "name": "_ZN20NuSoundMemoryManagerD2Ev",
@@ -111878,7 +112016,7 @@
           "address": 3282112,
           "offset": 2392144,
           "size": 78,
-          "match_percent": 23.333334
+          "match_percent": 99.94444
         },
         {
           "name": "_ZN20NuSoundMemoryManager13PopFreeBufferEv",
@@ -111942,7 +112080,7 @@
           "address": 3283296,
           "offset": 2393328,
           "size": 124,
-          "match_percent": 78.741936
+          "match_percent": 99.96774
         },
         {
           "name": "_ZN20NuSoundMemoryManager11FreeAddressEPv",
@@ -111950,7 +112088,7 @@
           "address": 3283424,
           "offset": 2393456,
           "size": 115,
-          "match_percent": 12.0
+          "match_percent": 99.975
         },
         {
           "name": "_ZN20NuSoundMemoryManager18SwapSimilarBuffersEP19NuSoundMemoryBufferS1_",
@@ -111958,7 +112096,7 @@
           "address": 3283552,
           "offset": 2393584,
           "size": 676,
-          "match_percent": 2.307692
+          "match_percent": 99.98351
         },
         {
           "name": "_ZN20NuSoundMemoryManager26SwapOrMergeAdjacentBuffersEP19NuSoundMemoryBuffer",
@@ -111966,7 +112104,7 @@
           "address": 3284240,
           "offset": 2394272,
           "size": 549,
-          "match_percent": 2.857143
+          "match_percent": 83.319725
         },
         {
           "name": "_ZN20NuSoundMemoryManager24CountAdjacentFreeBuffersEP19NuSoundMemoryBuffer",
@@ -111974,7 +112112,7 @@
           "address": 3284800,
           "offset": 2394832,
           "size": 156,
-          "match_percent": 9.545455
+          "match_percent": 99.97727
         },
         {
           "name": "_ZN20NuSoundMemoryManager35MoveLargestTrailingBufferIntoBufferEP19NuSoundMemoryBufferPS1_S2_",
@@ -111982,7 +112120,7 @@
           "address": 3284960,
           "offset": 2394992,
           "size": 507,
-          "match_percent": 2.658228
+          "match_percent": 34.8038
         },
         {
           "name": "_ZN20NuSoundMemoryManager10DefragmentEj",
@@ -111990,7 +112128,7 @@
           "address": 3285472,
           "offset": 2395504,
           "size": 456,
-          "match_percent": 3.138686
+          "match_percent": 50.10219
         },
         {
           "name": "_ZN20NuSoundMemoryManager7GetSizeEv",
@@ -112014,7 +112152,7 @@
           "address": 3285968,
           "offset": 2396000,
           "size": 377,
-          "match_percent": 59.474136
+          "match_percent": 92.706894
         },
         {
           "name": "_ZN20NuSoundMemoryManager12AllocAddressEj",
@@ -112022,7 +112160,7 @@
           "address": 3286352,
           "offset": 2396384,
           "size": 60,
-          "match_percent": 22.105263
+          "match_percent": 99.947365
         },
         {
           "name": "_ZN20NuSoundMemoryManager7GetUsedEv",
@@ -112062,7 +112200,7 @@
           "address": 3286864,
           "offset": 2396896,
           "size": 25,
-          "match_percent": 35.0
+          "match_percent": 67.5
         },
         {
           "name": "_ZN20NuSoundMemoryManager19EnableDefragOnAllocEb",
@@ -112078,7 +112216,7 @@
           "address": 3286928,
           "offset": 2396960,
           "size": 28,
-          "match_percent": 46.666668
+          "match_percent": 88.888885
         },
         {
           "name": "_ZN20NuSoundMemoryManager9RenderMapEfff",
@@ -112093,7 +112231,7 @@
     {
       "name": "nu2api/nusound/nusound_mixer.cpp.o",
       "source": "src/nu2api/nusound/nusound_mixer.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_mixer.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_mixer.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_mixer.cpp",
@@ -112101,7 +112239,7 @@
           "address": 913920,
           "offset": 23952,
           "size": 93,
-          "match_percent": 29.411764
+          "match_percent": 92.35294
         },
         {
           "name": "_ZN12NuSoundMixerC1EN13NuSoundSystem13ChannelConfigES1_NS_12OutputLayoutENS0_11DownmixTypeEP19NuSoundRoutingTable",
@@ -112109,7 +112247,7 @@
           "address": 3343664,
           "offset": 2453696,
           "size": 62,
-          "match_percent": 15.555555
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundMixerC2EN13NuSoundSystem13ChannelConfigES1_NS_12OutputLayoutENS0_11DownmixTypeEP19NuSoundRoutingTable",
@@ -112117,7 +112255,7 @@
           "address": 3343664,
           "offset": 2453696,
           "size": 62,
-          "match_percent": 15.555555
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundMixerD1Ev",
@@ -112125,7 +112263,7 @@
           "address": 3343728,
           "offset": 2453760,
           "size": 9,
-          "match_percent": 24.444445
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundMixerD2Ev",
@@ -112133,7 +112271,7 @@
           "address": 3343728,
           "offset": 2453760,
           "size": 9,
-          "match_percent": 24.444445
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundMixer14GetOutputIndexEii",
@@ -112141,7 +112279,7 @@
           "address": 3343744,
           "offset": 2453776,
           "size": 36,
-          "match_percent": 18.333334
+          "match_percent": 76.333336
         },
         {
           "name": "_ZN12NuSoundMixer3MixEPfS0_",
@@ -112149,14 +112287,14 @@
           "address": 3343792,
           "offset": 2453824,
           "size": 580,
-          "match_percent": 2.312925
+          "match_percent": 96.265305
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_plain.cpp.o",
       "source": "src/nu2api/nusound/nusound_plain.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_plain.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_plain.o",
       "functions": [
         {
           "name": "NuSound3InitEx",
@@ -112164,7 +112302,7 @@
           "address": 3214128,
           "offset": 2324160,
           "size": 39,
-          "match_percent": 42.0
+          "match_percent": 99.9
         },
         {
           "name": "NuSound3UpdateEx",
@@ -112191,124 +112329,12 @@
           "match_percent": 99.75
         },
         {
-          "name": "NuSound3IsSampleLoaded",
-          "demangled_name": "NuSound3IsSampleLoaded",
-          "address": 3214960,
-          "offset": 2324992,
-          "size": 52,
-          "match_percent": 28.0
-        },
-        {
-          "name": "NuSound3CountVoices",
-          "demangled_name": "NuSound3CountVoices",
-          "address": 3215024,
-          "offset": 2325056,
-          "size": 94,
-          "match_percent": 13.714286
-        },
-        {
-          "name": "NuSound3FindOldestVoice",
-          "demangled_name": "NuSound3FindOldestVoice",
-          "address": 3215120,
-          "offset": 2325152,
-          "size": 76,
-          "match_percent": 19.09091
-        },
-        {
-          "name": "NuSound3FindQuietestVoice",
-          "demangled_name": "NuSound3FindQuietestVoice",
-          "address": 3215200,
-          "offset": 2325232,
-          "size": 76,
-          "match_percent": 19.09091
-        },
-        {
-          "name": "NuSound3StopVoice",
-          "demangled_name": "NuSound3StopVoice",
-          "address": 3215280,
-          "offset": 2325312,
-          "size": 195,
-          "match_percent": 7.741935
-        },
-        {
-          "name": "NuSound3Play3dLoopSfx",
-          "demangled_name": "NuSound3Play3dLoopSfx",
-          "address": 3215968,
-          "offset": 2326000,
-          "size": 296,
-          "match_percent": 6.4
-        },
-        {
-          "name": "NuSound3Play3d",
-          "demangled_name": "NuSound3Play3d",
-          "address": 3216272,
-          "offset": 2326304,
-          "size": 102,
-          "match_percent": 18.26087
-        },
-        {
-          "name": "NuSound3Play3dPri",
-          "demangled_name": "NuSound3Play3dPri",
-          "address": 3216384,
-          "offset": 2326416,
-          "size": 93,
-          "match_percent": 19.09091
-        },
-        {
-          "name": "NuSound3PlayPri",
-          "demangled_name": "NuSound3PlayPri",
-          "address": 3216480,
-          "offset": 2326512,
-          "size": 93,
-          "match_percent": 20.0
-        },
-        {
-          "name": "NuSound3Play",
-          "demangled_name": "NuSound3Play",
-          "address": 3216576,
-          "offset": 2326608,
-          "size": 93,
-          "match_percent": 20.0
-        },
-        {
-          "name": "NuSound3Listener",
-          "demangled_name": "NuSound3Listener",
-          "address": 3216672,
-          "offset": 2326704,
-          "size": 44,
-          "match_percent": 35.0
-        },
-        {
-          "name": "NuSound3GetListener",
-          "demangled_name": "NuSound3GetListener",
-          "address": 3216720,
-          "offset": 2326752,
-          "size": 36,
-          "match_percent": 42.0
-        },
-        {
           "name": "NuSound3SetStreamVolume",
           "demangled_name": "NuSound3SetStreamVolume",
           "address": 3218224,
           "offset": 2328256,
           "size": 47,
-          "match_percent": 32.307693
-        },
-        {
-          "name": "NuSound3GetStreamPlaybackTime",
-          "demangled_name": "NuSound3GetStreamPlaybackTime",
-          "address": 3218400,
-          "offset": 2328432,
-          "size": 72,
-          "match_percent": 19.09091
-        },
-        {
-          "name": "NuSound3AmplitudeTodB",
-          "demangled_name": "NuSound3AmplitudeTodB",
-          "address": 3219216,
-          "offset": 2329248,
-          "size": 38,
-          "match_percent": 42.0
+          "match_percent": 99.92308
         },
         {
           "name": "NuSound3FClose",
@@ -112779,7 +112805,7 @@
     {
       "name": "nu2api/nusound/nusound_routing.cpp.o",
       "source": "src/nu2api/nusound/nusound_routing.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_routing.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_routing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_routing.cpp",
@@ -112787,7 +112813,7 @@
           "address": 911696,
           "offset": 21728,
           "size": 93,
-          "match_percent": 29.411764
+          "match_percent": 92.35294
         },
         {
           "name": "_ZN19NuSoundRoutingTableC1EPKc",
@@ -112795,7 +112821,7 @@
           "address": 3286976,
           "offset": 2397008,
           "size": 237,
-          "match_percent": 2.972973
+          "match_percent": 99.98649
         },
         {
           "name": "_ZN19NuSoundRoutingTableC2EPKc",
@@ -112803,7 +112829,7 @@
           "address": 3286976,
           "offset": 2397008,
           "size": 237,
-          "match_percent": 2.972973
+          "match_percent": 99.98649
         },
         {
           "name": "_ZNK19NuSoundRoutingTable7GetNameEv",
@@ -112811,7 +112837,7 @@
           "address": 3287216,
           "offset": 2397248,
           "size": 12,
-          "match_percent": 11.428572
+          "match_percent": 100.0
         },
         {
           "name": "_ZN19NuSoundRoutingTable8GetIndexEN13NuSoundSystem13ChannelConfigE",
@@ -112819,7 +112845,7 @@
           "address": 3287232,
           "offset": 2397264,
           "size": 33,
-          "match_percent": 8.888889
+          "match_percent": 99.77778
         },
         {
           "name": "_ZNK19NuSoundRoutingTable9GetMatrixEN13NuSoundSystem13ChannelConfigES1_",
@@ -112827,7 +112853,7 @@
           "address": 3287280,
           "offset": 2397312,
           "size": 76,
-          "match_percent": 11.0
+          "match_percent": 99.95
         },
         {
           "name": "_ZN19NuSoundRoutingTable9SetMatrixEN13NuSoundSystem13ChannelConfigES1_P16NuSoundMixMatrix",
@@ -112835,7 +112861,7 @@
           "address": 3287360,
           "offset": 2397392,
           "size": 80,
-          "match_percent": 10.476191
+          "match_percent": 99.95238
         },
         {
           "name": "_ZN19NuSoundRoutingTable9GetConfigEi",
@@ -112843,7 +112869,7 @@
           "address": 3290464,
           "offset": 2400496,
           "size": 36,
-          "match_percent": 8.888889
+          "match_percent": 99.77778
         },
         {
           "name": "_ZN19NuSoundRoutingTableC1EPKcPKS_",
@@ -112851,7 +112877,7 @@
           "address": 3290512,
           "offset": 2400544,
           "size": 2752,
-          "match_percent": 0.53125
+          "match_percent": 99.998436
         },
         {
           "name": "_ZN19NuSoundRoutingTableC2EPKcPKS_",
@@ -112859,14 +112885,14 @@
           "address": 3290512,
           "offset": 2400544,
           "size": 2752,
-          "match_percent": 0.53125
+          "match_percent": 99.998436
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_sample.cpp.o",
       "source": "src/nu2api/nusound/nusound_sample.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_sample.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_sample.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_sample.cpp",
@@ -113002,7 +113028,7 @@
           "address": 3294384,
           "offset": 2404416,
           "size": 170,
-          "match_percent": 94.57143
+          "match_percent": 99.97619
         },
         {
           "name": "_ZN13NuSoundSampleD1Ev",
@@ -113010,7 +113036,7 @@
           "address": 3294560,
           "offset": 2404592,
           "size": 145,
-          "match_percent": 47.666668
+          "match_percent": 99.94444
         },
         {
           "name": "_ZN13NuSoundSampleD2Ev",
@@ -113018,7 +113044,7 @@
           "address": 3294560,
           "offset": 2404592,
           "size": 145,
-          "match_percent": 47.666668
+          "match_percent": 99.94444
         },
         {
           "name": "_ZN13NuSoundSampleD0Ev",
@@ -113065,7 +113091,7 @@
     {
       "name": "nu2api/nusound/nusound_source.cpp.o",
       "source": "src/nu2api/nusound/nusound_source.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_source.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_source.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_source.cpp",
@@ -113160,7 +113186,7 @@
     {
       "name": "nu2api/nusound/nusound_streamer.cpp.o",
       "source": "src/nu2api/nusound/nusound_streamer.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_streamer.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_streamer.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_streamer.cpp",
@@ -113200,7 +113226,7 @@
           "address": 3295872,
           "offset": 2405904,
           "size": 87,
-          "match_percent": 35.285713
+          "match_percent": 99.90476
         },
         {
           "name": "_ZN22NuSoundStreamingSampleD2Ev",
@@ -113208,7 +113234,7 @@
           "address": 3295872,
           "offset": 2405904,
           "size": 87,
-          "match_percent": 35.285713
+          "match_percent": 99.90476
         },
         {
           "name": "_ZN22NuSoundStreamingSampleD0Ev",
@@ -113240,7 +113266,7 @@
           "address": 3296208,
           "offset": 2406240,
           "size": 1479,
-          "match_percent": 7.665698
+          "match_percent": 19.997093
         },
         {
           "name": "_ZN22NuSoundStreamingSample5CloseEv",
@@ -113256,7 +113282,7 @@
           "address": 3298080,
           "offset": 2408112,
           "size": 567,
-          "match_percent": 3.935484
+          "match_percent": 50.167744
         },
         {
           "name": "_ZN15NuSoundStreamerC1Ev",
@@ -113264,7 +113290,7 @@
           "address": 3298656,
           "offset": 2408688,
           "size": 560,
-          "match_percent": 43.625954
+          "match_percent": 76.44275
         },
         {
           "name": "_ZN15NuSoundStreamerC2Ev",
@@ -113272,7 +113298,7 @@
           "address": 3298656,
           "offset": 2408688,
           "size": 560,
-          "match_percent": 43.625954
+          "match_percent": 76.44275
         },
         {
           "name": "_ZN15NuSoundStreamerD1Ev",
@@ -113280,7 +113306,7 @@
           "address": 3299216,
           "offset": 2409248,
           "size": 297,
-          "match_percent": 0.0
+          "match_percent": 29.213484
         },
         {
           "name": "_ZN15NuSoundStreamerD2Ev",
@@ -113288,7 +113314,7 @@
           "address": 3299216,
           "offset": 2409248,
           "size": 297,
-          "match_percent": 0.0
+          "match_percent": 29.213484
         },
         {
           "name": "_ZN15NuSoundStreamer10ThreadFuncEPv",
@@ -113296,7 +113322,7 @@
           "address": 3299520,
           "offset": 2409552,
           "size": 2539,
-          "match_percent": 13.235577
+          "match_percent": 29.637821
         },
         {
           "name": "_ZN15NuSoundStreamer11RequestFillEP22NuSoundStreamingSampleP13NuSoundBufferb14NuSoundWeakPtrI21NuSoundBufferCallbackE",
@@ -113304,7 +113330,7 @@
           "address": 3302064,
           "offset": 2412096,
           "size": 1115,
-          "match_percent": 27.64
+          "match_percent": 28.81091
         },
         {
           "name": "_ZN22NuSoundStreamingSample13RequestBufferEb14NuSoundWeakPtrI21NuSoundBufferCallbackE",
@@ -113312,7 +113338,7 @@
           "address": 3303184,
           "offset": 2413216,
           "size": 459,
-          "match_percent": 51.786884
+          "match_percent": 71.44262
         },
         {
           "name": "_ZN15NuSoundStreamer14ShutdownThreadEv",
@@ -113320,7 +113346,7 @@
           "address": 3303648,
           "offset": 2413680,
           "size": 357,
-          "match_percent": 26.75
+          "match_percent": 40.108696
         },
         {
           "name": "_ZN15NuSoundStreamer11ShutdownAllEv",
@@ -113336,7 +113362,7 @@
           "address": 3304096,
           "offset": 2414128,
           "size": 361,
-          "match_percent": 66.595505
+          "match_percent": 69.26966
         },
         {
           "name": "_ZN15NuSoundStreamer12RequestCloseEP22NuSoundStreamingSample",
@@ -113344,7 +113370,7 @@
           "address": 3304464,
           "offset": 2414496,
           "size": 353,
-          "match_percent": 63.390804
+          "match_percent": 70.333336
         },
         {
           "name": "_ZN15NuSoundStreamer10RequestCueEP22NuSoundStreamingSamplebfb",
@@ -113352,7 +113378,15 @@
           "address": 3304832,
           "offset": 2414864,
           "size": 385,
-          "match_percent": 68.04256
+          "match_percent": 74.82979
+        },
+        {
+          "name": "_ZNK22NuSoundStreamingSample12IsStreamOpenEv",
+          "demangled_name": "NuSoundStreamingSample::IsStreamOpen() const",
+          "address": 3305232,
+          "offset": 2415264,
+          "size": 40,
+          "match_percent": 99.916664
         },
         {
           "name": "_ZN6NuListIP15NuSoundStreamerED1Ev",
@@ -113375,7 +113409,7 @@
     {
       "name": "nu2api/nusound/nusound_system.cpp.o",
       "source": "src/nu2api/nusound/nusound_system.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_system.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_system.o",
       "functions": [
         {
           "name": "_Z19NuSound3ExitThreadsv",
@@ -113391,7 +113425,7 @@
           "address": 3248800,
           "offset": 2358832,
           "size": 24,
-          "match_percent": 0.0
+          "match_percent": 99.666664
         },
         {
           "name": "_ZN13NuSoundSystem20GetScratchMemorySizeEv",
@@ -113407,7 +113441,7 @@
           "address": 3248848,
           "offset": 2358880,
           "size": 89,
-          "match_percent": 16.153847
+          "match_percent": 99.92308
         },
         {
           "name": "_ZN13NuSoundSystem19GetStreamBufferSizeEv",
@@ -113423,7 +113457,7 @@
           "address": 3248960,
           "offset": 2358992,
           "size": 12,
-          "match_percent": 62.5
+          "match_percent": 100.0
         },
         {
           "name": "_ZN13NuSoundSystem20GetDecoderMemorySizeEv",
@@ -113439,7 +113473,7 @@
           "address": 3248992,
           "offset": 2359024,
           "size": 515,
-          "match_percent": 21.673685
+          "match_percent": 67.31579
         },
         {
           "name": "_ZN13NuSoundSystemC2Ev",
@@ -113447,7 +113481,7 @@
           "address": 3248992,
           "offset": 2359024,
           "size": 515,
-          "match_percent": 21.673685
+          "match_percent": 67.31579
         },
         {
           "name": "_ZN13NuSoundSystem3GetEv",
@@ -113455,7 +113489,7 @@
           "address": 3249520,
           "offset": 2359552,
           "size": 22,
-          "match_percent": 0.0
+          "match_percent": 99.71429
         },
         {
           "name": "_ZN13NuSoundSystem13ReAllocMemoryENS_16MemoryDisciplineEjj",
@@ -113479,7 +113513,7 @@
           "address": 3249936,
           "offset": 2359968,
           "size": 133,
-          "match_percent": 12.0
+          "match_percent": 59.17143
         },
         {
           "name": "_ZN13NuSoundSystem13ReleaseEffectEP13NuSoundEffect",
@@ -113487,7 +113521,7 @@
           "address": 3250080,
           "offset": 2360112,
           "size": 298,
-          "match_percent": 4.565218
+          "match_percent": 49.913044
         },
         {
           "name": "_ZN13NuSoundSystem15GetAllocdMemoryENS_16MemoryDisciplineE",
@@ -113495,7 +113529,7 @@
           "address": 3250384,
           "offset": 2360416,
           "size": 25,
-          "match_percent": 0.0
+          "match_percent": 99.666664
         },
         {
           "name": "_ZN13NuSoundSystem13GetFreeMemoryENS_16MemoryDisciplineE",
@@ -113519,7 +113553,7 @@
           "address": 3250672,
           "offset": 2360704,
           "size": 863,
-          "match_percent": 82.53171
+          "match_percent": 97.560974
         },
         {
           "name": "_ZN13NuSoundSystem9CreateBusEPKcb",
@@ -113527,7 +113561,7 @@
           "address": 3251536,
           "offset": 2361568,
           "size": 179,
-          "match_percent": 73.422226
+          "match_percent": 99.95556
         },
         {
           "name": "_ZN13NuSoundSystem14GetTotalMemoryENS_16MemoryDisciplineE",
@@ -113535,7 +113569,7 @@
           "address": 3251728,
           "offset": 2361760,
           "size": 25,
-          "match_percent": 0.0
+          "match_percent": 99.666664
         },
         {
           "name": "_ZN13NuSoundSystem19GetPeakAllocdMemoryENS_16MemoryDisciplineE",
@@ -113551,7 +113585,7 @@
           "address": 3251792,
           "offset": 2361824,
           "size": 48,
-          "match_percent": 28.0
+          "match_percent": 99.86667
         },
         {
           "name": "_ZN13NuSoundSystem22DefragmentSampleMemoryEv",
@@ -113559,7 +113593,7 @@
           "address": 3251840,
           "offset": 2361872,
           "size": 46,
-          "match_percent": 35.0
+          "match_percent": 99.833336
         },
         {
           "name": "_ZN13NuSoundSystem12GenerateHashEPKc",
@@ -113567,7 +113601,7 @@
           "address": 3251888,
           "offset": 2361920,
           "size": 105,
-          "match_percent": 66.25
+          "match_percent": 99.46875
         },
         {
           "name": "_ZN13NuSoundSystem13ReleaseSampleEP13NuSoundSample",
@@ -113575,7 +113609,7 @@
           "address": 3252000,
           "offset": 2362032,
           "size": 146,
-          "match_percent": 10.243902
+          "match_percent": 47.341465
         },
         {
           "name": "_ZN13NuSoundSystem10LoadSampleEP13NuSoundSamplePviP23NuSoundOutOfMemCallback",
@@ -113583,7 +113617,7 @@
           "address": 3252160,
           "offset": 2362192,
           "size": 125,
-          "match_percent": 12.352942
+          "match_percent": 99.97059
         },
         {
           "name": "_ZN13NuSoundSystem12UnloadSampleEP13NuSoundSample",
@@ -113591,7 +113625,7 @@
           "address": 3252288,
           "offset": 2362320,
           "size": 94,
-          "match_percent": 15.0
+          "match_percent": 99.42857
         },
         {
           "name": "_ZN13NuSoundSystem16UnloadAllSamplesEv",
@@ -113599,7 +113633,7 @@
           "address": 3252384,
           "offset": 2362416,
           "size": 137,
-          "match_percent": 8.4
+          "match_percent": 19.8
         },
         {
           "name": "_ZN13NuSoundSystem13StopAllVoicesEv",
@@ -113631,7 +113665,7 @@
           "address": 3252896,
           "offset": 2362928,
           "size": 129,
-          "match_percent": 2.916667
+          "match_percent": 85.708336
         },
         {
           "name": "_ZN13NuSoundSystem14PauseAllVoicesEv",
@@ -113639,7 +113673,7 @@
           "address": 3253040,
           "offset": 2363072,
           "size": 101,
-          "match_percent": 10.5
+          "match_percent": 81.475
         },
         {
           "name": "_ZN13NuSoundSystem12ResumeVoicesEi",
@@ -113647,7 +113681,7 @@
           "address": 3253152,
           "offset": 2363184,
           "size": 129,
-          "match_percent": 2.916667
+          "match_percent": 85.708336
         },
         {
           "name": "_ZN13NuSoundSystem15ResumeAllVoicesEv",
@@ -113655,7 +113689,7 @@
           "address": 3253296,
           "offset": 2363328,
           "size": 101,
-          "match_percent": 10.5
+          "match_percent": 81.475
         },
         {
           "name": "_ZN13NuSoundSystem14GetOldestVoiceEP13NuSoundSampleRf",
@@ -113663,7 +113697,7 @@
           "address": 3253408,
           "offset": 2363440,
           "size": 229,
-          "match_percent": 6.31579
+          "match_percent": 88.60526
         },
         {
           "name": "_ZN13NuSoundSystem16GetQuietestVoiceEP13NuSoundSampleRf",
@@ -113671,7 +113705,7 @@
           "address": 3253648,
           "offset": 2363680,
           "size": 245,
-          "match_percent": 6.153846
+          "match_percent": 88.89744
         },
         {
           "name": "_ZN13NuSoundSystem9GetSampleEPKc",
@@ -113679,7 +113713,7 @@
           "address": 3253904,
           "offset": 2363936,
           "size": 116,
-          "match_percent": 84.46512
+          "match_percent": 99.976746
         },
         {
           "name": "_ZN13NuSoundSystem17ReleaseFileLoaderEP13NuSoundLoader",
@@ -113695,7 +113729,7 @@
           "address": 3254288,
           "offset": 2364320,
           "size": 716,
-          "match_percent": 21.827587
+          "match_percent": 45.38506
         },
         {
           "name": "_ZN13NuSoundSystem14ReleaseDecoderEP14NuSoundDecoder",
@@ -113711,7 +113745,7 @@
           "address": 3255088,
           "offset": 2365120,
           "size": 36,
-          "match_percent": 35.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN13NuSoundSystem15GetRoutingTableEPKc",
@@ -113719,7 +113753,7 @@
           "address": 3255136,
           "offset": 2365168,
           "size": 109,
-          "match_percent": 10.243902
+          "match_percent": 90.19512
         },
         {
           "name": "_ZN13NuSoundSystem22SetDefaultRoutingTableEP19NuSoundRoutingTable",
@@ -113727,7 +113761,7 @@
           "address": 3255248,
           "offset": 2365280,
           "size": 24,
-          "match_percent": 0.0
+          "match_percent": 99.666664
         },
         {
           "name": "_ZN13NuSoundSystem22GetDefaultRoutingTableEv",
@@ -113743,7 +113777,7 @@
           "address": 3255312,
           "offset": 2365344,
           "size": 41,
-          "match_percent": 32.307693
+          "match_percent": 100.0
         },
         {
           "name": "_ZN13NuSoundSystem14RemoveListenerEP15NuSoundListener",
@@ -113751,7 +113785,7 @@
           "address": 3255360,
           "offset": 2365392,
           "size": 69,
-          "match_percent": 18.26087
+          "match_percent": 100.0
         },
         {
           "name": "_ZN13NuSoundSystem12GetListenersEv",
@@ -113759,7 +113793,7 @@
           "address": 3255440,
           "offset": 2365472,
           "size": 14,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK13NuSoundSystem17GetCrossfadeCurveEj",
@@ -113775,7 +113809,7 @@
           "address": 3255536,
           "offset": 2365568,
           "size": 9,
-          "match_percent": 62.5
+          "match_percent": 100.0
         },
         {
           "name": "_ZN13NuSoundSystem17DetermineFileTypeEPKc",
@@ -113791,7 +113825,7 @@
           "address": 3256112,
           "offset": 2366144,
           "size": 87,
-          "match_percent": 22.105263
+          "match_percent": 99.947365
         },
         {
           "name": "_ZN13NuSoundSystem18GetDefaultFileTypeEN13NuSoundSource8FeedTypeE",
@@ -113799,7 +113833,7 @@
           "address": 3256208,
           "offset": 2366240,
           "size": 78,
-          "match_percent": 19.09091
+          "match_percent": 99.954544
         },
         {
           "name": "_ZN13NuSoundSystem16GetFileExtensionENS_8FileTypeE",
@@ -113815,7 +113849,7 @@
           "address": 3256320,
           "offset": 2366352,
           "size": 472,
-          "match_percent": 57.028847
+          "match_percent": 75.47115
         },
         {
           "name": "_ZN13NuSoundSystem21SourceRequiresDecoderEP13NuSoundSource",
@@ -113823,7 +113857,7 @@
           "address": 3256800,
           "offset": 2366832,
           "size": 222,
-          "match_percent": 32.235294
+          "match_percent": 34.514706
         },
         {
           "name": "_ZN13NuSoundSystem12ReleaseVoiceEP12NuSoundVoice",
@@ -113831,7 +113865,7 @@
           "address": 3257024,
           "offset": 2367056,
           "size": 325,
-          "match_percent": 42.60606
+          "match_percent": 78.79798
         },
         {
           "name": "_ZN13NuSoundSystem8ShutdownEv",
@@ -113839,7 +113873,7 @@
           "address": 3257360,
           "offset": 2367392,
           "size": 615,
-          "match_percent": 2.470588
+          "match_percent": 66.329414
         },
         {
           "name": "_ZN13NuSoundSystem6UpdateEf",
@@ -113847,7 +113881,7 @@
           "address": 3257984,
           "offset": 2368016,
           "size": 365,
-          "match_percent": 61.767857
+          "match_percent": 90.59821
         },
         {
           "name": "_ZN13NuSoundSystem11CreateVoiceEP13NuSoundSourceb",
@@ -113855,7 +113889,7 @@
           "address": 3258352,
           "offset": 2368384,
           "size": 418,
-          "match_percent": 20.512
+          "match_percent": 41.216
         },
         {
           "name": "_ZN13NuSoundSystem17FileTypeSupportedENS_8FileTypeE",
@@ -113863,7 +113897,23 @@
           "address": 3258784,
           "offset": 2368816,
           "size": 31,
-          "match_percent": 35.0
+          "match_percent": 99.75
+        },
+        {
+          "name": "_ZN13NuSoundSystem22GetNearestRealListenerERK7NuEListI15NuSoundListener12DefaultElistERK5VuVec",
+          "demangled_name": "NuSoundSystem::GetNearestRealListener(NuEList<NuSoundListener, DefaultElist> const&, VuVec const&)",
+          "address": 3258816,
+          "offset": 2368848,
+          "size": 242,
+          "match_percent": 75.24286
+        },
+        {
+          "name": "_ZN13NuSoundSystem23GetNearestFocusListenerERK7NuEListI15NuSoundListener12DefaultElistERK5VuVecRf",
+          "demangled_name": "NuSoundSystem::GetNearestFocusListener(NuEList<NuSoundListener, DefaultElist> const&, VuVec const&, float&)",
+          "address": 3259072,
+          "offset": 2369104,
+          "size": 237,
+          "match_percent": 91.80303
         },
         {
           "name": "_ZN13NuSoundSystem13AmplitudeTodBEf",
@@ -113871,7 +113921,7 @@
           "address": 3259312,
           "offset": 2369344,
           "size": 118,
-          "match_percent": 15.0
+          "match_percent": 99.875
         },
         {
           "name": "_ZN13NuSoundSystem13dBToAmplitudeEf",
@@ -113887,7 +113937,7 @@
           "address": 3259536,
           "offset": 2369568,
           "size": 22,
-          "match_percent": 0.0
+          "match_percent": 99.71429
         },
         {
           "name": "_ZN13NuSoundSystem25GetClosestSupportedConfigEi",
@@ -113895,7 +113945,7 @@
           "address": 3259568,
           "offset": 2369600,
           "size": 33,
-          "match_percent": 19.09091
+          "match_percent": 20.0
         },
         {
           "name": "_ZN13NuSoundSystem28GetNumAvailableOutputDevicesEv",
@@ -113919,7 +113969,7 @@
           "address": 3259664,
           "offset": 2369696,
           "size": 22,
-          "match_percent": 12.5
+          "match_percent": 99.75
         },
         {
           "name": "_ZN13NuSoundSystem17GetLanguageStringEb",
@@ -113927,7 +113977,7 @@
           "address": 3259696,
           "offset": 2369728,
           "size": 22,
-          "match_percent": 12.5
+          "match_percent": 99.75
         },
         {
           "name": "_ZN13NuSoundSystem7DisableEv",
@@ -113935,7 +113985,7 @@
           "address": 3259728,
           "offset": 2369760,
           "size": 26,
-          "match_percent": 0.0
+          "match_percent": 99.71429
         },
         {
           "name": "_Z29NuSound_GetAllocdSampleMemoryv",
@@ -113951,7 +114001,7 @@
           "address": 3259808,
           "offset": 2369840,
           "size": 1180,
-          "match_percent": 2.222222
+          "match_percent": 51.358025
         },
         {
           "name": "_ZN13NuSoundSystem21ReleaseCrossfadeCurveEj",
@@ -113975,7 +114025,7 @@
           "address": 3261104,
           "offset": 2371136,
           "size": 1141,
-          "match_percent": 4.312704
+          "match_percent": 7.661238
         },
         {
           "name": "_ZN13NuSoundSystemD2Ev",
@@ -113983,7 +114033,7 @@
           "address": 3261104,
           "offset": 2371136,
           "size": 1141,
-          "match_percent": 4.312704
+          "match_percent": 7.661238
         },
         {
           "name": "_ZN13NuSoundSystemD0Ev",
@@ -113994,12 +114044,204 @@
           "match_percent": 70.47369
         },
         {
+          "name": "_ZN24NuSoundEffectAttenuation9AttachBusEP10NuSoundBus",
+          "demangled_name": "NuSoundEffectAttenuation::AttachBus(NuSoundBus*)",
+          "address": 3262624,
+          "offset": 2372656,
+          "size": 12,
+          "match_percent": 100.0
+        },
+        {
+          "name": "_ZN22NuSoundSystemCallbacks11ReleasePageEP15NuMemoryManagerPvj",
+          "demangled_name": "NuSoundSystemCallbacks::ReleasePage(NuMemoryManager*, void*, unsigned int)",
+          "address": 3262640,
+          "offset": 2372672,
+          "size": 9,
+          "match_percent": 100.0
+        },
+        {
+          "name": "_ZN24NuSoundEffectAttenuationD1Ev",
+          "demangled_name": "NuSoundEffectAttenuation::~NuSoundEffectAttenuation()",
+          "address": 3262656,
+          "offset": 2372688,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "_ZN24NuSoundEffectAttenuationD2Ev",
+          "demangled_name": "NuSoundEffectAttenuation::~NuSoundEffectAttenuation()",
+          "address": 3262656,
+          "offset": 2372688,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "_ZN18NuSoundEffectPitchD1Ev",
+          "demangled_name": "NuSoundEffectPitch::~NuSoundEffectPitch()",
+          "address": 3262704,
+          "offset": 2372736,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "_ZN18NuSoundEffectPitchD2Ev",
+          "demangled_name": "NuSoundEffectPitch::~NuSoundEffectPitch()",
+          "address": 3262704,
+          "offset": 2372736,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "_ZN25NuSoundEffectRandomVolumeD1Ev",
+          "demangled_name": "NuSoundEffectRandomVolume::~NuSoundEffectRandomVolume()",
+          "address": 3262752,
+          "offset": 2372784,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "_ZN25NuSoundEffectRandomVolumeD2Ev",
+          "demangled_name": "NuSoundEffectRandomVolume::~NuSoundEffectRandomVolume()",
+          "address": 3262752,
+          "offset": 2372784,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "_ZN24NuSoundEffectRandomPitchD1Ev",
+          "demangled_name": "NuSoundEffectRandomPitch::~NuSoundEffectRandomPitch()",
+          "address": 3262800,
+          "offset": 2372832,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "_ZN24NuSoundEffectRandomPitchD2Ev",
+          "demangled_name": "NuSoundEffectRandomPitch::~NuSoundEffectRandomPitch()",
+          "address": 3262800,
+          "offset": 2372832,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "_ZN19NuSoundEffectRepeatD1Ev",
+          "demangled_name": "NuSoundEffectRepeat::~NuSoundEffectRepeat()",
+          "address": 3262848,
+          "offset": 2372880,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "_ZN19NuSoundEffectRepeatD2Ev",
+          "demangled_name": "NuSoundEffectRepeat::~NuSoundEffectRepeat()",
+          "address": 3262848,
+          "offset": 2372880,
+          "size": 45,
+          "match_percent": 99.84615
+        },
+        {
+          "name": "_ZN22NuSoundSystemCallbacks4DumpEP15NuMemoryManagerjPKc",
+          "demangled_name": "NuSoundSystemCallbacks::Dump(NuMemoryManager*, unsigned int, char const*)",
+          "address": 3262896,
+          "offset": 2372928,
+          "size": 68,
+          "match_percent": 99.94118
+        },
+        {
+          "name": "_ZN22NuSoundSystemCallbacks9CloseDumpEP15NuMemoryManagerj",
+          "demangled_name": "NuSoundSystemCallbacks::CloseDump(NuMemoryManager*, unsigned int)",
+          "address": 3262976,
+          "offset": 2373008,
+          "size": 34,
+          "match_percent": 99.9
+        },
+        {
+          "name": "_ZN22NuSoundSystemCallbacks8OpenDumpEP15NuMemoryManagerPKcRj",
+          "demangled_name": "NuSoundSystemCallbacks::OpenDump(NuMemoryManager*, char const*, unsigned int&)",
+          "address": 3263024,
+          "offset": 2373056,
+          "size": 53,
+          "match_percent": 99.933334
+        },
+        {
+          "name": "_ZN22NuSoundSystemCallbacks12AllocatePageEP15NuMemoryManagerjj",
+          "demangled_name": "NuSoundSystemCallbacks::AllocatePage(NuMemoryManager*, unsigned int, unsigned int)",
+          "address": 3263088,
+          "offset": 2373120,
+          "size": 92,
+          "match_percent": 99.95652
+        },
+        {
+          "name": "_ZN19NuSoundEffectRepeat12ProcessVoiceEP12NuSoundVoicef",
+          "demangled_name": "NuSoundEffectRepeat::ProcessVoice(NuSoundVoice*, float)",
+          "address": 3263184,
+          "offset": 2373216,
+          "size": 214,
+          "match_percent": 99.98333
+        },
+        {
+          "name": "_ZN24NuSoundEffectAttenuation12ProcessVoiceEP12NuSoundVoicef",
+          "demangled_name": "NuSoundEffectAttenuation::ProcessVoice(NuSoundVoice*, float)",
+          "address": 3263408,
+          "offset": 2373440,
+          "size": 143,
+          "match_percent": 99.725
+        },
+        {
+          "name": "_ZN19NuSoundEffectRepeatD0Ev",
+          "demangled_name": "NuSoundEffectRepeat::~NuSoundEffectRepeat()",
+          "address": 3263552,
+          "offset": 2373584,
+          "size": 92,
+          "match_percent": 74.454544
+        },
+        {
+          "name": "_ZN24NuSoundEffectRandomPitchD0Ev",
+          "demangled_name": "NuSoundEffectRandomPitch::~NuSoundEffectRandomPitch()",
+          "address": 3263648,
+          "offset": 2373680,
+          "size": 92,
+          "match_percent": 74.454544
+        },
+        {
+          "name": "_ZN25NuSoundEffectRandomVolumeD0Ev",
+          "demangled_name": "NuSoundEffectRandomVolume::~NuSoundEffectRandomVolume()",
+          "address": 3263744,
+          "offset": 2373776,
+          "size": 92,
+          "match_percent": 74.454544
+        },
+        {
+          "name": "_ZN18NuSoundEffectPitchD0Ev",
+          "demangled_name": "NuSoundEffectPitch::~NuSoundEffectPitch()",
+          "address": 3263840,
+          "offset": 2373872,
+          "size": 92,
+          "match_percent": 74.454544
+        },
+        {
+          "name": "_ZN24NuSoundEffectAttenuationD0Ev",
+          "demangled_name": "NuSoundEffectAttenuation::~NuSoundEffectAttenuation()",
+          "address": 3263936,
+          "offset": 2373968,
+          "size": 92,
+          "match_percent": 74.454544
+        },
+        {
+          "name": "_ZN13NuSoundMemory14PushNuListNodeIP13NuSoundEffectEEvR6NuListIT_ERKS4_",
+          "demangled_name": "void NuSoundMemory::PushNuListNode<NuSoundEffect*>(NuList<NuSoundEffect*>&, NuSoundEffect* const&)",
+          "address": 3264032,
+          "offset": 2374064,
+          "size": 193,
+          "match_percent": 94.39216
+        },
+        {
           "name": "_Z31NuSoundInitDefaultRoutingTablesv",
           "demangled_name": "NuSoundInitDefaultRoutingTables()",
           "address": 3287440,
           "offset": 2397472,
           "size": 3014,
-          "match_percent": 0.717949
+          "match_percent": 99.950424
         },
         {
           "name": "_ZN17NuSoundStreamDescD1Ev",
@@ -114054,7 +114296,7 @@
     {
       "name": "nu2api/nusound/nusound_voice.cpp.o",
       "source": "src/nu2api/nusound/nusound_voice.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_voice.cpp",
@@ -114070,7 +114312,7 @@
           "address": 3305408,
           "offset": 2415440,
           "size": 630,
-          "match_percent": 21.790123
+          "match_percent": 76.65432
         },
         {
           "name": "_ZN12NuSoundVoiceD2Ev",
@@ -114078,7 +114320,7 @@
           "address": 3305408,
           "offset": 2415440,
           "size": 630,
-          "match_percent": 21.790123
+          "match_percent": 76.65432
         },
         {
           "name": "_ZN12NuSoundVoiceD0Ev",
@@ -114094,7 +114336,7 @@
           "address": 3306144,
           "offset": 2416176,
           "size": 78,
-          "match_percent": 99.8421
+          "match_percent": 99.89474
         },
         {
           "name": "_ZN12NuSoundVoice8SetStateENS_9PlayStateE",
@@ -114102,7 +114344,7 @@
           "address": 3306224,
           "offset": 2416256,
           "size": 72,
-          "match_percent": 99.82353
+          "match_percent": 99.882355
         },
         {
           "name": "_ZN12NuSoundVoiceC1EP13NuSoundSourceb",
@@ -114110,7 +114352,7 @@
           "address": 3306304,
           "offset": 2416336,
           "size": 749,
-          "match_percent": 16.25
+          "match_percent": 84.460526
         },
         {
           "name": "_ZN12NuSoundVoiceC2EP13NuSoundSourceb",
@@ -114118,7 +114360,7 @@
           "address": 3306304,
           "offset": 2416336,
           "size": 749,
-          "match_percent": 16.25
+          "match_percent": 84.460526
         },
         {
           "name": "_ZN12NuSoundVoice5PauseEv",
@@ -114126,7 +114368,7 @@
           "address": 3307056,
           "offset": 2417088,
           "size": 106,
-          "match_percent": 33.172413
+          "match_percent": 98.93104
         },
         {
           "name": "_ZN12NuSoundVoice6ResumeEv",
@@ -114134,7 +114376,7 @@
           "address": 3307168,
           "offset": 2417200,
           "size": 162,
-          "match_percent": 35.477272
+          "match_percent": 51.545456
         },
         {
           "name": "_ZN12NuSoundVoice14RegisterHandleEP13NuSoundHandle",
@@ -114158,7 +114400,7 @@
           "address": 3307584,
           "offset": 2417616,
           "size": 25,
-          "match_percent": 67.25
+          "match_percent": 67.5
         },
         {
           "name": "_ZN12NuSoundVoice12SetListenersEPK7NuEListI15NuSoundListener12DefaultElistE",
@@ -114166,7 +114408,7 @@
           "address": 3307616,
           "offset": 2417648,
           "size": 17,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice11SetPositionEP5VuVec",
@@ -114174,7 +114416,7 @@
           "address": 3307648,
           "offset": 2417680,
           "size": 43,
-          "match_percent": 30.0
+          "match_percent": 37.357143
         },
         {
           "name": "_ZN12NuSoundVoice12SetDirectionEP5VuVec",
@@ -114182,7 +114424,7 @@
           "address": 3307696,
           "offset": 2417728,
           "size": 105,
-          "match_percent": 17.5
+          "match_percent": 99.958336
         },
         {
           "name": "_ZN12NuSoundVoice11SetVelocityERK5VuVec",
@@ -114190,7 +114432,7 @@
           "address": 3307808,
           "offset": 2417840,
           "size": 39,
-          "match_percent": 35.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice9SetVolumeEf",
@@ -114198,7 +114440,7 @@
           "address": 3307856,
           "offset": 2417888,
           "size": 53,
-          "match_percent": 99.666664
+          "match_percent": 99.75
         },
         {
           "name": "_ZN12NuSoundVoice8SetPitchEf",
@@ -114206,7 +114448,7 @@
           "address": 3307920,
           "offset": 2417952,
           "size": 39,
-          "match_percent": 99.625
+          "match_percent": 99.75
         },
         {
           "name": "_ZN12NuSoundVoice10SetFalloffEffN13NuSoundSystem11FalloffTypeE",
@@ -114214,7 +114456,7 @@
           "address": 3307968,
           "offset": 2418000,
           "size": 68,
-          "match_percent": 30.0
+          "match_percent": 99.85714
         },
         {
           "name": "_ZN12NuSoundVoice18SetLowFrequencyMixEf",
@@ -114222,7 +114464,7 @@
           "address": 3308048,
           "offset": 2418080,
           "size": 21,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice15SetSurroundModeEN13NuSoundSystem12SurroundModeE",
@@ -114230,7 +114472,7 @@
           "address": 3308080,
           "offset": 2418112,
           "size": 14,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice16SetDownmixerTypeEN13NuSoundSystem11DownmixTypeE",
@@ -114238,7 +114480,7 @@
           "address": 3308096,
           "offset": 2418128,
           "size": 14,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice15SetRoutingTableEP19NuSoundRoutingTable",
@@ -114246,7 +114488,7 @@
           "address": 3308112,
           "offset": 2418144,
           "size": 14,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice17SetControllerBitsEi",
@@ -114254,7 +114496,7 @@
           "address": 3308128,
           "offset": 2418160,
           "size": 17,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice12SetOutputBusEP10NuSoundBus",
@@ -114262,7 +114504,7 @@
           "address": 3308160,
           "offset": 2418192,
           "size": 51,
-          "match_percent": 0.0
+          "match_percent": 99.85714
         },
         {
           "name": "_ZN12NuSoundVoice20SetCustomSurroundMixEPf",
@@ -114278,7 +114520,7 @@
           "address": 3308240,
           "offset": 2418272,
           "size": 17,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice20SetSpeakerFieldAngleEff",
@@ -114286,7 +114528,7 @@
           "address": 3308272,
           "offset": 2418304,
           "size": 33,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice20SetSpeakerBleedAngleEf",
@@ -114294,7 +114536,7 @@
           "address": 3308320,
           "offset": 2418352,
           "size": 21,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice19SetSpeakerBleedNearEf",
@@ -114302,7 +114544,7 @@
           "address": 3308352,
           "offset": 2418384,
           "size": 21,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice18SetSpeakerBleedFarEf",
@@ -114310,7 +114552,7 @@
           "address": 3308384,
           "offset": 2418416,
           "size": 21,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice14SetPenetrationEf",
@@ -114318,7 +114560,7 @@
           "address": 3308416,
           "offset": 2418448,
           "size": 21,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice12SetMixUpdateEb",
@@ -114326,7 +114568,7 @@
           "address": 3308448,
           "offset": 2418480,
           "size": 34,
-          "match_percent": 88.666664
+          "match_percent": 88.888885
         },
         {
           "name": "_ZN12NuSoundVoice15SetReverbWetMixEf",
@@ -114334,7 +114576,7 @@
           "address": 3308496,
           "offset": 2418528,
           "size": 21,
-          "match_percent": 99.833336
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice14SetStartOffsetEf",
@@ -114342,7 +114584,7 @@
           "address": 3308528,
           "offset": 2418560,
           "size": 21,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice13GetAutoDeleteEv",
@@ -114350,7 +114592,7 @@
           "address": 3308560,
           "offset": 2418592,
           "size": 14,
-          "match_percent": 99.833336
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice9IsLoopingEv",
@@ -114358,7 +114600,7 @@
           "address": 3308576,
           "offset": 2418608,
           "size": 15,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice11GetPositionEv",
@@ -114366,7 +114608,7 @@
           "address": 3308592,
           "offset": 2418624,
           "size": 14,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice11GetVelocityEv",
@@ -114374,7 +114616,7 @@
           "address": 3308608,
           "offset": 2418640,
           "size": 14,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice12GetDirectionEv",
@@ -114382,7 +114624,7 @@
           "address": 3308624,
           "offset": 2418656,
           "size": 14,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice9GetVolumeEv",
@@ -114390,7 +114632,7 @@
           "address": 3308640,
           "offset": 2418672,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice8GetPitchEv",
@@ -114398,7 +114640,7 @@
           "address": 3308656,
           "offset": 2418688,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice7GetNearEv",
@@ -114406,7 +114648,7 @@
           "address": 3308672,
           "offset": 2418704,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice6GetFarEv",
@@ -114414,7 +114656,7 @@
           "address": 3308688,
           "offset": 2418720,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice18GetLowFrequencyMixEv",
@@ -114422,7 +114664,7 @@
           "address": 3308704,
           "offset": 2418736,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice14GetFalloffTypeEv",
@@ -114430,7 +114672,7 @@
           "address": 3308720,
           "offset": 2418752,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice15GetSurroundModeEv",
@@ -114438,7 +114680,7 @@
           "address": 3308736,
           "offset": 2418768,
           "size": 12,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice16GetDownmixerTypeEv",
@@ -114446,7 +114688,7 @@
           "address": 3308752,
           "offset": 2418784,
           "size": 12,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice15GetRoutingTableEv",
@@ -114454,7 +114696,7 @@
           "address": 3308768,
           "offset": 2418800,
           "size": 12,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice17GetControllerBitsEv",
@@ -114462,7 +114704,7 @@
           "address": 3308784,
           "offset": 2418816,
           "size": 16,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice12GetOutputBusEv",
@@ -114470,7 +114712,7 @@
           "address": 3308800,
           "offset": 2418832,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice23GetSpeakerFieldAngleMinEv",
@@ -114478,7 +114720,7 @@
           "address": 3308816,
           "offset": 2418848,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice23GetSpeakerFieldAngleMaxEv",
@@ -114486,7 +114728,7 @@
           "address": 3308832,
           "offset": 2418864,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice20GetSpeakerBleedAngleEv",
@@ -114494,7 +114736,7 @@
           "address": 3308848,
           "offset": 2418880,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice19GetSpeakerBleedNearEv",
@@ -114502,7 +114744,7 @@
           "address": 3308864,
           "offset": 2418896,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice18GetSpeakerBleedFarEv",
@@ -114510,7 +114752,7 @@
           "address": 3308880,
           "offset": 2418912,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice14GetPenetrationEv",
@@ -114518,7 +114760,7 @@
           "address": 3308896,
           "offset": 2418928,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice15GetReverbWetMixEv",
@@ -114526,7 +114768,7 @@
           "address": 3308912,
           "offset": 2418944,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZNK12NuSoundVoice14GetStartOffsetEv",
@@ -114534,7 +114776,7 @@
           "address": 3308928,
           "offset": 2418960,
           "size": 15,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice16BeginStopEffectsEv",
@@ -114542,7 +114784,7 @@
           "address": 3308944,
           "offset": 2418976,
           "size": 112,
-          "match_percent": 13.962264
+          "match_percent": 48.943398
         },
         {
           "name": "_ZN12NuSoundVoice16CheckStopEffectsEv",
@@ -114550,7 +114792,7 @@
           "address": 3309056,
           "offset": 2419088,
           "size": 70,
-          "match_percent": 15.833333
+          "match_percent": 99.166664
         },
         {
           "name": "_ZN12NuSoundVoice4StopEb",
@@ -114558,7 +114800,7 @@
           "address": 3309136,
           "offset": 2419168,
           "size": 122,
-          "match_percent": 98.138885
+          "match_percent": 98.166664
         },
         {
           "name": "_ZNK12NuSoundVoice21AreStopEffectsRunningEv",
@@ -114566,7 +114808,7 @@
           "address": 3309264,
           "offset": 2419296,
           "size": 67,
-          "match_percent": 12.6
+          "match_percent": 98.8
         },
         {
           "name": "_ZN12NuSoundVoice31CalculatePositionalCoefficientsEPfRK5VuVecRK5VuMtxff",
@@ -114574,7 +114816,7 @@
           "address": 3309344,
           "offset": 2419376,
           "size": 3157,
-          "match_percent": 0.767045
+          "match_percent": 24.84659
         },
         {
           "name": "_ZN12NuSoundVoice27CalculateFalloffAttenuationEf",
@@ -114582,7 +114824,7 @@
           "address": 3312512,
           "offset": 2422544,
           "size": 191,
-          "match_percent": 10.434783
+          "match_percent": 99.91304
         },
         {
           "name": "_ZN12NuSoundVoice19CalculateFieldAngleEf",
@@ -114590,7 +114832,7 @@
           "address": 3312704,
           "offset": 2422736,
           "size": 125,
-          "match_percent": 6.666666
+          "match_percent": 84.833336
         },
         {
           "name": "_ZN12NuSoundVoice22CalculatePositionalMixEv",
@@ -114598,7 +114840,7 @@
           "address": 3312832,
           "offset": 2422864,
           "size": 5626,
-          "match_percent": 0.979424
+          "match_percent": 50.87243
         },
         {
           "name": "_ZN12NuSoundVoice12RemoveEffectEP13NuSoundEffect",
@@ -114606,7 +114848,7 @@
           "address": 3318464,
           "offset": 2428496,
           "size": 308,
-          "match_percent": 4.2
+          "match_percent": 39.39
         },
         {
           "name": "_ZN12NuSoundVoice13UpdateEffectsEfN13NuSoundEffect18EffectProcessStageE",
@@ -114614,7 +114856,7 @@
           "address": 3318784,
           "offset": 2428816,
           "size": 172,
-          "match_percent": 7.924528
+          "match_percent": 59.16981
         },
         {
           "name": "_ZNK12NuSoundVoice13GetNumEffectsEv",
@@ -114622,7 +114864,7 @@
           "address": 3318960,
           "offset": 2428992,
           "size": 12,
-          "match_percent": 14.285714
+          "match_percent": 100.0
         },
         {
           "name": "_ZN12NuSoundVoice26CalculateEffectAttenuationEv",
@@ -114630,7 +114872,7 @@
           "address": 3318976,
           "offset": 2429008,
           "size": 77,
-          "match_percent": 17.272728
+          "match_percent": 99.0
         },
         {
           "name": "_ZN12NuSoundVoice25CalculateEffectPitchScaleEv",
@@ -114638,7 +114880,7 @@
           "address": 3319056,
           "offset": 2429088,
           "size": 77,
-          "match_percent": 17.272728
+          "match_percent": 99.0
         },
         {
           "name": "_ZN12NuSoundVoice9UpdateMixEf",
@@ -114646,7 +114888,7 @@
           "address": 3319136,
           "offset": 2429168,
           "size": 283,
-          "match_percent": 54.523075
+          "match_percent": 99.98462
         },
         {
           "name": "_ZN12NuSoundVoice6UpdateEf",
@@ -114654,7 +114896,7 @@
           "address": 3319424,
           "offset": 2429456,
           "size": 210,
-          "match_percent": 88.92157
+          "match_percent": 99.98039
         },
         {
           "name": "_ZN12NuSoundVoice26GetPlaybackPositionSecondsEv",
@@ -114662,7 +114904,7 @@
           "address": 3319648,
           "offset": 2429680,
           "size": 152,
-          "match_percent": 10.5
+          "match_percent": 99.95
         },
         {
           "name": "_ZN12NuSoundVoice9GetEffectEN13NuSoundEffect10EffectTypeE",
@@ -114670,7 +114912,7 @@
           "address": 3319808,
           "offset": 2429840,
           "size": 52,
-          "match_percent": 20.0
+          "match_percent": 99.04762
         },
         {
           "name": "_ZN12NuSoundVoice9AddEffectEP13NuSoundEffect",
@@ -114678,7 +114920,7 @@
           "address": 3319872,
           "offset": 2429904,
           "size": 158,
-          "match_percent": 7.636363
+          "match_percent": 48.036366
         },
         {
           "name": "_ZN12NuSoundVoice4PlayEv",
@@ -114686,7 +114928,7 @@
           "address": 3320032,
           "offset": 2430064,
           "size": 795,
-          "match_percent": 16.88325
+          "match_percent": 42.624367
         },
         {
           "name": "_ZN12NuSoundVoice19CheckStarvedBuffersEv",
@@ -114695,13 +114937,21 @@
           "offset": 2430864,
           "size": 9,
           "match_percent": 100.0
+        },
+        {
+          "name": "_ZN12NuSoundVoice19UpdateHardwareVoiceEf",
+          "demangled_name": "NuSoundVoice::UpdateHardwareVoice(float)",
+          "address": 3320848,
+          "offset": 2430880,
+          "size": 9,
+          "match_percent": 100.0
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_voice_android.cpp.o",
       "source": "src/nu2api/nusound/nusound_voice_android.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice_android.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice_android.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_voice_android.cpp",
@@ -114709,7 +114959,7 @@
           "address": 913120,
           "offset": 23152,
           "size": 93,
-          "match_percent": 29.411764
+          "match_percent": 92.35294
         },
         {
           "name": "_ZN23NuSoundVoiceFactoryListC1Ev",
@@ -114717,7 +114967,7 @@
           "address": 3248480,
           "offset": 2358512,
           "size": 259,
-          "match_percent": 2.101695
+          "match_percent": 68.745766
         },
         {
           "name": "_ZN23NuSoundVoiceFactoryListC2Ev",
@@ -114725,7 +114975,7 @@
           "address": 3248480,
           "offset": 2358512,
           "size": 259,
-          "match_percent": 2.101695
+          "match_percent": 68.745766
         },
         {
           "name": "_ZN23NuSoundVoiceFactoryList15RegisterFactoryEP19NuSoundVoiceFactoryN17NuSoundStreamDesc10DataFormatE",
@@ -114733,7 +114983,7 @@
           "address": 3248752,
           "offset": 2358784,
           "size": 18,
-          "match_percent": 42.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN23NuSoundVoiceFactoryList10GetFactoryEN17NuSoundStreamDesc10DataFormatE",
@@ -114741,7 +114991,7 @@
           "address": 3248784,
           "offset": 2358816,
           "size": 14,
-          "match_percent": 31.8
+          "match_percent": 100.0
         },
         {
           "name": "_ZN30NuSoundVoiceFactoryAndroid_PCM11CreateVoiceEP13NuSoundSourceb",
@@ -114749,7 +114999,7 @@
           "address": 3321584,
           "offset": 2431616,
           "size": 116,
-          "match_percent": 30.73077
+          "match_percent": 76.0
         },
         {
           "name": "_ZN14NuVoiceAndroid26GetPlaybackPositionSamplesEv",
@@ -114765,7 +115015,7 @@
           "address": 3323488,
           "offset": 2433520,
           "size": 83,
-          "match_percent": 0.0
+          "match_percent": 100.0
         },
         {
           "name": "_ZN14NuVoiceAndroid18StartHardwareVoiceEv",
@@ -114773,7 +115023,7 @@
           "address": 3323584,
           "offset": 2433616,
           "size": 97,
-          "match_percent": 0.0
+          "match_percent": 51.5
         },
         {
           "name": "_ZN14NuVoiceAndroid19ResumeHardwareVoiceEv",
@@ -114781,7 +115031,7 @@
           "address": 3323696,
           "offset": 2433728,
           "size": 73,
-          "match_percent": 0.0
+          "match_percent": 99.90476
         },
         {
           "name": "_ZN14NuVoiceAndroid18PauseHardwareVoiceEv",
@@ -114789,7 +115039,7 @@
           "address": 3323776,
           "offset": 2433808,
           "size": 73,
-          "match_percent": 0.0
+          "match_percent": 99.90476
         },
         {
           "name": "_ZN14NuVoiceAndroid17StopHardwareVoiceEv",
@@ -114797,7 +115047,7 @@
           "address": 3323856,
           "offset": 2433888,
           "size": 123,
-          "match_percent": 0.0
+          "match_percent": 99.90625
         },
         {
           "name": "_ZN14NuVoiceAndroid21ApplyHardwareVoiceMixEv",
@@ -114805,7 +115055,7 @@
           "address": 3323984,
           "offset": 2434016,
           "size": 548,
-          "match_percent": 0.0
+          "match_percent": 99.78333
         },
         {
           "name": "_ZN14NuVoiceAndroidD1Ev",
@@ -114813,7 +115063,7 @@
           "address": 3324544,
           "offset": 2434576,
           "size": 81,
-          "match_percent": 2.3
+          "match_percent": 99.9
         },
         {
           "name": "_ZN14NuVoiceAndroidD2Ev",
@@ -114821,7 +115071,7 @@
           "address": 3324544,
           "offset": 2434576,
           "size": 81,
-          "match_percent": 2.3
+          "match_percent": 99.9
         },
         {
           "name": "_ZN14NuVoiceAndroidD0Ev",
@@ -114829,7 +115079,7 @@
           "address": 3324640,
           "offset": 2434672,
           "size": 81,
-          "match_percent": 30.842106
+          "match_percent": 70.47369
         },
         {
           "name": "_ZN14NuVoiceAndroid12SubmitBufferEP13NuSoundBuffer",
@@ -114837,7 +115087,7 @@
           "address": 3324736,
           "offset": 2434768,
           "size": 525,
-          "match_percent": 24.34074
+          "match_percent": 99.97037
         },
         {
           "name": "_ZN14NuVoiceAndroid13RealiseObjectEv",
@@ -114845,7 +115095,7 @@
           "address": 3325264,
           "offset": 2435296,
           "size": 70,
-          "match_percent": 0.0
+          "match_percent": 45.157894
         },
         {
           "name": "_ZN14NuVoiceAndroid13GetInterfacesEv",
@@ -114853,7 +115103,7 @@
           "address": 3325344,
           "offset": 2435376,
           "size": 326,
-          "match_percent": 0.0
+          "match_percent": 99.22222
         },
         {
           "name": "_ZN14NuVoiceAndroid19CreateHardwareVoiceEv",
@@ -114861,7 +115111,7 @@
           "address": 3325680,
           "offset": 2435712,
           "size": 461,
-          "match_percent": 14.938597
+          "match_percent": 98.210526
         },
         {
           "name": "_ZN14NuVoiceAndroidC1EP13NuSoundSourceb",
@@ -114869,7 +115119,7 @@
           "address": 3326144,
           "offset": 2436176,
           "size": 263,
-          "match_percent": 15.063829
+          "match_percent": 99.95744
         },
         {
           "name": "_ZN14NuVoiceAndroidC2EP13NuSoundSourceb",
@@ -114877,7 +115127,7 @@
           "address": 3326144,
           "offset": 2436176,
           "size": 263,
-          "match_percent": 15.063829
+          "match_percent": 99.95744
         },
         {
           "name": "_ZN14NuVoiceAndroid11UpdateStateEv",
@@ -114885,7 +115135,7 @@
           "address": 3326416,
           "offset": 2436448,
           "size": 301,
-          "match_percent": 0.0
+          "match_percent": 61.340206
         },
         {
           "name": "_ZN14NuVoiceAndroid11UpdateQueueEv",
@@ -114893,7 +115143,7 @@
           "address": 3326720,
           "offset": 2436752,
           "size": 181,
-          "match_percent": 0.0
+          "match_percent": 52.966667
         },
         {
           "name": "_ZN14NuVoiceAndroid25UpdateSamplePlaybackCountEv",
@@ -114901,7 +115151,7 @@
           "address": 3326912,
           "offset": 2436944,
           "size": 1202,
-          "match_percent": 19.832827
+          "match_percent": 28.465046
         },
         {
           "name": "_ZN14NuVoiceAndroid13OnPlayerEventEj",
@@ -114909,7 +115159,7 @@
           "address": 3328128,
           "offset": 2438160,
           "size": 137,
-          "match_percent": 0.0
+          "match_percent": 99.97222
         },
         {
           "name": "_ZN14NuVoiceAndroid14PlayerCallbackEPKPK10SLPlayItf_Pvj",
@@ -114917,7 +115167,7 @@
           "address": 3328272,
           "offset": 2438304,
           "size": 46,
-          "match_percent": 39.0
+          "match_percent": 99.92857
         },
         {
           "name": "_ZN14NuVoiceAndroid19UpdateHardwareVoiceEf",
@@ -114925,15 +115175,31 @@
           "address": 3328320,
           "offset": 2438352,
           "size": 593,
-          "match_percent": 22.385136
+          "match_percent": 91.22298
         }
       ]
     },
     {
       "name": "nu2api/nusound/nusound_weakptr.cpp.o",
       "source": "src/nu2api/nusound/nusound_weakptr.cpp",
-      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_weakptr.o",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_weakptr.o",
       "functions": [
+        {
+          "name": "_ZN14NuSoundWeakPtrI12NuSoundVoiceE3SetEPS0_",
+          "demangled_name": "NuSoundWeakPtr<NuSoundVoice>::Set(NuSoundVoice*)",
+          "address": 3232208,
+          "offset": 2342240,
+          "size": 331,
+          "match_percent": 58.613636
+        },
+        {
+          "name": "_ZN17NuSoundWeakPtrObjI21NuSoundBufferCallbackE4LinkEP22NuSoundWeakPtrListNode",
+          "demangled_name": "NuSoundWeakPtrObj<NuSoundBufferCallback>::Link(NuSoundWeakPtrListNode*)",
+          "address": 3232544,
+          "offset": 2342576,
+          "size": 201,
+          "match_percent": 53.13793
+        },
         {
           "name": "_ZN17NuCriticalSectionC1EPKc",
           "demangled_name": "NuCriticalSection::NuCriticalSection(char const*)",
@@ -114951,12 +115217,20 @@
           "match_percent": 99.95238
         },
         {
+          "name": "_ZN14NuSoundWeakPtrI21NuSoundBufferCallbackE3SetEPS0_",
+          "demangled_name": "NuSoundWeakPtr<NuSoundBufferCallback>::Set(NuSoundBufferCallback*)",
+          "address": 3276544,
+          "offset": 2386576,
+          "size": 331,
+          "match_percent": 61.579544
+        },
+        {
           "name": "_ZN17NuSoundWeakPtrObjI21NuSoundBufferCallbackED1Ev",
           "demangled_name": "NuSoundWeakPtrObj<NuSoundBufferCallback>::~NuSoundWeakPtrObj()",
           "address": 3320864,
           "offset": 2430896,
           "size": 469,
-          "match_percent": 17.964539
+          "match_percent": 41.765957
         },
         {
           "name": "_ZN17NuSoundWeakPtrObjI21NuSoundBufferCallbackED2Ev",
@@ -114964,7 +115238,15 @@
           "address": 3320864,
           "offset": 2430896,
           "size": 469,
-          "match_percent": 17.964539
+          "match_percent": 41.765957
+        },
+        {
+          "name": "_ZN17NuSoundWeakPtrObjI21NuSoundBufferCallbackED0Ev",
+          "demangled_name": "NuSoundWeakPtrObj<NuSoundBufferCallback>::~NuSoundWeakPtrObj()",
+          "address": 3321344,
+          "offset": 2431376,
+          "size": 56,
+          "match_percent": 99.92857
         }
       ]
     }
@@ -115292,6 +115574,7 @@
       "size": 34,
       "match_percent": 99.9,
       "candidate_units": [
+        "nu2api/nusound/nusound3_include.cpp.o",
         "nu2api/nusound/nusound_buffer.cpp.o",
         "nu2api/nusound/nusound_weakptr.cpp.o"
       ]
@@ -115304,6 +115587,7 @@
       "size": 34,
       "match_percent": 99.9,
       "candidate_units": [
+        "nu2api/nusound/nusound3_include.cpp.o",
         "nu2api/nusound/nusound_buffer.cpp.o",
         "nu2api/nusound/nusound_weakptr.cpp.o"
       ]
@@ -115508,6 +115792,18 @@
       ]
     },
     {
+      "name": "_ZL15NuErrorFunctionPcz",
+      "demangled_name": "NuErrorFunction(char*, ...)",
+      "address": 2546843,
+      "offset": 1656875,
+      "size": 197,
+      "match_percent": 8.4,
+      "candidate_units": [
+        "nu2api/nucore/nu2api_nucore_misc.cpp.o",
+        "nu2api/nucore/nuerror.cpp.o"
+      ]
+    },
+    {
       "name": "_Z41__static_initialization_and_destruction_0ii",
       "demangled_name": "__static_initialization_and_destruction_0(int, int)",
       "address": 2554226,
@@ -115621,7 +115917,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -115631,17 +115926,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -115758,7 +116043,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -115768,17 +116052,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -115895,7 +116169,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -115905,17 +116178,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -116043,7 +116306,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -116053,17 +116315,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -116075,11 +116327,13 @@
       "match_percent": 99.84615,
       "candidate_units": [
         "gameapi/ai/gameai_sockpar.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "legoapi/actions/movement/jumping.cpp.o",
         "legoapi/core/net/network.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
         "legoapi/props/system/socksysall.cpp.o",
         "legoapi/render/core/render_stubs.cpp.o",
+        "nu2api/nu3d/nurndr_specular.cpp.o",
         "nu2api/nucore/nupad.cpp.o",
         "nu2api/numath/nufloat.c.o",
         "nu2api/numath/numtx.cpp.o",
@@ -116215,7 +116469,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -116225,17 +116478,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -116363,7 +116606,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -116373,17 +116615,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -116511,7 +116743,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -116521,17 +116752,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -116659,7 +116880,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -116669,17 +116889,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -116807,7 +117017,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -116817,17 +117026,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -116955,7 +117154,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -116965,17 +117163,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -116999,11 +117187,13 @@
       "match_percent": 99.84615,
       "candidate_units": [
         "gameapi/ai/gameai_sockpar.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "legoapi/actions/movement/jumping.cpp.o",
         "legoapi/core/net/network.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
         "legoapi/props/system/socksysall.cpp.o",
         "legoapi/render/core/render_stubs.cpp.o",
+        "nu2api/nu3d/nurndr_specular.cpp.o",
         "nu2api/nucore/nupad.cpp.o",
         "nu2api/numath/nufloat.c.o",
         "nu2api/numath/numtx.cpp.o",
@@ -117023,11 +117213,13 @@
       "match_percent": 99.8125,
       "candidate_units": [
         "gameapi/ai/gameai_sockpar.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "legoapi/actions/movement/jumping.cpp.o",
         "legoapi/core/net/network.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
         "legoapi/props/system/socksysall.cpp.o",
         "legoapi/render/core/render_stubs.cpp.o",
+        "nu2api/nu3d/nurndr_specular.cpp.o",
         "nu2api/nucore/nupad.cpp.o",
         "nu2api/numath/nufloat.c.o",
         "nu2api/numath/numtx.cpp.o",
@@ -117163,7 +117355,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -117173,17 +117364,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -117311,7 +117492,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -117321,17 +117501,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -117459,7 +117629,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -117469,17 +117638,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -117488,9 +117647,10 @@
       "address": 2699624,
       "offset": 1809656,
       "size": 40,
-      "match_percent": 82.0,
+      "match_percent": 99.76923,
       "candidate_units": [
-        "nu2api/nu3d/android/nuiosdl_gl.cpp.o"
+        "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
+        "nu2api/nu3d/android/nuptl_flush.cpp.o"
       ]
     },
     {
@@ -117651,7 +117811,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -117661,17 +117820,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -117810,7 +117959,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -117820,17 +117968,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -117839,9 +117977,10 @@
       "address": 2714284,
       "offset": 1824316,
       "size": 40,
-      "match_percent": 0.0,
+      "match_percent": 99.76923,
       "candidate_units": [
-        "nu2api/nu3d/android/nuiosdl_gl.cpp.o"
+        "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
+        "nu2api/nu3d/android/nuptl_flush.cpp.o"
       ]
     },
     {
@@ -117864,6 +118003,7 @@
       "match_percent": 99.75,
       "candidate_units": [
         "gameapi/ai/aisys/gameai_actions.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "globals.cpp.o",
         "legoapi/actions/character/simpletons.cpp.o",
         "legoapi/actions/character/specialmoves.cpp.o",
@@ -118084,7 +118224,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -118094,17 +118233,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -118138,6 +118267,7 @@
       "match_percent": 99.75,
       "candidate_units": [
         "gameapi/ai/aisys/gameai_actions.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "globals.cpp.o",
         "legoapi/actions/character/simpletons.cpp.o",
         "legoapi/actions/character/specialmoves.cpp.o",
@@ -118313,7 +118443,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -118323,17 +118452,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -118356,6 +118475,7 @@
       "match_percent": 99.75,
       "candidate_units": [
         "gameapi/ai/aisys/gameai_actions.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "globals.cpp.o",
         "legoapi/actions/character/simpletons.cpp.o",
         "legoapi/actions/character/specialmoves.cpp.o",
@@ -118543,7 +118663,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -118553,17 +118672,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -118691,7 +118800,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -118701,17 +118809,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -118839,7 +118937,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -118849,17 +118946,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -118987,7 +119074,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -118997,17 +119083,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -119041,6 +119117,7 @@
       "match_percent": 99.75,
       "candidate_units": [
         "gameapi/ai/aisys/gameai_actions.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "globals.cpp.o",
         "legoapi/actions/character/simpletons.cpp.o",
         "legoapi/actions/character/specialmoves.cpp.o",
@@ -119194,7 +119271,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -119204,17 +119280,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -119342,7 +119408,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -119352,17 +119417,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -119501,7 +119556,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -119511,17 +119565,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -119649,7 +119693,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -119659,17 +119702,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -119680,7 +119713,8 @@
       "size": 40,
       "match_percent": 0.0,
       "candidate_units": [
-        "nu2api/nu3d/android/nuiosdl_gl.cpp.o"
+        "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
+        "nu2api/nu3d/android/nuptl_flush.cpp.o"
       ]
     },
     {
@@ -119808,7 +119842,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -119818,17 +119851,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -119956,7 +119979,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -119966,17 +119988,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -119988,11 +120000,13 @@
       "match_percent": 99.84615,
       "candidate_units": [
         "gameapi/ai/gameai_sockpar.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "legoapi/actions/movement/jumping.cpp.o",
         "legoapi/core/net/network.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
         "legoapi/props/system/socksysall.cpp.o",
         "legoapi/render/core/render_stubs.cpp.o",
+        "nu2api/nu3d/nurndr_specular.cpp.o",
         "nu2api/nucore/nupad.cpp.o",
         "nu2api/numath/nufloat.c.o",
         "nu2api/numath/numtx.cpp.o",
@@ -120128,7 +120142,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -120138,17 +120151,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -120276,7 +120279,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -120286,17 +120288,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -120424,7 +120416,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -120434,17 +120425,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -120572,7 +120553,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -120582,17 +120562,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -120654,18 +120624,6 @@
         "nu2api/nusound/nusound_decoder_ogg.cpp.o",
         "nu2api/nusound/nusound_streamer.cpp.o",
         "nu2api/nusound/nusound_voice.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o",
-        "nu2api/nusound/nusound_weakptr.cpp.o"
-      ]
-    },
-    {
-      "name": "_ZN17NuSoundWeakPtrObjI21NuSoundBufferCallbackE4LinkEP22NuSoundWeakPtrListNode",
-      "demangled_name": "NuSoundWeakPtrObj<NuSoundBufferCallback>::Link(NuSoundWeakPtrListNode*)",
-      "address": 3232544,
-      "offset": 2342576,
-      "size": 201,
-      "match_percent": 27.706896,
-      "candidate_units": [
         "nu2api/nusound/nusound_voice_android.cpp.o",
         "nu2api/nusound/nusound_weakptr.cpp.o"
       ]
@@ -120795,7 +120753,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -120805,17 +120762,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -120943,7 +120890,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -120953,17 +120899,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -121091,7 +121027,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -121101,17 +121036,398 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice10FileRenameEPKcS1_",
+      "demangled_name": "NuFileDevice::FileRename(char const*, char const*)",
+      "address": 3243984,
+      "offset": 2354016,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice11FileGetInfoEPKcP13nufile_info_s",
+      "demangled_name": "NuFileDevice::FileGetInfo(char const*, nufile_info_s*)",
+      "address": 3244000,
+      "offset": 2354032,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice10FileDeleteEPKc",
+      "demangled_name": "NuFileDevice::FileDelete(char const*)",
+      "address": 3244016,
+      "offset": 2354048,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice9FileTouchEPKc",
+      "demangled_name": "NuFileDevice::FileTouch(char const*)",
+      "address": 3244032,
+      "offset": 2354064,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice7DirOpenEPKc",
+      "demangled_name": "NuFileDevice::DirOpen(char const*)",
+      "address": 3244048,
+      "offset": 2354080,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice8DirCloseEi",
+      "demangled_name": "NuFileDevice::DirClose(int)",
+      "address": 3244064,
+      "offset": 2354096,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice9DirExistsEPKc",
+      "demangled_name": "NuFileDevice::DirExists(char const*)",
+      "address": 3244080,
+      "offset": 2354112,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice7DirReadEiP13nufile_info_s",
+      "demangled_name": "NuFileDevice::DirRead(int, nufile_info_s*)",
+      "address": 3244096,
+      "offset": 2354128,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice13DirCreatePathEPKc",
+      "demangled_name": "NuFileDevice::DirCreatePath(char const*)",
+      "address": 3244112,
+      "offset": 2354144,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice9DirRemoveEPKc",
+      "demangled_name": "NuFileDevice::DirRemove(char const*)",
+      "address": 3244128,
+      "offset": 2354160,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice18DirRemoveRecursiveEPKcb",
+      "demangled_name": "NuFileDevice::DirRemoveRecursive(char const*, bool)",
+      "address": 3244144,
+      "offset": 2354176,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN12NuFileDevice9DirRenameEPKcS1_",
+      "demangled_name": "NuFileDevice::DirRename(char const*, char const*)",
+      "address": 3244160,
+      "offset": 2354192,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZNK12NuFileDevice17GetPositionOnDiscEPKcRx",
+      "demangled_name": "NuFileDevice::GetPositionOnDisc(char const*, long long&) const",
+      "address": 3244176,
+      "offset": 2354208,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
+        "nu2api/nufile/nufiledevice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundEffect8ShutdownEv",
+      "demangled_name": "NuSoundEffect::Shutdown()",
+      "address": 3262368,
+      "offset": 2372400,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_effect.cpp.o",
         "nu2api/nusound/nusound_effect_doppler.cpp.o",
         "nu2api/nusound/nusound_effect_fader.cpp.o",
         "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundEffect6EnableEv",
+      "demangled_name": "NuSoundEffect::Enable()",
+      "address": 3262384,
+      "offset": 2372416,
+      "size": 13,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_effect.cpp.o",
+        "nu2api/nusound/nusound_effect_doppler.cpp.o",
+        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundEffect7DisableEv",
+      "demangled_name": "NuSoundEffect::Disable()",
+      "address": 3262400,
+      "offset": 2372432,
+      "size": 13,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_effect.cpp.o",
+        "nu2api/nusound/nusound_effect_doppler.cpp.o",
+        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundEffect11AttachVoiceEP12NuSoundVoice",
+      "demangled_name": "NuSoundEffect::AttachVoice(NuSoundVoice*)",
+      "address": 3262416,
+      "offset": 2372448,
+      "size": 12,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_effect.cpp.o",
+        "nu2api/nusound/nusound_effect_doppler.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundEffect11DetachVoiceEP12NuSoundVoice",
+      "demangled_name": "NuSoundEffect::DetachVoice(NuSoundVoice*)",
+      "address": 3262432,
+      "offset": 2372464,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_effect.cpp.o",
+        "nu2api/nusound/nusound_effect_doppler.cpp.o",
+        "nu2api/nusound/nusound_effect_fader.cpp.o",
+        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundEffect12ProcessVoiceEP12NuSoundVoicef",
+      "demangled_name": "NuSoundEffect::ProcessVoice(NuSoundVoice*, float)",
+      "address": 3262448,
+      "offset": 2372480,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_effect.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundEffect9AttachBusEP10NuSoundBus",
+      "demangled_name": "NuSoundEffect::AttachBus(NuSoundBus*)",
+      "address": 3262464,
+      "offset": 2372496,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_effect.cpp.o",
+        "nu2api/nusound/nusound_effect_doppler.cpp.o",
+        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundEffect9DetachBusEP10NuSoundBus",
+      "demangled_name": "NuSoundEffect::DetachBus(NuSoundBus*)",
+      "address": 3262480,
+      "offset": 2372512,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_effect.cpp.o",
+        "nu2api/nusound/nusound_effect_doppler.cpp.o",
+        "nu2api/nusound/nusound_effect_fader.cpp.o",
+        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundEffect10ProcessBusEP10NuSoundBusf",
+      "demangled_name": "NuSoundEffect::ProcessBus(NuSoundBus*, float)",
+      "address": 3262496,
+      "offset": 2372528,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_effect.cpp.o",
+        "nu2api/nusound/nusound_effect_doppler.cpp.o",
+        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundEffect7ProcessEf",
+      "demangled_name": "NuSoundEffect::Process(float)",
+      "address": 3262512,
+      "offset": 2372544,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_effect.cpp.o",
+        "nu2api/nusound/nusound_effect_doppler.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundSystem18IsUserPlayingMusicEv",
+      "demangled_name": "NuSoundSystem::IsUserPlayingMusic()",
+      "address": 3262528,
+      "offset": 2372560,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_android.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundSystem14PauseUserMusicEv",
+      "demangled_name": "NuSoundSystem::PauseUserMusic()",
+      "address": 3262544,
+      "offset": 2372576,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_android.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundSystem15ResumeUserMusicEv",
+      "demangled_name": "NuSoundSystem::ResumeUserMusic()",
+      "address": 3262560,
+      "offset": 2372592,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_android.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundSystem24TitleHasUserMusicControlEv",
+      "demangled_name": "NuSoundSystem::TitleHasUserMusicControl()",
+      "address": 3262576,
+      "offset": 2372608,
+      "size": 12,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_android.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundSystem17OnEnterSystemMenuEv",
+      "demangled_name": "NuSoundSystem::OnEnterSystemMenu()",
+      "address": 3262592,
+      "offset": 2372624,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_android.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundSystem16OnExitSystemMenuEv",
+      "demangled_name": "NuSoundSystem::OnExitSystemMenu()",
+      "address": 3262608,
+      "offset": 2372640,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_android.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN14NuSoundDecoder16GetEncodedSourceEv",
+      "demangled_name": "NuSoundDecoder::GetEncodedSource()",
+      "address": 3276432,
+      "offset": 2386464,
+      "size": 12,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_decoder.cpp.o",
+        "nu2api/nusound/nusound_decoder_ogg.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZNK14NuSoundDecoder7GetNameEv",
+      "demangled_name": "NuSoundDecoder::GetName() const",
+      "address": 3276448,
+      "offset": 2386480,
+      "size": 60,
+      "match_percent": 99.89474,
+      "candidate_units": [
+        "nu2api/nusound/nusound_decoder.cpp.o",
+        "nu2api/nusound/nusound_decoder_ogg.cpp.o"
       ]
     },
     {
@@ -121131,24 +121447,12 @@
       ]
     },
     {
-      "name": "_ZN14NuSoundWeakPtrI21NuSoundBufferCallbackE3SetEPS0_",
-      "demangled_name": "NuSoundWeakPtr<NuSoundBufferCallback>::Set(NuSoundBufferCallback*)",
-      "address": 3276544,
-      "offset": 2386576,
-      "size": 331,
-      "match_percent": 22.113636,
-      "candidate_units": [
-        "nu2api/nusound/nusound_voice_android.cpp.o",
-        "nu2api/nusound/nusound_weakptr.cpp.o"
-      ]
-    },
-    {
       "name": "_ZN14NuSoundWeakPtrI21NuSoundBufferCallbackED1Ev",
       "demangled_name": "NuSoundWeakPtr<NuSoundBufferCallback>::~NuSoundWeakPtr()",
       "address": 3276880,
       "offset": 2386912,
       "size": 202,
-      "match_percent": 77.929825,
+      "match_percent": 80.807014,
       "candidate_units": [
         "nu2api/nusound/nusound_decoder.cpp.o",
         "nu2api/nusound/nusound_decoder_ogg.cpp.o",
@@ -121164,7 +121468,7 @@
       "address": 3276880,
       "offset": 2386912,
       "size": 202,
-      "match_percent": 77.929825,
+      "match_percent": 80.807014,
       "candidate_units": [
         "nu2api/nusound/nusound_decoder.cpp.o",
         "nu2api/nusound/nusound_decoder_ogg.cpp.o",
@@ -121180,7 +121484,7 @@
       "address": 3277088,
       "offset": 2387120,
       "size": 210,
-      "match_percent": 78.67796,
+      "match_percent": 81.45763,
       "candidate_units": [
         "nu2api/nusound/nusound_decoder.cpp.o",
         "nu2api/nusound/nusound_decoder_ogg.cpp.o",
@@ -121191,12 +121495,62 @@
       ]
     },
     {
+      "name": "_ZN13NuSoundSource16GetEncodedSourceEv",
+      "demangled_name": "NuSoundSource::GetEncodedSource()",
+      "address": 3294880,
+      "offset": 2404912,
+      "size": 11,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_sample.cpp.o",
+        "nu2api/nusound/nusound_source.cpp.o",
+        "nu2api/nusound/nusound_streamer.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundSource16GetMaxBufferSizeEv",
+      "demangled_name": "NuSoundSource::GetMaxBufferSize()",
+      "address": 3294896,
+      "offset": 2404928,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_sample.cpp.o",
+        "nu2api/nusound/nusound_source.cpp.o",
+        "nu2api/nusound/nusound_streamer.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundSample10OpenStreamEb",
+      "demangled_name": "NuSoundSample::OpenStream(bool)",
+      "address": 3294944,
+      "offset": 2404976,
+      "size": 12,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_sample.cpp.o",
+        "nu2api/nusound/nusound_streamer.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZN13NuSoundSample11CloseStreamEv",
+      "demangled_name": "NuSoundSample::CloseStream()",
+      "address": 3294960,
+      "offset": 2404992,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_sample.cpp.o",
+        "nu2api/nusound/nusound_streamer.cpp.o"
+      ]
+    },
+    {
       "name": "_ZN21NuSoundBufferCallbackD1Ev",
       "demangled_name": "NuSoundBufferCallback::~NuSoundBufferCallback()",
       "address": 3321408,
       "offset": 2431440,
       "size": 45,
-      "match_percent": 40.23077,
+      "match_percent": 99.84615,
       "candidate_units": [
         "nu2api/nusound/nusound_decoder_ogg.cpp.o",
         "nu2api/nusound/nusound_voice.cpp.o"
@@ -121208,7 +121562,7 @@
       "address": 3321408,
       "offset": 2431440,
       "size": 45,
-      "match_percent": 40.23077,
+      "match_percent": 99.84615,
       "candidate_units": [
         "nu2api/nusound/nusound_decoder_ogg.cpp.o",
         "nu2api/nusound/nusound_voice.cpp.o"
@@ -121220,10 +121574,82 @@
       "address": 3321456,
       "offset": 2431488,
       "size": 67,
-      "match_percent": 46.52941,
+      "match_percent": 99.882355,
       "candidate_units": [
         "nu2api/nusound/nusound_decoder_ogg.cpp.o",
         "nu2api/nusound/nusound_voice.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZNK17NuSoundStreamDesc20GetEncodedDataFormatEv",
+      "demangled_name": "NuSoundStreamDesc::GetEncodedDataFormat() const",
+      "address": 3331056,
+      "offset": 2441088,
+      "size": 21,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_loader_wav.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZNK17NuSoundStreamDesc21GetDecodedLengthBytesEv",
+      "demangled_name": "NuSoundStreamDesc::GetDecodedLengthBytes() const",
+      "address": 3331088,
+      "offset": 2441120,
+      "size": 21,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_loader_wav.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZNK17NuSoundStreamDesc17GetInterleaveSizeEv",
+      "demangled_name": "NuSoundStreamDesc::GetInterleaveSize() const",
+      "address": 3331168,
+      "offset": 2441200,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_loader_wav.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZNK17NuSoundStreamDesc11GetFormatIDEv",
+      "demangled_name": "NuSoundStreamDesc::GetFormatID() const",
+      "address": 3331184,
+      "offset": 2441216,
+      "size": 12,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_loader_wav.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZNK17NuSoundStreamDesc19GetExtendedDataSizeEv",
+      "demangled_name": "NuSoundStreamDesc::GetExtendedDataSize() const",
+      "address": 3331200,
+      "offset": 2441232,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_loader_wav.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZNK17NuSoundStreamDesc15GetExtendedDataEv",
+      "demangled_name": "NuSoundStreamDesc::GetExtendedData() const",
+      "address": 3331216,
+      "offset": 2441248,
+      "size": 9,
+      "match_percent": 100.0,
+      "candidate_units": [
+        "nu2api/nusound/nusound_loader_wav.cpp.o",
+        "nu2api/nusound/nusound_system.cpp.o"
       ]
     },
     {
@@ -121235,11 +121661,13 @@
       "match_percent": 99.84615,
       "candidate_units": [
         "gameapi/ai/gameai_sockpar.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "legoapi/actions/movement/jumping.cpp.o",
         "legoapi/core/net/network.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
         "legoapi/props/system/socksysall.cpp.o",
         "legoapi/render/core/render_stubs.cpp.o",
+        "nu2api/nu3d/nurndr_specular.cpp.o",
         "nu2api/nucore/nupad.cpp.o",
         "nu2api/numath/nufloat.c.o",
         "nu2api/numath/numtx.cpp.o",
@@ -121408,7 +121836,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -121418,17 +121845,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -121440,11 +121857,13 @@
       "match_percent": 99.84615,
       "candidate_units": [
         "gameapi/ai/gameai_sockpar.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "legoapi/actions/movement/jumping.cpp.o",
         "legoapi/core/net/network.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
         "legoapi/props/system/socksysall.cpp.o",
         "legoapi/render/core/render_stubs.cpp.o",
+        "nu2api/nu3d/nurndr_specular.cpp.o",
         "nu2api/nucore/nupad.cpp.o",
         "nu2api/numath/nufloat.c.o",
         "nu2api/numath/numtx.cpp.o",
@@ -121464,11 +121883,13 @@
       "match_percent": 99.8125,
       "candidate_units": [
         "gameapi/ai/gameai_sockpar.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "legoapi/actions/movement/jumping.cpp.o",
         "legoapi/core/net/network.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
         "legoapi/props/system/socksysall.cpp.o",
         "legoapi/render/core/render_stubs.cpp.o",
+        "nu2api/nu3d/nurndr_specular.cpp.o",
         "nu2api/nucore/nupad.cpp.o",
         "nu2api/numath/nufloat.c.o",
         "nu2api/numath/numtx.cpp.o",
@@ -121664,7 +122085,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -121674,17 +122094,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -121696,11 +122106,13 @@
       "match_percent": 99.84615,
       "candidate_units": [
         "gameapi/ai/gameai_sockpar.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "legoapi/actions/movement/jumping.cpp.o",
         "legoapi/core/net/network.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
         "legoapi/props/system/socksysall.cpp.o",
         "legoapi/render/core/render_stubs.cpp.o",
+        "nu2api/nu3d/nurndr_specular.cpp.o",
         "nu2api/nucore/nupad.cpp.o",
         "nu2api/numath/nufloat.c.o",
         "nu2api/numath/numtx.cpp.o",
@@ -121720,11 +122132,13 @@
       "match_percent": 99.8125,
       "candidate_units": [
         "gameapi/ai/gameai_sockpar.cpp.o",
+        "gamelib/nuwind/nuwind_groups.cpp.o",
         "legoapi/actions/movement/jumping.cpp.o",
         "legoapi/core/net/network.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
         "legoapi/props/system/socksysall.cpp.o",
         "legoapi/render/core/render_stubs.cpp.o",
+        "nu2api/nu3d/nurndr_specular.cpp.o",
         "nu2api/nucore/nupad.cpp.o",
         "nu2api/numath/nufloat.c.o",
         "nu2api/numath/numtx.cpp.o",
@@ -121895,7 +122309,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -121905,17 +122318,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -122315,7 +122718,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -122325,17 +122727,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     },
     {
@@ -122463,7 +122855,6 @@
         "legoapi/render/fx/game_deb.cpp.o",
         "legoapi/render/fx/inflate.cpp.o",
         "legoapi/render/fx/parts_stubs.cpp.o",
-        "legoapi/render/light/occlusion.cpp.o",
         "legoapi/world/levels/new_town.cpp.o",
         "legoapi/world/levels/senate.cpp.o",
         "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
@@ -122473,17 +122864,7 @@
         "nu2api/nucore/android/nuapi_android.cpp.o",
         "nu2api/nuplatform/nudevicespecs.cpp.o",
         "nu2api/nusound/nu2api_nusound_misc.cpp.o",
-        "nu2api/nusound/nu2api_nusound_types.cpp.o",
-        "nu2api/nusound/nusound_android.cpp.o",
-        "nu2api/nusound/nusound_bus.cpp.o",
-        "nu2api/nusound/nusound_clock.cpp.o",
-        "nu2api/nusound/nusound_effect_doppler.cpp.o",
-        "nu2api/nusound/nusound_effect_fader.cpp.o",
-        "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
-        "nu2api/nusound/nusound_listener.cpp.o",
-        "nu2api/nusound/nusound_mixer.cpp.o",
-        "nu2api/nusound/nusound_routing.cpp.o",
-        "nu2api/nusound/nusound_voice_android.cpp.o"
+        "nu2api/nusound/nu2api_nusound_types.cpp.o"
       ]
     }
   ],
@@ -122542,14 +122923,6 @@
       "address": 892080,
       "offset": 2112,
       "size": 93,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_GLOBAL__sub_I_NuInputDevice_android.cpp",
-      "demangled_name": "_GLOBAL__sub_I_NuInputDevice_android.cpp",
-      "address": 892176,
-      "offset": 2208,
-      "size": 313,
       "match_percent": 0.0
     },
     {
@@ -123262,7 +123635,7 @@
       "address": 935392,
       "offset": 45424,
       "size": 11528,
-      "match_percent": 2.34726
+      "match_percent": 3.659931
     },
     {
       "name": "_ZN6squish19DecompressAlphaDxt5EPhPKv",
@@ -123942,14 +124315,6 @@
       "address": 2554628,
       "offset": 1664660,
       "size": 5,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN16NuFileAndroidAPK7GetFileEi",
-      "demangled_name": "NuFileAndroidAPK::GetFile(int)",
-      "address": 2554710,
-      "offset": 1664742,
-      "size": 35,
       "match_percent": 0.0
     },
     {
@@ -124881,14 +125246,6 @@
       "match_percent": 0.0
     },
     {
-      "name": "_ZN14NuSoundWeakPtrI12NuSoundVoiceE3SetEPS0_",
-      "demangled_name": "NuSoundWeakPtr<NuSoundVoice>::Set(NuSoundVoice*)",
-      "address": 3232208,
-      "offset": 2342240,
-      "size": 331,
-      "match_percent": 0.0
-    },
-    {
       "name": "_GLOBAL__sub_I_stubs_android.c",
       "demangled_name": "_GLOBAL__sub_I_stubs_android.c",
       "address": 3239160,
@@ -124910,430 +125267,6 @@
       "address": 3241427,
       "offset": 2351459,
       "size": 29,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice10FileRenameEPKcS1_",
-      "demangled_name": "NuFileDevice::FileRename(char const*, char const*)",
-      "address": 3243984,
-      "offset": 2354016,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice11FileGetInfoEPKcP13nufile_info_s",
-      "demangled_name": "NuFileDevice::FileGetInfo(char const*, nufile_info_s*)",
-      "address": 3244000,
-      "offset": 2354032,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice10FileDeleteEPKc",
-      "demangled_name": "NuFileDevice::FileDelete(char const*)",
-      "address": 3244016,
-      "offset": 2354048,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice9FileTouchEPKc",
-      "demangled_name": "NuFileDevice::FileTouch(char const*)",
-      "address": 3244032,
-      "offset": 2354064,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice7DirOpenEPKc",
-      "demangled_name": "NuFileDevice::DirOpen(char const*)",
-      "address": 3244048,
-      "offset": 2354080,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice8DirCloseEi",
-      "demangled_name": "NuFileDevice::DirClose(int)",
-      "address": 3244064,
-      "offset": 2354096,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice9DirExistsEPKc",
-      "demangled_name": "NuFileDevice::DirExists(char const*)",
-      "address": 3244080,
-      "offset": 2354112,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice7DirReadEiP13nufile_info_s",
-      "demangled_name": "NuFileDevice::DirRead(int, nufile_info_s*)",
-      "address": 3244096,
-      "offset": 2354128,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice13DirCreatePathEPKc",
-      "demangled_name": "NuFileDevice::DirCreatePath(char const*)",
-      "address": 3244112,
-      "offset": 2354144,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice9DirRemoveEPKc",
-      "demangled_name": "NuFileDevice::DirRemove(char const*)",
-      "address": 3244128,
-      "offset": 2354160,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice18DirRemoveRecursiveEPKcb",
-      "demangled_name": "NuFileDevice::DirRemoveRecursive(char const*, bool)",
-      "address": 3244144,
-      "offset": 2354176,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuFileDevice9DirRenameEPKcS1_",
-      "demangled_name": "NuFileDevice::DirRename(char const*, char const*)",
-      "address": 3244160,
-      "offset": 2354192,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZNK12NuFileDevice17GetPositionOnDiscEPKcRx",
-      "demangled_name": "NuFileDevice::GetPositionOnDisc(char const*, long long&) const",
-      "address": 3244176,
-      "offset": 2354208,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundEffect8ShutdownEv",
-      "demangled_name": "NuSoundEffect::Shutdown()",
-      "address": 3262368,
-      "offset": 2372400,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundEffect6EnableEv",
-      "demangled_name": "NuSoundEffect::Enable()",
-      "address": 3262384,
-      "offset": 2372416,
-      "size": 13,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundEffect7DisableEv",
-      "demangled_name": "NuSoundEffect::Disable()",
-      "address": 3262400,
-      "offset": 2372432,
-      "size": 13,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundEffect11AttachVoiceEP12NuSoundVoice",
-      "demangled_name": "NuSoundEffect::AttachVoice(NuSoundVoice*)",
-      "address": 3262416,
-      "offset": 2372448,
-      "size": 12,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundEffect11DetachVoiceEP12NuSoundVoice",
-      "demangled_name": "NuSoundEffect::DetachVoice(NuSoundVoice*)",
-      "address": 3262432,
-      "offset": 2372464,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundEffect12ProcessVoiceEP12NuSoundVoicef",
-      "demangled_name": "NuSoundEffect::ProcessVoice(NuSoundVoice*, float)",
-      "address": 3262448,
-      "offset": 2372480,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundEffect9AttachBusEP10NuSoundBus",
-      "demangled_name": "NuSoundEffect::AttachBus(NuSoundBus*)",
-      "address": 3262464,
-      "offset": 2372496,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundEffect9DetachBusEP10NuSoundBus",
-      "demangled_name": "NuSoundEffect::DetachBus(NuSoundBus*)",
-      "address": 3262480,
-      "offset": 2372512,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundEffect10ProcessBusEP10NuSoundBusf",
-      "demangled_name": "NuSoundEffect::ProcessBus(NuSoundBus*, float)",
-      "address": 3262496,
-      "offset": 2372528,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundEffect7ProcessEf",
-      "demangled_name": "NuSoundEffect::Process(float)",
-      "address": 3262512,
-      "offset": 2372544,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundSystem18IsUserPlayingMusicEv",
-      "demangled_name": "NuSoundSystem::IsUserPlayingMusic()",
-      "address": 3262528,
-      "offset": 2372560,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundSystem14PauseUserMusicEv",
-      "demangled_name": "NuSoundSystem::PauseUserMusic()",
-      "address": 3262544,
-      "offset": 2372576,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundSystem15ResumeUserMusicEv",
-      "demangled_name": "NuSoundSystem::ResumeUserMusic()",
-      "address": 3262560,
-      "offset": 2372592,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundSystem24TitleHasUserMusicControlEv",
-      "demangled_name": "NuSoundSystem::TitleHasUserMusicControl()",
-      "address": 3262576,
-      "offset": 2372608,
-      "size": 12,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundSystem17OnEnterSystemMenuEv",
-      "demangled_name": "NuSoundSystem::OnEnterSystemMenu()",
-      "address": 3262592,
-      "offset": 2372624,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundSystem16OnExitSystemMenuEv",
-      "demangled_name": "NuSoundSystem::OnExitSystemMenu()",
-      "address": 3262608,
-      "offset": 2372640,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN24NuSoundEffectAttenuation9AttachBusEP10NuSoundBus",
-      "demangled_name": "NuSoundEffectAttenuation::AttachBus(NuSoundBus*)",
-      "address": 3262624,
-      "offset": 2372656,
-      "size": 12,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN22NuSoundSystemCallbacks11ReleasePageEP15NuMemoryManagerPvj",
-      "demangled_name": "NuSoundSystemCallbacks::ReleasePage(NuMemoryManager*, void*, unsigned int)",
-      "address": 3262640,
-      "offset": 2372672,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN24NuSoundEffectAttenuationD1Ev",
-      "demangled_name": "NuSoundEffectAttenuation::~NuSoundEffectAttenuation()",
-      "address": 3262656,
-      "offset": 2372688,
-      "size": 45,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN24NuSoundEffectAttenuationD2Ev",
-      "demangled_name": "NuSoundEffectAttenuation::~NuSoundEffectAttenuation()",
-      "address": 3262656,
-      "offset": 2372688,
-      "size": 45,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN18NuSoundEffectPitchD1Ev",
-      "demangled_name": "NuSoundEffectPitch::~NuSoundEffectPitch()",
-      "address": 3262704,
-      "offset": 2372736,
-      "size": 45,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN18NuSoundEffectPitchD2Ev",
-      "demangled_name": "NuSoundEffectPitch::~NuSoundEffectPitch()",
-      "address": 3262704,
-      "offset": 2372736,
-      "size": 45,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN25NuSoundEffectRandomVolumeD1Ev",
-      "demangled_name": "NuSoundEffectRandomVolume::~NuSoundEffectRandomVolume()",
-      "address": 3262752,
-      "offset": 2372784,
-      "size": 45,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN25NuSoundEffectRandomVolumeD2Ev",
-      "demangled_name": "NuSoundEffectRandomVolume::~NuSoundEffectRandomVolume()",
-      "address": 3262752,
-      "offset": 2372784,
-      "size": 45,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN24NuSoundEffectRandomPitchD1Ev",
-      "demangled_name": "NuSoundEffectRandomPitch::~NuSoundEffectRandomPitch()",
-      "address": 3262800,
-      "offset": 2372832,
-      "size": 45,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN24NuSoundEffectRandomPitchD2Ev",
-      "demangled_name": "NuSoundEffectRandomPitch::~NuSoundEffectRandomPitch()",
-      "address": 3262800,
-      "offset": 2372832,
-      "size": 45,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN19NuSoundEffectRepeatD1Ev",
-      "demangled_name": "NuSoundEffectRepeat::~NuSoundEffectRepeat()",
-      "address": 3262848,
-      "offset": 2372880,
-      "size": 45,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN19NuSoundEffectRepeatD2Ev",
-      "demangled_name": "NuSoundEffectRepeat::~NuSoundEffectRepeat()",
-      "address": 3262848,
-      "offset": 2372880,
-      "size": 45,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN22NuSoundSystemCallbacks4DumpEP15NuMemoryManagerjPKc",
-      "demangled_name": "NuSoundSystemCallbacks::Dump(NuMemoryManager*, unsigned int, char const*)",
-      "address": 3262896,
-      "offset": 2372928,
-      "size": 68,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN22NuSoundSystemCallbacks9CloseDumpEP15NuMemoryManagerj",
-      "demangled_name": "NuSoundSystemCallbacks::CloseDump(NuMemoryManager*, unsigned int)",
-      "address": 3262976,
-      "offset": 2373008,
-      "size": 34,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN22NuSoundSystemCallbacks8OpenDumpEP15NuMemoryManagerPKcRj",
-      "demangled_name": "NuSoundSystemCallbacks::OpenDump(NuMemoryManager*, char const*, unsigned int&)",
-      "address": 3263024,
-      "offset": 2373056,
-      "size": 53,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN22NuSoundSystemCallbacks12AllocatePageEP15NuMemoryManagerjj",
-      "demangled_name": "NuSoundSystemCallbacks::AllocatePage(NuMemoryManager*, unsigned int, unsigned int)",
-      "address": 3263088,
-      "offset": 2373120,
-      "size": 92,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN19NuSoundEffectRepeat12ProcessVoiceEP12NuSoundVoicef",
-      "demangled_name": "NuSoundEffectRepeat::ProcessVoice(NuSoundVoice*, float)",
-      "address": 3263184,
-      "offset": 2373216,
-      "size": 214,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN24NuSoundEffectAttenuation12ProcessVoiceEP12NuSoundVoicef",
-      "demangled_name": "NuSoundEffectAttenuation::ProcessVoice(NuSoundVoice*, float)",
-      "address": 3263408,
-      "offset": 2373440,
-      "size": 143,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN19NuSoundEffectRepeatD0Ev",
-      "demangled_name": "NuSoundEffectRepeat::~NuSoundEffectRepeat()",
-      "address": 3263552,
-      "offset": 2373584,
-      "size": 92,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN24NuSoundEffectRandomPitchD0Ev",
-      "demangled_name": "NuSoundEffectRandomPitch::~NuSoundEffectRandomPitch()",
-      "address": 3263648,
-      "offset": 2373680,
-      "size": 92,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN25NuSoundEffectRandomVolumeD0Ev",
-      "demangled_name": "NuSoundEffectRandomVolume::~NuSoundEffectRandomVolume()",
-      "address": 3263744,
-      "offset": 2373776,
-      "size": 92,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN18NuSoundEffectPitchD0Ev",
-      "demangled_name": "NuSoundEffectPitch::~NuSoundEffectPitch()",
-      "address": 3263840,
-      "offset": 2373872,
-      "size": 92,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN24NuSoundEffectAttenuationD0Ev",
-      "demangled_name": "NuSoundEffectAttenuation::~NuSoundEffectAttenuation()",
-      "address": 3263936,
-      "offset": 2373968,
-      "size": 92,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundMemory14PushNuListNodeIP13NuSoundEffectEEvR6NuListIT_ERKS4_",
-      "demangled_name": "void NuSoundMemory::PushNuListNode<NuSoundEffect*>(NuList<NuSoundEffect*>&, NuSoundEffect* const&)",
-      "address": 3264032,
-      "offset": 2374064,
-      "size": 193,
       "match_percent": 0.0
     },
     {
@@ -125381,126 +125314,6 @@
       "demangled_name": "NuSoundClock::Callback::OnCallback(unsigned long long, unsigned long long)",
       "address": 3271088,
       "offset": 2381120,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN14NuSoundDecoder16GetEncodedSourceEv",
-      "demangled_name": "NuSoundDecoder::GetEncodedSource()",
-      "address": 3276432,
-      "offset": 2386464,
-      "size": 12,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZNK14NuSoundDecoder7GetNameEv",
-      "demangled_name": "NuSoundDecoder::GetName() const",
-      "address": 3276448,
-      "offset": 2386480,
-      "size": 60,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundSource16GetEncodedSourceEv",
-      "demangled_name": "NuSoundSource::GetEncodedSource()",
-      "address": 3294880,
-      "offset": 2404912,
-      "size": 11,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundSource16GetMaxBufferSizeEv",
-      "demangled_name": "NuSoundSource::GetMaxBufferSize()",
-      "address": 3294896,
-      "offset": 2404928,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundSample10OpenStreamEb",
-      "demangled_name": "NuSoundSample::OpenStream(bool)",
-      "address": 3294944,
-      "offset": 2404976,
-      "size": 12,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN13NuSoundSample11CloseStreamEv",
-      "demangled_name": "NuSoundSample::CloseStream()",
-      "address": 3294960,
-      "offset": 2404992,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZNK22NuSoundStreamingSample12IsStreamOpenEv",
-      "demangled_name": "NuSoundStreamingSample::IsStreamOpen() const",
-      "address": 3305232,
-      "offset": 2415264,
-      "size": 40,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN12NuSoundVoice19UpdateHardwareVoiceEf",
-      "demangled_name": "NuSoundVoice::UpdateHardwareVoice(float)",
-      "address": 3320848,
-      "offset": 2430880,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZN17NuSoundWeakPtrObjI21NuSoundBufferCallbackED0Ev",
-      "demangled_name": "NuSoundWeakPtrObj<NuSoundBufferCallback>::~NuSoundWeakPtrObj()",
-      "address": 3321344,
-      "offset": 2431376,
-      "size": 56,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZNK17NuSoundStreamDesc20GetEncodedDataFormatEv",
-      "demangled_name": "NuSoundStreamDesc::GetEncodedDataFormat() const",
-      "address": 3331056,
-      "offset": 2441088,
-      "size": 21,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZNK17NuSoundStreamDesc21GetDecodedLengthBytesEv",
-      "demangled_name": "NuSoundStreamDesc::GetDecodedLengthBytes() const",
-      "address": 3331088,
-      "offset": 2441120,
-      "size": 21,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZNK17NuSoundStreamDesc17GetInterleaveSizeEv",
-      "demangled_name": "NuSoundStreamDesc::GetInterleaveSize() const",
-      "address": 3331168,
-      "offset": 2441200,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZNK17NuSoundStreamDesc11GetFormatIDEv",
-      "demangled_name": "NuSoundStreamDesc::GetFormatID() const",
-      "address": 3331184,
-      "offset": 2441216,
-      "size": 12,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZNK17NuSoundStreamDesc19GetExtendedDataSizeEv",
-      "demangled_name": "NuSoundStreamDesc::GetExtendedDataSize() const",
-      "address": 3331200,
-      "offset": 2441232,
-      "size": 9,
-      "match_percent": 0.0
-    },
-    {
-      "name": "_ZNK17NuSoundStreamDesc15GetExtendedDataEv",
-      "demangled_name": "NuSoundStreamDesc::GetExtendedData() const",
-      "address": 3331216,
-      "offset": 2441248,
       "size": 9,
       "match_percent": 0.0
     },
@@ -131310,7 +131123,7 @@
       "address": 5637416,
       "offset": 4747448,
       "size": 315,
-      "match_percent": 0.0
+      "match_percent": 100.0
     },
     {
       "name": "emutls_init",
@@ -131346,10 +131159,10 @@
     }
   ],
   "summary": {
-    "bazel_units": 497,
+    "bazel_units": 502,
     "functions": 13454,
-    "assigned_functions": 12144,
-    "ambiguous_functions": 203,
-    "unassigned_functions": 1107
+    "assigned_functions": 12175,
+    "ambiguous_functions": 243,
+    "unassigned_functions": 1036
   }
 }

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -48,6 +48,7 @@ _ENGINE_SRCS = _ENGINE_ROOT_SRCS + glob(
 
 _HOST_EXCLUDES = [
     "java/android.cpp",
+    "nu2api/nu3d/android/gles_extensions.cpp",
     "nu2api/nucore/android/NuInputDevice_android.cpp",
     "nu2api/nucore/nunew.cpp",
 ]
@@ -62,6 +63,7 @@ _HOST_COMMON_SRCS = [source for source in _ENGINE_SRCS if source not in _HOST_EX
     "host/platform/android_assets.cpp",
     "host/platform/documents.cpp",
     "host/platform/egl.cpp",
+    "host/platform/gles_extensions.cpp",
     "host/platform/free_camera.cpp",
     "host/platform/free_camera_culling.cpp",
     "host/platform/input.cpp",
@@ -216,7 +218,7 @@ _NATIVE_COMPONENTS = saga_component_libraries(
     engine_dirs = _ENGINE_DIRS,
     headers = _PUBLIC_HEADERS,
     name_prefix = "saga_native",
-    root_sources = _ENGINE_ROOT_SRCS,
+    root_sources = [source for source in _ENGINE_ROOT_SRCS if source not in _HOST_EXCLUDES] + ["java/jni_stub.cpp"],
     sources = _HOST_COMMON_SRCS,
     textual_headers = _TEXTUAL_HEADERS,
     deps = _HOST_PLATFORM_DEPS,

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -36,7 +36,8 @@ _ENGINE_DIRS = [
 _ENGINE_ROOT_SRCS = [
     "batman.cpp",
     "globals.cpp",
-    "java/jni_stub.cpp",
+    "java/android.cpp",
+    "java/android_state.cpp",
 ]
 
 _ENGINE_SRCS = _ENGINE_ROOT_SRCS + glob(
@@ -46,16 +47,19 @@ _ENGINE_SRCS = _ENGINE_ROOT_SRCS + glob(
 )
 
 _HOST_EXCLUDES = [
+    "java/android.cpp",
     "nu2api/nucore/android/NuInputDevice_android.cpp",
     "nu2api/nucore/nunew.cpp",
 ]
 
 _HOST_COMMON_SRCS = [source for source in _ENGINE_SRCS if source not in _HOST_EXCLUDES] + [
+    "java/jni_stub.cpp",
     "host/harness/audio.cpp",
     "host/harness/load.cpp",
     "host/harness/main.cpp",
     "host/harness/window.cpp",
     "host/platform/compressed_texture.cpp",
+    "host/platform/android_assets.cpp",
     "host/platform/documents.cpp",
     "host/platform/egl.cpp",
     "host/platform/free_camera.cpp",
@@ -150,9 +154,12 @@ clang_tidy_android_check(
 cc_binary(
     name = "libTTapp.so",
     linkopts = [
-        "-lGLESv2",
-        "-lEGL",
+        "-Wl,--no-undefined",
+        "-llog",
+        "-landroid",
         "-lOpenSLES",
+        "-lEGL",
+        "-lGLESv2",
         "-lstdc++",
     ],
     linkshared = True,

--- a/src/gamelib/nuwind/nuwind.h
+++ b/src/gamelib/nuwind/nuwind.h
@@ -1,6 +1,34 @@
 #pragma once
 
 #include "nu2api/numath/nuvec4.h"
+#include "decomp.h"
+
+struct NuWindGType {
+    u16 in_use;
+    u16 flags;
+    u32 unknown_0x04;
+    u32 unknown_0x08;
+    NUMTX *matrices;
+    NUVEC center;
+    u8 drawn;
+    u8 visible;
+    i16 matrix_count;
+    f32 unknown_0x20;
+    f32 unknown_0x24;
+    f32 radius_squared;
+    f32 radius;
+    f32 near_distance;
+    f32 far_distance;
+    f32 extended_radius_squared;
+    f32 distance_range;
+    f32 unknown_0x40;
+    f32 unknown_0x44;
+    f32 unknown_0x48;
+};
+
+DECOMP_ASSERT(sizeof(NuWindGType) == 0x4c, "wind group size");
+DECOMP_ASSERT(__builtin_offsetof(NuWindGType, matrices) == 0x0c, "wind matrices offset");
+DECOMP_ASSERT(__builtin_offsetof(NuWindGType, matrix_count) == 0x1e, "wind matrix count offset");
 
 typedef struct nuwind_s {
     i32 unk0[8];

--- a/src/gamelib/nuwind/nuwind_groups.cpp
+++ b/src/gamelib/nuwind/nuwind_groups.cpp
@@ -1,0 +1,282 @@
+#include "gamelib/nuwind/nuwind.h"
+#include "nu2api/numath/nufloat.h"
+#include "nu2api/numath/nutrig.h"
+#include "nu2api/nu3d/nucamera.h"
+#include "nu2api/nu3d/nuspecial.h"
+
+// The legacy wind-group routines have unoptimized code in the reference.
+extern "C" {
+struct NuPlainSpecialHandleLayout {
+    NUGSCN *scene;
+    void *special;
+    void *display_special;
+};
+extern "C++" NuWindGType *NuWindAllocateGrp();
+extern "C++" void NuWindFreeGrp(NuWindGType *);
+void NuWindUpdateArray(NUVEC **);
+    static i32 maxwindmats;
+    static i32 maxgroups;
+    NuWindGType *NuWindGroup;
+    NuWindGType *NuWindCurGrp;
+    i32 NuWindWave;
+    i32 NuWindDir;
+    i32 NuWindDir2;
+    u32 NuWindQS = 0x1365;
+
+    NuWindGType *NuWindCreateMtx(u32 *source, NUMTX *matrices, i16 count,
+                               f32 value20, f32 value24, i32 flags,
+                               f32 near_distance, f32 far_distance) {
+        NuWindGType *group = NuWindAllocateGrp();
+        NUMTX *matrix = matrices;
+        if (group == NULL || matrix == NULL) {
+            NuWindFreeGrp(group);
+            return NULL;
+        }
+        group->matrices = matrices;
+        group->unknown_0x04 = source[0];
+        group->unknown_0x08 = source[2];
+        group->matrix_count = count;
+        group->unknown_0x20 = value20;
+        group->unknown_0x24 = value24;
+        group->flags = flags;
+        group->near_distance = near_distance;
+        group->far_distance = far_distance;
+        group->extended_radius_squared = far_distance * far_distance;
+        group->distance_range = group->far_distance - group->near_distance;
+        group->unknown_0x48 = 0.2f;
+        group->unknown_0x40 = 0.025f;
+        group->unknown_0x44 = 0.0006250000442378223f;
+        f32 min_x, min_y, min_z, max_x, max_y, max_z;
+        min_x = min_y = min_z = 10000000.0f;
+        max_x = max_y = max_z = -10000000.0f;
+        for (i32 index = 0; index < count; ++index, ++matrix) {
+            if (min_x > matrix->m30) min_x = matrix->m30;
+            if (min_y > matrix->m31) min_y = matrix->m31;
+            if (min_z > matrix->m32) min_z = matrix->m32;
+            if (matrix->m30 > max_x) max_x = matrix->m30;
+            if (matrix->m31 > max_y) max_y = matrix->m31;
+            if (matrix->m32 > max_z) max_z = matrix->m32;
+        }
+        group->center.x = 0.5f * (max_x + min_x);
+        group->center.y = 0.5f * (max_y + min_y);
+        group->center.z = 0.5f * (max_z + min_z);
+        group->radius_squared = 1.5f +
+            ((0.5f * (max_x - min_x)) * ((max_x - min_x) * 0.5f) +
+             ((max_y - min_y) * 0.5f) * (0.5f * (max_y - min_y)) +
+             ((max_z - min_z) * 0.5f) * (0.5f * (max_z - min_z)));
+        group->extended_radius_squared += group->radius_squared;
+        group->radius = NuFsqrt(group->radius_squared);
+        return group;
+    }
+
+    void NuWindDraw(void) {
+        NuPlainSpecialHandleLayout special;
+        special.special = NULL;
+        NuWindGType *group = NuWindGroup;
+        for (i32 index = 0; index < maxgroups; ++index, ++group) {
+            if (group->in_use == 0 || group->visible == 0) continue;
+            NuWindCurGrp = group;
+            group->drawn = 0;
+            NUMTX *matrix = group->matrices;
+            f32 near_squared = group->near_distance * group->near_distance;
+            f32 far_squared = group->far_distance * group->far_distance;
+            for (i32 instance = 0; instance < group->matrix_count; ++instance, ++matrix) {
+                f32 saved_m23 = matrix->m23;
+                f32 saved_m33 = matrix->m33;
+                matrix->m33 = 1.0f;
+                f32 dx = matrix->m30 - global_camera.mtx.m30;
+                f32 dy = matrix->m31 - global_camera.mtx.m31;
+                f32 dz = matrix->m32 - global_camera.mtx.m32;
+                f32 distance_squared = dx * dx + dy * dy + dz * dz;
+                if (far_squared > distance_squared) {
+                    matrix->m23 = near_squared > distance_squared ? 0.0f : 1.0e-11f;
+                    special.scene = reinterpret_cast<NUGSCN *>((usize)group->unknown_0x04);
+                    special.display_special = reinterpret_cast<void *>((usize)group->unknown_0x08);
+                    if (NuSpecialDrawAt(&special, matrix) != 0) group->drawn = 1;
+                }
+                matrix->m23 = saved_m23;
+                matrix->m33 = saved_m33;
+            }
+        }
+    }
+
+    void NuWindInit(void) {
+        NuWindWave = 0;
+        NuWindDir = 0;
+        NuWindDir2 = 0;
+        for (i32 index = 0; index < maxgroups; ++index) {
+            NuWindGroup[index].in_use = 0;
+        }
+    }
+
+    u32 NuWindRand(void) {
+        NuWindQS = (NuWindQS * 0x24cd + 1) & 0xffff;
+        return NuWindQS;
+    }
+
+    extern "C++" NuWindGType *NuWindAllocateGrp() {
+        for (i32 index = 0; index < maxgroups; ++index) {
+            if (NuWindGroup[index].in_use == 0) {
+                NuWindGroup[index].in_use = 1;
+                return &NuWindGroup[index];
+            }
+        }
+        return NULL;
+    }
+
+    void NuWindSetup(VARIPTR *buffer, VARIPTR buffer_end, i32 matrix_count, i32 group_count) {
+        maxwindmats = matrix_count;
+        maxgroups = group_count;
+        buffer->addr = (buffer->addr + 15) & ~(usize)15;
+        NuWindGroup = static_cast<NuWindGType *>(buffer->void_ptr);
+        buffer->addr += group_count * sizeof(NuWindGType);
+    }
+
+    void NuWindUpdate(NUVEC *wind) {
+        NUVEC *winds[8];
+        for (i32 index = 1; index <= 7; ++index) {
+            winds[index] = NULL;
+        }
+        winds[0] = wind;
+        NuWindUpdateArray(winds);
+    }
+
+    void NuWindUpdateArray(NUVEC **positions) {
+        NuWindGType *group = NuWindGroup;
+        NuWindDir2 = (i32)((u32)NuWindDir2 + 501);
+        NuWindWave = (i32)((u32)NuWindWave + 133);
+        NuWindDir = (i32)((u32)NuWindDir + 377);
+        f32 wind_x = NU_SIN_LUT((i32)(16384.0f + NU_SIN_LUT(NuWindWave) * 8192.0f)) * 0.75f +
+                     NU_SIN_LUT((i32)((u32)NuWindDir + 0x4000)) * 0.15f;
+        f32 wind_z = NU_SIN_LUT((i32)(NU_SIN_LUT(NuWindWave) * 8192.0f)) * 0.75f -
+                     NU_SIN_LUT(NuWindDir) * 0.15f;
+        i32 any_interaction = 0;
+        i32 nearby[8];
+        for (i32 index = 0; index < maxgroups; ++index, ++group) {
+            if (group->in_use == 0) continue;
+            f32 dx = group->center.x - global_camera.mtx.m30;
+            f32 dy = group->center.y - global_camera.mtx.m31;
+            f32 dz = group->center.z - global_camera.mtx.m32;
+            f32 distance_squared = dz * dz + (dx * dx + dy * dy);
+            if (group->extended_radius_squared > distance_squared) {
+                group->visible = 1;
+                if (group->drawn == 0 || !(group->unknown_0x20 > 0.0f)) continue;
+                if (group->flags != 0) {
+                    for (i32 object = 0; object < 8; ++object) {
+                        if (positions[object] == NULL) {
+                            nearby[object] = 0;
+                            continue;
+                        }
+                        f32 x = group->center.x - positions[object]->x;
+                        f32 y = group->center.y - positions[object]->y;
+                        f32 z = group->center.z - positions[object]->z;
+                        if (group->radius_squared > z * z + (x * x + y * y)) {
+                            nearby[object] = 1;
+                            any_interaction = 1;
+                        } else {
+                            nearby[object] = 0;
+                        }
+                    }
+                }
+                NUMTX *matrix = group->matrices;
+                for (i32 instance = 0; instance < group->matrix_count; ++instance, ++matrix) {
+                    i32 closest = -1;
+                    f32 contact_radius = 0.0f;
+                    f32 contact_height = 0.0f;
+                    f32 contact_x = 0.0f;
+                    f32 contact_z = 0.0f;
+                    f32 contact_squared = 0.0f;
+                    bool interacting = group->flags != 0 && any_interaction != 0;
+                    if (interacting) {
+                        f32 closest_squared = 1000000.0f;
+                        for (i32 object = 0; object < 8; ++object) {
+                            if (positions[object] == NULL) continue;
+                            f32 x = matrix->m30 - positions[object]->x;
+                            f32 z = matrix->m32 - positions[object]->z;
+                            f32 squared = x * x + z * z;
+                            if (closest_squared > squared) {
+                                closest_squared = squared;
+                                closest = object;
+                            }
+                        }
+                        if (closest == -1) break;
+                        f32 height = positions[closest]->y - matrix->m31;
+                        if (height > (group->unknown_0x24 * matrix->m33) / group->unknown_0x20) {
+                            contact_radius = 0.0f;
+                            contact_height = (matrix->m33 * 0.2f) / group->unknown_0x20;
+                        } else {
+                            contact_radius = 0.45f;
+                            if (0.0f > height) {
+                                contact_height = (matrix->m33 * 0.2f) / group->unknown_0x20;
+                            } else {
+                                contact_height = (matrix->m33 * (height * 0.5f + 0.2f)) / group->unknown_0x20;
+                            }
+                        }
+                        matrix->m10 *= matrix->m23;
+                        matrix->m12 *= matrix->m23;
+                        contact_x = (matrix->m30 + matrix->m10 * contact_height) - positions[closest]->x;
+                        contact_z = (matrix->m32 + matrix->m12 * contact_height) - positions[closest]->z;
+                        contact_squared = contact_x * contact_x + contact_z * contact_z;
+                    }
+                    f32 phase = (f32)NuWindDir2 + (matrix->m30 + matrix->m32) * 8192.0f;
+                    f32 target_x = matrix->m33 * wind_x * (NU_SIN_LUT((i32)phase) * 0.5f + 1.0f);
+                    f32 target_z = matrix->m33 * wind_z *
+                        (NU_SIN_LUT((i32)(16384.0f + phase)) * 0.5f + 1.0f);
+                    if (!interacting) {
+                        matrix->m10 += (target_x - matrix->m10) * 0.2f;
+                        matrix->m12 += (target_z - matrix->m12) * 0.2f;
+                    } else if (contact_squared >= contact_radius * contact_radius) {
+                        f32 x = 0.2f * (target_x - matrix->m10);
+                        f32 z = 0.2f * (target_z - matrix->m12);
+                        f32 squared = x * x + z * z;
+                        if (squared > 0.000144f) {
+                            f32 scale = 0.012f / NuFsqrt(squared);
+                            x *= scale;
+                            z *= scale;
+                        }
+                        matrix->m10 += x;
+                        matrix->m12 += z;
+                    } else {
+                        if (contact_squared == 0.0f) {
+                            contact_x = contact_radius;
+                            contact_z = 0.0f;
+                        } else {
+                            f32 scale = contact_radius / NuFsqrt(contact_squared);
+                            contact_x *= scale;
+                            contact_z *= scale;
+                        }
+                        contact_x = (0.3f * ((positions[closest]->x + contact_x) - matrix->m30)) / contact_height;
+                        contact_z = (0.3f * ((positions[closest]->z + contact_z) - matrix->m32)) / contact_height;
+                        f32 squared = contact_x * contact_x + contact_z * contact_z;
+                        if (squared > 0.25f) {
+                            f32 scale = 0.5f / NuFsqrt(squared);
+                            contact_x *= scale;
+                            contact_z *= scale;
+                        }
+                        contact_x = group->unknown_0x48 * (contact_x - matrix->m10);
+                        contact_z = group->unknown_0x48 * (contact_z - matrix->m12);
+                        squared = contact_x * contact_x + contact_z * contact_z;
+                        if (squared > group->unknown_0x44) {
+                            f32 scale = group->unknown_0x40 / NuFsqrt(squared);
+                            contact_x *= scale;
+                            contact_z *= scale;
+                        }
+                        matrix->m10 += contact_x;
+                        matrix->m12 += contact_z;
+                        matrix->m10 += (target_x - matrix->m10) * 0.05f;
+                        matrix->m12 += (target_z - matrix->m12) * 0.05f;
+                    }
+                    f32 scale = 1.0f - NuFsqrt(matrix->m10 * matrix->m10 + matrix->m12 * matrix->m12) * 0.35f;
+                    if (0.05f > scale) scale = 0.05f;
+                    matrix->m10 *= scale;
+                    matrix->m12 *= scale;
+                    matrix->m23 = 1.0f / scale;
+                    if (0.19f > scale) scale = 0.19f;
+                    matrix->m11 = (matrix->m33 / group->unknown_0x20) * scale;
+                }
+            } else {
+                group->visible = 0;
+            }
+        }
+    }
+}

--- a/src/gamelib/util/AndroidOBBUtils.cpp
+++ b/src/gamelib/util/AndroidOBBUtils.cpp
@@ -1,10 +1,110 @@
 #include "gamelib_util_types.h"
 
+#include <stdio.h>
+#include <string.h>
+
+#include "nu2api/nucore/nustring.h"
+#include "nu2api/nufile/nufile.h"
+
+#include "java/asset_manager.h"
+#include "java/android.h"
+
+char AndroidOBBUtils::ms_packageName[3][512];
+bool AndroidOBBUtils::ms_initializedPackage[3];
+bool AndroidOBBUtils::ms_initializedPackageIsAsset[3];
+
 void AndroidOBBUtils::InitPackagePaths() {
+    memset(ms_initializedPackage, 0, sizeof(ms_initializedPackage));
+    LookupPackagePath(NULL, NuFileDeviceAndroidOBBType::MAIN);
+    LookupPackagePath(NULL, NuFileDeviceAndroidOBBType::PATCH);
 }
 
-void AndroidOBBUtils::LookupPackagePath(char *, NuFileDeviceAndroidOBBType::T) {
+i32 AndroidOBBUtils::LookupPackagePath(char *output, NuFileDeviceAndroidOBBType::T type) {
+    char directory[512];
+    char filename[512];
+    if (output != NULL) {
+        output[0] = '\0';
+    }
+    i32 prefix_length = NuStrIStr(g_externalDataPath, "Android/Data") + 8 - g_externalDataPath;
+    if ((type == NuFileDeviceAndroidOBBType::MAIN && g_obbMainSize > 0) ||
+        (type != NuFileDeviceAndroidOBBType::MAIN && g_obbPatchSize > 0)) {
+        directory[0] = '\0';
+        sprintf(filename, "%s%s.%04d.0000.%s", directory,
+                type == NuFileDeviceAndroidOBBType::MAIN ? "main" : "patch",
+                type == NuFileDeviceAndroidOBBType::MAIN ? g_obbMainVersion : g_obbPatchVersion, "jpg");
+        AAsset *asset = AAssetManager_open(g_assetManager, filename, AASSET_MODE_UNKNOWN);
+        if (asset != NULL) {
+            AAsset_close(asset);
+            strcpy(ms_packageName[type], filename);
+            ms_initializedPackage[type] = true;
+            ms_initializedPackageIsAsset[type] = true;
+            if (output != NULL) {
+                strcpy(output, filename);
+            }
+            return 2;
+        }
+    }
+    if ((type == NuFileDeviceAndroidOBBType::MAIN && g_obbMainSize > 0) ||
+        (type != NuFileDeviceAndroidOBBType::MAIN && g_obbPatchSize > 0)) {
+        memcpy(directory, g_externalDataPath, prefix_length);
+        directory[prefix_length] = '\0';
+        strcat(directory, "obb/");
+        strcat(directory, g_activityName);
+        strcat(directory, "/");
+        sprintf(filename, "%s%s.%04d.%s.%s", directory,
+                type == NuFileDeviceAndroidOBBType::MAIN ? "main" : "patch",
+                type == NuFileDeviceAndroidOBBType::MAIN ? g_obbMainVersion : g_obbPatchVersion,
+                g_activityName, "obb");
+        FILE *file = fopen(filename, "rb");
+        if (file != NULL) {
+            fclose(file);
+            strcpy(ms_packageName[type], filename);
+            ms_initializedPackage[type] = true;
+            ms_initializedPackageIsAsset[type] = false;
+            if (output != NULL) {
+                strcpy(output, filename);
+            }
+            return 1;
+        }
+    }
+    if ((type == NuFileDeviceAndroidOBBType::MAIN && g_obbMainSize > 0) ||
+        (type != NuFileDeviceAndroidOBBType::MAIN && g_obbPatchSize > 0)) {
+        prefix_length -= 9;
+        memcpy(directory, g_externalDataPath, prefix_length);
+        directory[prefix_length] = '\0';
+        strcat(directory, "/TTGames/");
+        strcat(directory, g_activityName);
+        strcat(directory, "/obb/");
+        sprintf(filename, "%s%s.%04d.%s.%s", directory,
+                type == NuFileDeviceAndroidOBBType::MAIN ? "main" : "patch",
+                type == NuFileDeviceAndroidOBBType::MAIN ? g_obbMainVersion : g_obbPatchVersion,
+                g_activityName, "obb");
+        FILE *file = fopen(filename, "rb");
+        if (file != NULL) {
+            fclose(file);
+            strcpy(ms_packageName[type], filename);
+            ms_initializedPackage[type] = true;
+            ms_initializedPackageIsAsset[type] = false;
+            if (output != NULL) {
+                strcpy(output, filename);
+            }
+            return 1;
+        }
+    }
+    return 0;
 }
 
-void AndroidOBBUtils::OpenFile(char const *) {
+i32 AndroidOBBUtils::OpenFile(char const *name) {
+    NuFileDeviceAndroidOBBType::T type;
+    if (NuStrIStr(const_cast<char *>(name), "GAME.DAT") != NULL) {
+        type = NuFileDeviceAndroidOBBType::MAIN;
+    } else if (NuStrIStr(const_cast<char *>(name), "PATCH.DAT") != NULL) {
+        type = NuFileDeviceAndroidOBBType::PATCH;
+    } else {
+        return 0;
+    }
+    if (ms_initializedPackage[type]) {
+        return NuFileOpen(ms_packageName[type], NUFILE_READ);
+    }
+    return 0;
 }

--- a/src/gamelib/util/gamelib_util_types.h
+++ b/src/gamelib/util/gamelib_util_types.h
@@ -64,12 +64,15 @@ struct WORLDINFO_s;
 struct ePeerLeftReason {};
 
 struct NuFileDeviceAndroidOBBType {
-    struct T {};
+    enum T { NONE = 0, MAIN = 1, PATCH = 2 };
 };
 struct AndroidOBBUtils {
-    void InitPackagePaths();
-    void LookupPackagePath(char *, NuFileDeviceAndroidOBBType::T);
-    void OpenFile(char const *);
+    static char ms_packageName[3][512];
+    static bool ms_initializedPackage[3];
+    static bool ms_initializedPackageIsAsset[3];
+    static void InitPackagePaths();
+    static i32 LookupPackagePath(char *, NuFileDeviceAndroidOBBType::T);
+    static i32 OpenFile(char const *);
 };
 struct CRC16 {
     CRC16();

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -349,7 +349,7 @@ u8 aicreature_sets_alive[16] = {};
 // ------------------------------------------------------------------------
 // Render / compatibility options
 // ------------------------------------------------------------------------
-i32 g_forceSysMemVbs = 0;
+bool g_forceSysMemVbs = false;
 i32 g_forceETC1 = 0;
 i32 Reflections_On = 1;
 i32 disable_narrow_socks = 0;

--- a/src/globals.h
+++ b/src/globals.h
@@ -487,6 +487,7 @@ extern NUCAMERA *pNuCam;
 // ------------------------------------------------------------------------
 struct ANativeWindow;
 extern ANativeWindow *g_appWindow;
+extern volatile bool g_isBlockedInSwapScreen;
 extern char g_deviceManufacturer[256];
 extern char g_deviceModel[256];
 extern i32 g_isLowestEndDevice;
@@ -500,7 +501,7 @@ extern i32 finishloop_backdroponly;
 // ------------------------------------------------------------------------
 // Render / compatibility options
 // ------------------------------------------------------------------------
-extern i32 g_forceSysMemVbs;
+extern bool g_forceSysMemVbs;
 extern i32 g_forceETC1;
 extern i32 texanimbits;
 extern i32 Reflections_On;

--- a/src/host/platform/android_assets.cpp
+++ b/src/host/platform/android_assets.cpp
@@ -1,0 +1,14 @@
+#include "java/asset_manager.h"
+#include "java/native_window.h"
+
+// Host games use filesystem assets; there is no Android APK asset manager.
+extern "C" AAsset *AAssetManager_open(AAssetManager *, const char *, int) { return NULL; }
+extern "C" void AAsset_close(AAsset *) {}
+extern "C" off_t AAsset_seek(AAsset *, off_t, int) { return -1; }
+extern "C" int AAsset_read(AAsset *, void *, size_t) { return -1; }
+extern "C" off_t AAsset_getLength(AAsset *) { return 0; }
+
+// The host renderer does not create Android native windows.
+extern "C" int32_t ANativeWindow_getWidth(ANativeWindow *) { return 0; }
+extern "C" int32_t ANativeWindow_getHeight(ANativeWindow *) { return 0; }
+extern "C" int32_t ANativeWindow_setBuffersGeometry(ANativeWindow *, int32_t, int32_t, int32_t) { return -1; }

--- a/src/host/platform/gles_extensions.cpp
+++ b/src/host/platform/gles_extensions.cpp
@@ -28,4 +28,3 @@ extern "C" void glGenVertexArraysOESC(GLsizei count, GLuint *arrays) {
 extern "C" void glDeleteVertexArraysOESC(GLsizei count, const GLuint *arrays) {
     host_glDeleteVertexArraysOES(count, arrays);
 }
-

--- a/src/host/platform/gles_extensions.cpp
+++ b/src/host/platform/gles_extensions.cpp
@@ -1,0 +1,31 @@
+#include <EGL/egl.h>
+#include <GLES2/gl2.h>
+
+// Keep the extension-loader interface while giving host pointer storage local
+// names that cannot collide with the GL implementation's exported functions.
+namespace {
+void (*host_glGetProgramBinaryOES)(GLuint, GLsizei, GLsizei *, GLenum *, void *);
+void (*host_glProgramBinaryOES)(GLuint, GLenum, const void *, GLint);
+void (*host_glDiscardFramebufferEXT)(GLenum, GLsizei, const GLenum *);
+void (*host_glGenVertexArraysOES)(GLsizei, GLuint *);
+void (*host_glBindVertexArrayOES)(GLuint);
+void (*host_glDeleteVertexArraysOES)(GLsizei, const GLuint *);
+}
+
+void NuGLES2ExtensionsInit() {
+    host_glGetProgramBinaryOES = reinterpret_cast<decltype(host_glGetProgramBinaryOES)>(eglGetProcAddress("glGetProgramBinaryOES"));
+    host_glProgramBinaryOES = reinterpret_cast<decltype(host_glProgramBinaryOES)>(eglGetProcAddress("glProgramBinaryOES"));
+    host_glDiscardFramebufferEXT = reinterpret_cast<decltype(host_glDiscardFramebufferEXT)>(eglGetProcAddress("glDiscardFramebufferEXT"));
+    host_glGenVertexArraysOES = reinterpret_cast<decltype(host_glGenVertexArraysOES)>(eglGetProcAddress("glGenVertexArraysOES"));
+    host_glBindVertexArrayOES = reinterpret_cast<decltype(host_glBindVertexArrayOES)>(eglGetProcAddress("glBindVertexArrayOES"));
+    host_glDeleteVertexArraysOES = reinterpret_cast<decltype(host_glDeleteVertexArraysOES)>(eglGetProcAddress("glDeleteVertexArraysOES"));
+}
+
+extern "C" void glGenVertexArraysOESC(GLsizei count, GLuint *arrays) {
+    host_glGenVertexArraysOES(count, arrays);
+}
+
+extern "C" void glDeleteVertexArraysOESC(GLsizei count, const GLuint *arrays) {
+    host_glDeleteVertexArraysOES(count, arrays);
+}
+

--- a/src/java/android.cpp
+++ b/src/java/android.cpp
@@ -1,0 +1,252 @@
+#include "java/java.h"
+#include "java/android.h"
+
+#include <android/asset_manager_jni.h>
+#include <android/native_window_jni.h>
+#include <pthread.h>
+#include <string.h>
+
+#include "batman.h"
+#include "gamelib/util/gamelib_util_types.h"
+#include "globals.h"
+#include "nu2api/nu3d/NuRenderDevice.h"
+#include "nu2api/nu3d/nuscreen.hpp"
+#include "nu2api/nucore/NuInputDevice.h"
+#include "nu2api/nucore/android/NuInputDevice_android.h"
+#include "nu2api/nucore/nucore.hpp"
+#include "nu2api/nucore/numemory.h"
+#include "nu2api/nuplatform/nudevicespecs.hpp"
+#include "nu2api/nuplatform/nuplatform.h"
+
+JavaVM *g_javaVM;
+jclass g_activityClass;
+extern "C" char g_language[16];
+pthread_t g_appPthread;
+bool g_appPthreadStarted;
+
+static bool g_isStopped = true;
+static bool g_isPaused = true;
+static bool g_validSurface;
+static i32 android_argc;
+static char *android_argv[32];
+
+void *AndroidMain(void *) {
+    JNIEnv *env = NULL;
+    g_javaVM->AttachCurrentThread(&env, NULL);
+    char *package = strstr(g_internalDataPath, "/com.");
+    if (package != NULL) {
+        char *begin = package + 1;
+        char *end = strchr(package + 2, '/');
+        if (end != NULL) {
+            usize length = end - begin;
+            if (length < sizeof(g_activityName)) {
+                memcpy(g_activityName, begin, length);
+                g_activityName[length] = '\0';
+            }
+        }
+    }
+    android_argv[android_argc++] = "app.so";
+    g_disallowGlobalNew = true;
+    AndroidOBBUtils::InitPackagePaths();
+    NuPlatform::Create();
+    if (!NuScreen::Exists()) {
+        NuScreen::Create();
+    }
+    g_renderDevice.Initialize();
+    g_isLowestEndDevice = 1;
+    g_isLowEndDevice = 1;
+    g_isMidRangeDevice = 0;
+    switch (NuDeviceSpecs::ms_instance->specs) {
+        case 1:
+            g_isLowestEndDevice = 0;
+            g_isLowEndDevice = 0;
+            g_isMidRangeDevice = 1;
+            break;
+        case 2:
+        case 3:
+            g_isLowestEndDevice = 0;
+            g_isLowEndDevice = 0;
+            break;
+    }
+    g_lowEndLevelBehaviour = g_isLowEndDevice;
+    return reinterpret_cast<void *>(NuMain(android_argc, android_argv));
+}
+
+static inline void UpdateApplicationStatus() {
+    NuApplicationState *state = NuCore::GetApplicationState();
+    NUAPPLICATIONSTATUS previous = state->GetStatus();
+    if (!g_isPaused && !g_isStopped && g_validSurface) {
+        state->SetStatus(NUAPPLICATIONSTATUS_IDLE);
+    } else {
+        // Status 1 blocks presentation; wait for the game thread to acknowledge
+        // the transition before Android destroys the window.
+        state->SetStatus(NUAPPLICATIONSTATUS_RENDERING);
+        if (previous == NUAPPLICATIONSTATUS_IDLE) {
+            while (!g_isBlockedInSwapScreen) {
+                NuThreadSleep(1);
+            }
+        }
+    }
+}
+
+extern "C" {
+
+jint JNI_OnLoad(JavaVM *vm, void *) {
+    JNIEnv *env;
+    if (vm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6) != JNI_OK) {
+        return JNI_ERR;
+    }
+    jclass activity = env->FindClass("com/tt/tech/TTActivity");
+    g_activityClass = static_cast<jclass>(env->NewGlobalRef(activity));
+    return JNI_VERSION_1_6;
+}
+
+void Java_com_tt_tech_TTActivity_nativeCacheJNIVars(JNIEnv *env, jobject) {
+    env->GetJavaVM(&g_javaVM);
+}
+
+void Java_com_tt_tech_TTActivity_nativeSetObbInfo(JNIEnv *env, jobject, jint main_version, jint main_size,
+                                               jint patch_version, jint patch_size, jstring version, jint force_etc1) {
+    g_obbMainVersion = main_version;
+    g_obbMainSize = main_size;
+    g_obbPatchVersion = patch_version;
+    g_obbPatchSize = patch_size;
+    g_forceETC1 = force_etc1;
+    const char *text = env->GetStringUTFChars(version, NULL);
+    strcpy(g_versionName, text);
+    env->ReleaseStringUTFChars(version, text);
+}
+
+void Java_com_tt_tech_TTActivity_nativeSetCaps(JNIEnv *, jobject, jint caps) {
+    g_flashAvailable = caps;
+}
+
+void Java_com_tt_tech_TTActivity_nativeSetPaths(JNIEnv *env, jobject, jstring internal, jstring external) {
+    const char *text = env->GetStringUTFChars(internal, NULL);
+    strcpy(g_internalDataPath, text);
+    env->ReleaseStringUTFChars(internal, text);
+    text = env->GetStringUTFChars(external, NULL);
+    strcpy(g_externalDataPath, text);
+    env->ReleaseStringUTFChars(external, text);
+}
+
+void Java_com_tt_tech_TTActivity_nativeSetLanguage(JNIEnv *env, jobject, jstring language) {
+    const char *text = env->GetStringUTFChars(language, NULL);
+    strcpy(g_language, text);
+    env->ReleaseStringUTFChars(language, text);
+}
+
+void Java_com_tt_tech_TTActivity_nativeSetAndroidVersion(JNIEnv *env, jobject, jstring version) {
+    const char *text = env->GetStringUTFChars(version, NULL);
+    strcpy(g_androidOsVersion, text);
+    env->ReleaseStringUTFChars(version, text);
+}
+
+void Java_com_tt_tech_TTActivity_nativeSetAssetManager(JNIEnv *env, jobject, jobject manager) {
+    g_assetManager = AAssetManager_fromJava(env, env->NewGlobalRef(manager));
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnCreate(JNIEnv *, jobject) {
+    NuCore::GetApplicationState()->SetStatus(NUAPPLICATIONSTATUS_RENDERING);
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnStart(JNIEnv *, jobject) {
+    g_isStopped = false;
+    UpdateApplicationStatus();
+    if (!g_appPthreadStarted) {
+        pthread_attr_t attributes;
+        pthread_attr_init(&attributes);
+        pthread_attr_setdetachstate(&attributes, PTHREAD_CREATE_DETACHED);
+        pthread_create(&g_appPthread, &attributes, AndroidMain, NULL);
+        g_appPthreadStarted = true;
+    }
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnResume(JNIEnv *, jobject) {
+    g_isPaused = false;
+    UpdateApplicationStatus();
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnPause(JNIEnv *, jobject) {
+    g_isPaused = true;
+    UpdateApplicationStatus();
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnStop(JNIEnv *, jobject) {
+    g_isStopped = true;
+    UpdateApplicationStatus();
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnKeyUp(JNIEnv *, jobject, jint key) {
+    NuInputDevicePS::HandleKeyUp_ANDROID_SPECIFIC(key);
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnKeyDown(JNIEnv *, jobject, jint key) {
+    NuInputDevicePS::HandleKeyDown_ANDROID_SPECIFIC(key);
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnTouchDown(JNIEnv *, jobject, jint device, jint touch, jfloat x, jfloat y) {
+    NuInputDevicePS::HandleTouch_ANDROID_SPECIFIC(0, device, touch, x, y);
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnTouchUp(JNIEnv *, jobject, jint device, jint touch) {
+    NuInputDevicePS::HandleTouch_ANDROID_SPECIFIC(1, device, touch, 0.0f, 0.0f);
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnTouchMove(JNIEnv *, jobject, jint device, jint touch, jfloat x, jfloat y) {
+    NuInputDevicePS::HandleTouch_ANDROID_SPECIFIC(2, device, touch, x, y);
+}
+
+void Java_com_tt_tech_TTActivity_nativeUpdateGamepadAxisValues(JNIEnv *, jobject, jfloat x, jfloat y, jfloat z,
+                                                           jfloat rz, jfloat left, jfloat right) {
+    NuInputDevicePS::HandleGamePadAxis_ANDROID_SPECIFIC(x, y, z, rz, left, right);
+}
+
+void Java_com_tt_tech_CheckGamepadStatus_nativeSetGamePadConnected(JNIEnv *, jobject, jboolean connected) {
+    NuInputDevicePS::HandleGamepPadStatusConnect(connected == JNI_TRUE);
+}
+
+void Java_com_tt_tech_TTActivity_nativeOnSensorUpdate(JNIEnv *, jobject, jint sensor, jfloat x, jfloat y, jfloat z) {
+    NuInputDevicePS::HandleSensor_ANDROID_SPECIFIC(sensor, x, y, z);
+}
+
+void Java_com_tt_tech_TTActivity_nativeSetSurface(JNIEnv *env, jobject, jobject surface) {
+    ANativeWindow *window = NULL;
+    if (surface != NULL) {
+        window = ANativeWindow_fromSurface(env, surface);
+        i32 width = ANativeWindow_getWidth(window);
+        i32 height = ANativeWindow_getHeight(window);
+        if (width <= 0 || height <= 0 || width < height) {
+            window = NULL;
+        }
+    }
+    if (window != NULL) {
+        g_renderDevice.OnWindowCreated(window);
+        g_appWindow = window;
+        g_validSurface = true;
+        UpdateApplicationStatus();
+    } else {
+        g_validSurface = false;
+        UpdateApplicationStatus();
+        g_renderDevice.OnWindowDestroy();
+    }
+}
+
+void Java_com_tt_tech_TTActivity_nativeSetScreenDimesions(JNIEnv *, jobject, jfloat width, jfloat height) {
+    NuScreen::Create();
+    NuScreen::Get()->SetSceeenDimensions(width, height);
+}
+
+void Java_com_tt_tech_TTActivity_nativeSetManufacturer(JNIEnv *env, jobject, jstring manufacturer) {
+    const char *text = env->GetStringUTFChars(manufacturer, NULL);
+    strcpy(g_deviceManufacturer, text);
+    env->ReleaseStringUTFChars(manufacturer, text);
+}
+
+void Java_com_tt_tech_TTActivity_nativeSetModel(JNIEnv *env, jobject, jstring model) {
+    const char *text = env->GetStringUTFChars(model, NULL);
+    strcpy(g_deviceModel, text);
+    env->ReleaseStringUTFChars(model, text);
+}
+
+} // extern "C"

--- a/src/java/android.h
+++ b/src/java/android.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "nu2api/nucore/common.h"
+
+struct AAssetManager;
+extern AAssetManager *g_assetManager;
+extern i32 g_obbMainVersion;
+extern i32 g_obbMainSize;
+extern i32 g_obbPatchVersion;
+extern i32 g_obbPatchSize;
+extern char g_activityName[64];
+extern char g_externalDataPath[256];
+extern char g_internalDataPath[256];
+extern char g_versionName[64];
+extern i32 g_flashAvailable;
+extern char g_androidOsVersion[64];

--- a/src/java/android_state.cpp
+++ b/src/java/android_state.cpp
@@ -1,0 +1,13 @@
+#include "java/android.h"
+
+i32 g_obbMainVersion;
+i32 g_obbMainSize;
+i32 g_obbPatchVersion;
+i32 g_obbPatchSize;
+char g_versionName[64];
+i32 g_flashAvailable;
+char g_internalDataPath[256];
+char g_externalDataPath[256];
+char g_androidOsVersion[64];
+AAssetManager *g_assetManager;
+char g_activityName[64];

--- a/src/java/asset_manager.h
+++ b/src/java/asset_manager.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stddef.h>
+#include <sys/types.h>
+
+struct AAssetManager;
+struct AAsset;
+enum { AASSET_MODE_UNKNOWN = 0 };
+extern "C" {
+    AAsset *AAssetManager_open(AAssetManager *, const char *, int);
+    void AAsset_close(AAsset *);
+    off_t AAsset_seek(AAsset *, off_t, int);
+    int AAsset_read(AAsset *, void *, size_t);
+    off_t AAsset_getLength(AAsset *);
+}

--- a/src/java/java.h
+++ b/src/java/java.h
@@ -1,4 +1,4 @@
 #include "jni.h"
 
-extern JavaVM g_javaVM;
+extern JavaVM *g_javaVM;
 extern jclass g_activityClass;

--- a/src/java/jni_stub.cpp
+++ b/src/java/jni_stub.cpp
@@ -30,9 +30,11 @@ struct JNIInvokeInterface stub = {
     .AttachCurrentThreadAsDaemon = NULL,
 };
 
-JavaVM g_javaVM = {
+static JavaVM host_javaVM = {
     .functions = &stub,
 };
+
+JavaVM *g_javaVM = &host_javaVM;
 
 jclass g_activityClass;
 

--- a/src/java/native_window.h
+++ b/src/java/native_window.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <stdint.h>
+struct ANativeWindow;
+extern "C" {
+    int32_t ANativeWindow_getWidth(ANativeWindow *);
+    int32_t ANativeWindow_getHeight(ANativeWindow *);
+    int32_t ANativeWindow_setBuffersGeometry(ANativeWindow *, int32_t, int32_t, int32_t);
+}

--- a/src/legoapi/core/input/timing.cpp
+++ b/src/legoapi/core/input/timing.cpp
@@ -2,6 +2,7 @@
 #include "globals.h"
 #include "legoapi/legoapi_types.h"
 #include "nu2api/nu3d/nutex.h"
+#include <time.h>
 
 struct AIROW_s;
 struct nuqthdr_s;
@@ -13,7 +14,11 @@ i32 do_multiframe_update;
 void TimingBars() {
 }
 
-void getCurrentTime() {
+// Original C++ entry point 0x2a6020, distinct from the C entry point.
+i64 getCurrentTime() {
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    return (i64)ts.tv_sec * 1000 + (i64)ts.tv_nsec;
 }
 
 void SetFramesToWait(u32) {

--- a/src/legoapi/legoapi_types.h
+++ b/src/legoapi/legoapi_types.h
@@ -10,6 +10,7 @@
 #include "nu2api/nu3d/nuhspecial.h"
 #include "nu2api/numath/numtx.h"
 #include "nu2api/numath/nuvec.h"
+#include "nu2api/numath/nuvec4.h"
 
 #include "legoapi/items/base/apiobject.h"
 #include "MechInputTouch/MechInputTouch_types.h"
@@ -3606,28 +3607,58 @@ struct MoveToMarker {
     void Process(float);
     void Render();
 };
+struct OccluderRecord {
+    NUVEC4 vertices[4];
+    NUVEC4 transformed[4];
+    f32 min_x, max_x, min_y, max_y, min_depth;
+    f32 depth;
+};
+DECOMP_ASSERT(sizeof(OccluderRecord) == 0x98, "occluder record size");
+DECOMP_ASSERT(offsetof(OccluderRecord, depth) == 0x94, "occluder depth offset");
 struct OccluderSet {
+    OccluderRecord *occluders;
+    u32 *indices;
+    u32 capacity;
+    u32 count;
+    bool queries_prepared;
+    u8 unknown_11[0x0f];
+    NUMTX projection_matrix;
+    NUMTX query_matrix;
+    static numtl_s *ms_pZOnlyMtl3D;
+    static numtl_s *ms_pZOnlyMtl2D;
+    static numtl_s *ms_pAlphaMtl2D;
     void AddOccluder(nuvec_s const *, nuvec_s const *, nuvec_s const *, nuvec_s const *);
     void Clear();
     void Init(u32, variptr_u *, variptr_u);
-    void IsOccludedOBB(nuvec_s const *, nuvec_s const *, numtx_s const *);
-    void IsOccludedSphere(nuvec_s const *, float);
+    bool IsOccludedOBB(nuvec_s const *, nuvec_s const *, numtx_s const *);
+    bool IsOccludedSphere(nuvec_s const *, float);
     OccluderSet();
     void OnCameraSet();
     void PrepareForQueries(numtx_s const *, numtx_s const *);
     void RenderOccluders(bool) const;
-    void SortByDepth(void const *, void const *);
+    static i32 SortByDepth(void const *, void const *);
     ~OccluderSet();
 };
 struct OcclusionManager {
+    bool initialized;
+    bool enabled;
+    u8 unknown_02[0x0e];
+    OccluderSet sets[2];
+    OccluderSet *building_set;
+    OccluderSet *current_set;
+    f32 unknown_158;
+    f32 unknown_15c;
+    u32 unknown_160;
+    u32 unknown_164;
+    u8 unknown_168[8];
     void AddOccluder(nuvec_s const *, float);
     void AddOccluder(nuvec_s const *, nuvec_s const *, numtx_s const *);
     void AddOccluder(nuvec_s const *, nuvec_s const *, nuvec_s const *, nuvec_s const *);
     void BeginFrame();
     void EndFrame();
     void Init(u32, variptr_u *, variptr_u);
-    void IsOccludedOBB(nuvec_s const *, nuvec_s const *, numtx_s const *);
-    void IsOccludedSphere(nuvec_s const *, float);
+    bool IsOccludedOBB(nuvec_s const *, nuvec_s const *, numtx_s const *);
+    bool IsOccludedSphere(nuvec_s const *, float);
     OcclusionManager();
     void OnCameraSet();
     void RenderStats() const;
@@ -3635,6 +3666,10 @@ struct OcclusionManager {
     void SetEnabled(bool);
     ~OcclusionManager();
 };
+DECOMP_ASSERT(sizeof(OccluderSet) == 0xa0, "occluder set size");
+DECOMP_ASSERT(sizeof(OcclusionManager) == 0x170, "occlusion manager size");
+DECOMP_ASSERT(offsetof(OcclusionManager, current_set) == 0x154, "current occluder set offset");
+extern OcclusionManager g_OcclusionManager;
 struct PART_s {
     union {
         NUMTX transform;

--- a/src/legoapi/misc/androidbatman.cpp
+++ b/src/legoapi/misc/androidbatman.cpp
@@ -136,9 +136,6 @@ void NewScanRot(nuvec_s *position, i32 terrain_mask) {
     TerI->scan_list = TerI->scan_list_storage;
 }
 
-void AndroidMain(void *) {
-}
-
 void ObjZappedBlue(GameObject_s *) {
 }
 

--- a/src/legoapi/render/core/render_stubs.cpp
+++ b/src/legoapi/render/core/render_stubs.cpp
@@ -598,10 +598,4 @@ extern "C" {
     void SphereDrawEx(void) {
     }
 
-    void glDeleteVertexArraysOESC(void) {
-    }
-
-    void glGenVertexArraysOESC(void) {
-    }
-
 } // extern "C"

--- a/src/legoapi/render/light/occlusion.cpp
+++ b/src/legoapi/render/light/occlusion.cpp
@@ -1,78 +1,420 @@
 #include "legoapi/legoapi_types.h"
 #include "decomp.h"
+#include "nu2api/nucore/common.h"
+#include "nu2api/nu3d/numtl.h"
+#include "nu2api/nu3d/nucamera.h"
+#include "nu2api/nu3d/nuprim.h"
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
 struct nuvisiboxtree_s;
 struct nuvisiboxtreenode_s;
+OcclusionManager g_OcclusionManager;
+NUMTL *OccluderSet::ms_pZOnlyMtl3D;
+NUMTL *OccluderSet::ms_pZOnlyMtl2D;
+NUMTL *OccluderSet::ms_pAlphaMtl2D;
 
-void OccluderSet::AddOccluder(nuvec_s const *, nuvec_s const *, nuvec_s const *, nuvec_s const *) {
+void OccluderSet::AddOccluder(const NUVEC *a, const NUVEC *b, const NUVEC *c, const NUVEC *d) {
+    if (count < capacity) {
+        queries_prepared = false;
+        occluders[count].vertices[0] = NUVEC4{a->x, a->y, a->z, 1.0f};
+        occluders[count].vertices[1] = NUVEC4{b->x, b->y, b->z, 1.0f};
+        occluders[count].vertices[2] = NUVEC4{c->x, c->y, c->z, 1.0f};
+        occluders[count].vertices[3] = NUVEC4{d->x, d->y, d->z, 1.0f};
+        ++count;
+    }
 }
 
 void OccluderSet::Clear() {
+    count = 0;
+    queries_prepared = false;
 }
 
-void OccluderSet::Init(u32, variptr_u *, variptr_u) {
+void OccluderSet::Init(u32 max_occluders, VARIPTR *buffer, VARIPTR buffer_end) {
+    capacity = max_occluders;
+    count = 0;
+    occluders = reinterpret_cast<OccluderRecord *>((buffer->addr + 15) & ~(usize)15);
+    indices = reinterpret_cast<u32 *>(occluders + max_occluders);
+    buffer->addr = reinterpret_cast<usize>(indices + max_occluders);
+    if (ms_pZOnlyMtl3D == NULL) {
+        ms_pZOnlyMtl3D = NuMtlCreate3D(1);
+        ms_pZOnlyMtl2D = NuMtlCreate(1);
+        ms_pAlphaMtl2D = NuMtlCreate(1);
+        NUSHADERMTLDESC desc2d;
+        memset(&desc2d, 0, sizeof(desc2d));
+        desc2d.flags = 0x1000;
+        desc2d.vtx_desc.has_position = 1;
+        desc2d.vtx_desc.has_no_transform = 1;
+        NuMtlSetShaderDescPS(ms_pZOnlyMtl2D, &desc2d);
+        ms_pZOnlyMtl2D->attribs.alpha_mode = 13;
+        ms_pZOnlyMtl2D->attribs.cull_mode = 2;
+        ms_pZOnlyMtl2D->attribs.z_mode = 0;
+        ms_pZOnlyMtl2D->attribs.unknown_2_8 = 0;
+        NuMtlUpdate(ms_pZOnlyMtl2D);
+        NUSHADERMTLDESC desc3d;
+        memset(&desc3d, 0, sizeof(desc3d));
+        desc3d.flags = 0x1000;
+        desc3d.vtx_desc.has_position = 1;
+        NuMtlSetShaderDescPS(ms_pZOnlyMtl3D, &desc3d);
+        ms_pZOnlyMtl3D->attribs.alpha_mode = 13;
+        ms_pZOnlyMtl3D->attribs.cull_mode = 2;
+        ms_pZOnlyMtl3D->attribs.z_mode = 0;
+        ms_pZOnlyMtl3D->attribs.unknown_2_8 = 0;
+        NuMtlUpdate(ms_pZOnlyMtl3D);
+        ms_pAlphaMtl2D->attribs.alpha_mode = 1;
+        ms_pAlphaMtl2D->attribs.cull_mode = 2;
+        ms_pAlphaMtl2D->attribs.z_mode = 1;
+        NuMtlUpdate(ms_pAlphaMtl2D);
+    }
 }
 
-void OccluderSet::IsOccludedOBB(nuvec_s const *, nuvec_s const *, numtx_s const *) {
+bool OccluderSet::IsOccludedOBB(nuvec_s const *minimum, nuvec_s const *maximum, numtx_s const *matrix) {
+    if (!queries_prepared) return false;
+    NUVEC4 corners[8] = {
+        {minimum->x, maximum->y, minimum->z, 1.0f},
+        {minimum->x, maximum->y, maximum->z, 1.0f},
+        {maximum->x, maximum->y, maximum->z, 1.0f},
+        {maximum->x, maximum->y, minimum->z, 1.0f},
+        {minimum->x, minimum->y, minimum->z, 1.0f},
+        {minimum->x, minimum->y, maximum->z, 1.0f},
+        {maximum->x, minimum->y, maximum->z, 1.0f},
+        {maximum->x, minimum->y, minimum->z, 1.0f}
+    };
+    NUMTX transform;
+    if (matrix) NuMtxMulH(&transform, const_cast<NUMTX *>(matrix), &projection_matrix);
+    else transform = projection_matrix;
+    float min_x = 1000000.0f, min_y = 1000000.0f, min_depth = 1000000.0f;
+    float max_x = -1000000.0f, max_y = -1000000.0f;
+    for (u32 i = 0; i < 8; ++i) {
+        NUVEC4 &v = corners[i];
+        NuVec4MtxTransform(&v, reinterpret_cast<NUVEC *>(&v), &transform);
+        if (v.w <= 0.0f) return false;
+        v.x /= v.w;
+        v.y /= v.w;
+        v.z /= v.w;
+        min_x = v.x < min_x ? v.x : min_x;
+        min_y = v.y < min_y ? v.y : min_y;
+        max_x = v.x > max_x ? v.x : max_x;
+        max_y = v.y > max_y ? v.y : max_y;
+        min_depth = v.w < min_depth ? v.w : min_depth;
+    }
+    i32 limit = static_cast<i32>(count) < 100 ? static_cast<i32>(count) : 100;
+    for (i32 i = 0; i != limit; ++i) {
+        if (indices[i] == 0xffffffffu) continue;
+        OccluderRecord &record = occluders[indices[i]];
+        if (record.depth > min_depth - 2.0f) return false;
+        if (min_x > record.max_x || min_y > record.max_y ||
+            record.min_x > max_x || record.min_y > max_y) continue;
+        NUVEC4 *v = record.transformed;
+        float winding = (v[2].x - v[0].x) * (v[1].y - v[0].y) -
+                        (v[1].x - v[0].x) * (v[2].y - v[0].y);
+        bool inside = true;
+        for (i32 edge = 0; edge < 4 && inside; ++edge) {
+            i32 start = winding > 0.0f ? edge : 3 - edge;
+            i32 end = winding > 0.0f ? (edge + 1) & 3 : (6 - edge) & 3;
+            NUVEC4 normal = {v[end].y - v[start].y, -(v[end].x - v[start].x), 0.0f, 0.0f};
+            NuVecNorm(reinterpret_cast<NUVEC *>(&normal), reinterpret_cast<NUVEC *>(&normal));
+            normal.z = normal.w = 0.0f;
+            for (u32 corner = 0; corner < 8; ++corner) {
+                float distance = (corners[corner].x - v[start].x) * normal.x +
+                                 (corners[corner].y - v[start].y) * normal.y + 0.0f;
+                if (distance < 0.01f) {
+                    inside = false;
+                    break;
+                }
+            }
+        }
+        if (inside) return true;
+    }
+    return false;
 }
 
-void OccluderSet::IsOccludedSphere(nuvec_s const *, float) {
+bool OccluderSet::IsOccludedSphere(nuvec_s const *center, float radius) {
+    if (!queries_prepared) return false;
+    NUVEC4 projected;
+    NuVec4MtxTransform(&projected, const_cast<NUVEC *>(center), &projection_matrix);
+    if (radius > projected.w) return false;
+    projected.x /= projected.w;
+    projected.y /= projected.w;
+    projected.z /= projected.w;
+    float screen_radius = radius / projected.w;
+    i32 limit = static_cast<i32>(count) < 100 ? static_cast<i32>(count) : 100;
+    for (i32 i = 0; i != limit; ++i) {
+        if (indices[i] == 0xffffffffu) continue;
+        OccluderRecord &record = occluders[indices[i]];
+        if (record.depth > projected.w - radius - 2.0f) return false;
+        if (projected.x - screen_radius > record.max_x ||
+            projected.y - screen_radius > record.max_y ||
+            record.min_x > projected.x + screen_radius ||
+            record.min_y > projected.y + screen_radius) continue;
+        NUVEC4 *v = record.transformed;
+        float winding = (v[1].y - v[0].y) * (v[2].x - v[0].x) -
+                        (v[1].x - v[0].x) * (v[2].y - v[0].y);
+        bool inside = true;
+        for (i32 edge = 0; edge < 4; ++edge) {
+            i32 start = winding > 0.0f ? edge : 3 - edge;
+            i32 end = winding > 0.0f ? (edge + 1) & 3 : (6 - edge) & 3;
+            NUVEC4 normal = {v[end].y - v[start].y, -(v[end].x - v[start].x), 0.0f, 0.0f};
+            NuVecNorm(reinterpret_cast<NUVEC *>(&normal), reinterpret_cast<NUVEC *>(&normal));
+            normal.z = normal.w = 0.0f;
+            float distance = (projected.x - v[start].x) * normal.x +
+                             (projected.y - v[start].y) * normal.y + 0.0f - screen_radius;
+            if (distance < 0.0f) {
+                inside = false;
+                break;
+            }
+        }
+        if (inside) return true;
+    }
+    return false;
 }
 
-OccluderSet::OccluderSet() {
+OccluderSet::OccluderSet() : occluders(NULL), indices(NULL), capacity(0), count(0) {
 }
 
 void OccluderSet::OnCameraSet() {
+    queries_prepared = false;
 }
 
-void OccluderSet::PrepareForQueries(numtx_s const *, numtx_s const *) {
+void OccluderSet::PrepareForQueries(numtx_s const *query, numtx_s const *projection) {
+    projection_matrix = *projection;
+    query_matrix = *query;
+    for (u32 index = 0; index < count; ++index) {
+        OccluderRecord &record = occluders[index];
+        record.min_x = record.min_y = record.min_depth = 1000000.0f;
+        record.max_x = record.max_y = record.depth = -1000000.0f;
+        bool valid = true;
+        for (u32 vertex = 0; vertex < 4; ++vertex) {
+            NUVEC4 &v = record.transformed[vertex];
+            NuVec4MtxTransform(&v, reinterpret_cast<NUVEC *>(&record.vertices[vertex]), &projection_matrix);
+            if (!(v.w > 0.0f)) {
+                valid = false;
+                break;
+            }
+            v.x /= v.w;
+            v.y /= v.w;
+            v.z /= v.w;
+            record.min_x = v.x < record.min_x ? v.x : record.min_x;
+            record.max_x = v.x > record.max_x ? v.x : record.max_x;
+            record.min_y = v.y < record.min_y ? v.y : record.min_y;
+            record.max_y = v.y > record.max_y ? v.y : record.max_y;
+            record.min_depth = v.w < record.min_depth ? v.w : record.min_depth;
+            record.depth = v.w > record.depth ? v.w : record.depth;
+        }
+        if (valid && (record.depth < 0.0f || record.min_depth < 0.0f ||
+                      record.max_x < -1.0f || record.min_x > 1.0f ||
+                      record.max_y < -1.0f || record.min_y > 1.0f)) {
+            valid = false;
+        }
+        indices[index] = valid ? index : 0xffffffffu;
+    }
+    qsort(indices, count, sizeof(*indices), SortByDepth);
+    queries_prepared = true;
 }
 
-void OccluderSet::RenderOccluders(bool) const {
+void OccluderSet::RenderOccluders(bool depth_only) const {
+    const u32 triangle_indices[6] = {0, 1, 2, 2, 3, 0};
+    if (queries_prepared) {
+        ++NuPrimCSPos;
+        NuPrimSetCoordinateSystem(NUPRIM_SCALEMODE_NORMALISED);
+        NuPrim2DBegin(0, 5, depth_only ? ms_pZOnlyMtl2D : NULL);
+        for (u32 i = 0; i < count; ++i) {
+            if (indices[i] == 0xffffffffu) continue;
+            const OccluderRecord &record = occluders[indices[i]];
+            if (record.min_depth < 0.0f || record.depth < 0.0f) continue;
+            u32 colour = static_cast<u32>(record.vertices[0].x * record.vertices[0].z) | 0xff000000u;
+            for (u32 vertex = 0; vertex < 6; ++vertex) {
+                u32 packed = g_NuPrim_NeedsOverbrightening ? colour :
+                             ((colour >> 1) & 0x007f7f7fu) | 0xff000000u;
+                *reinterpret_cast<u32 *>(g_NuPrim_StreamBufferPtr->addr + 12) = packed;
+                const NUVEC4 &v = record.transformed[triangle_indices[vertex]];
+                NuPrim2DAddXYZ(v.x, -v.y, v.z);
+            }
+        }
+        NuPrim2DEnd();
+        --NuPrimCSPos;
+        NuPrimSetCoordinateSystem(NuPrimCoordSystemStack[NuPrimCSPos]);
+    } else {
+        NuPrim3DBegin(0, 5, depth_only ? ms_pZOnlyMtl3D : NULL, NULL);
+        for (u32 i = 0; i < count; ++i) {
+            const OccluderRecord &record = occluders[i];
+            u32 colour = static_cast<u32>(record.vertices[0].x * record.vertices[0].z) | 0xff000000u;
+            for (u32 vertex = 0; vertex < 6; ++vertex) {
+                u32 packed = g_NuPrim_NeedsOverbrightening ? colour :
+                             ((colour >> 1) & 0x007f7f7fu) | 0xff000000u;
+                *reinterpret_cast<u32 *>(g_NuPrim_StreamBufferPtr->addr + 12) = packed;
+                const NUVEC4 &v = record.vertices[triangle_indices[vertex]];
+                *reinterpret_cast<NUVEC *>(g_NuPrim_StreamBufferPtr->addr) = NUVEC{v.x, v.y, v.z};
+                g_NuPrim_StreamBufferPtr->addr += 24;
+            }
+        }
+        g_NuPrim_VertexCount += count * 6;
+        NuPrim3DEnd();
+    }
 }
 
-void OccluderSet::SortByDepth(void const *, void const *) {
+i32 OccluderSet::SortByDepth(void const *left, void const *right) {
+    i32 a = *static_cast<const i32 *>(left);
+    i32 b = *static_cast<const i32 *>(right);
+    if (a == -1) return 1;
+    if (b == -1) return -1;
+    OccluderRecord *records = g_OcclusionManager.current_set->occluders;
+    return records[b].depth > records[a].depth ? -1 : 1;
 }
 
 OccluderSet::~OccluderSet() {
 }
 
-void OcclusionManager::AddOccluder(nuvec_s const *, float) {
+void OcclusionManager::AddOccluder(nuvec_s const *center, float radius) {
+    if (!initialized || !enabled) return;
+    NUMTX *view = NuCameraGetViewMtx();
+    NUVEC right = {view->m00 * radius, view->m10 * radius, view->m20 * radius};
+    NUVEC up = {view->m01 * radius, view->m11 * radius, view->m21 * radius};
+    NUVEC forward = {view->m02 * radius, view->m12 * radius, radius * view->m22};
+    NUVEC4 a = {((center->x + up.x) - right.x) - forward.x,
+                ((center->y + up.y) - right.y) - forward.y,
+                ((center->z + up.z) - right.z) - forward.z, 1.0f};
+    NUVEC4 b = {((center->x + up.x) + right.x) + forward.x,
+                ((center->y + up.y) + right.y) + forward.y,
+                ((center->z + up.z) + right.z) + forward.z, 1.0f};
+    NUVEC4 c = {(right.x + (center->x - up.x)) + forward.x,
+                (right.y + (center->y - up.y)) + forward.y,
+                (right.z + (center->z - up.z)) + forward.z, 1.0f};
+    NUVEC4 d = {((center->x - up.x) - right.x) - forward.x,
+                ((center->y - up.y) - right.y) - forward.y,
+                ((center->z - up.z) - right.z) - forward.z, 1.0f};
+    AddOccluder(reinterpret_cast<NUVEC *>(&a), reinterpret_cast<NUVEC *>(&b),
+                reinterpret_cast<NUVEC *>(&c), reinterpret_cast<NUVEC *>(&d));
 }
 
-void OcclusionManager::AddOccluder(nuvec_s const *, nuvec_s const *, numtx_s const *) {
+void OcclusionManager::AddOccluder(nuvec_s const *minimum, nuvec_s const *maximum, numtx_s const *matrix) {
+    if (!initialized || !enabled) return;
+    NUVEC4 corners[8] = {
+        {minimum->x, maximum->y, minimum->z, 1.0f},
+        {maximum->x, maximum->y, maximum->z, 1.0f},
+        {maximum->x, minimum->y, maximum->z, 1.0f},
+        {minimum->x, minimum->y, minimum->z, 1.0f},
+        {minimum->x, maximum->y, maximum->z, 1.0f},
+        {maximum->x, maximum->y, minimum->z, 1.0f},
+        {maximum->x, minimum->y, minimum->z, 1.0f},
+        {minimum->x, minimum->y, maximum->z, 1.0f}
+    };
+    for (u32 i = 0; i < 8; ++i) {
+        NUVEC *vertex = reinterpret_cast<NUVEC *>(&corners[i]);
+        NuVecMtxTransform(vertex, vertex, const_cast<NUMTX *>(matrix));
+    }
+    AddOccluder(reinterpret_cast<NUVEC *>(&corners[0]), reinterpret_cast<NUVEC *>(&corners[1]),
+                reinterpret_cast<NUVEC *>(&corners[2]), reinterpret_cast<NUVEC *>(&corners[3]));
+    AddOccluder(reinterpret_cast<NUVEC *>(&corners[4]), reinterpret_cast<NUVEC *>(&corners[5]),
+                reinterpret_cast<NUVEC *>(&corners[6]), reinterpret_cast<NUVEC *>(&corners[7]));
 }
 
-void OcclusionManager::AddOccluder(nuvec_s const *, nuvec_s const *, nuvec_s const *, nuvec_s const *) {
+void OcclusionManager::AddOccluder(nuvec_s const *a, nuvec_s const *b, nuvec_s const *c, nuvec_s const *d) {
+    if (!initialized || !enabled || building_set->count >= building_set->capacity) return;
+    if (unknown_158 > 0.0f || unknown_15c > 0.0f) {
+        NUVEC4 projected[4];
+        NuVec4MtxTransform(&projected[0], const_cast<NUVEC *>(a), NuCameraGetVPMtx());
+        NuVec4MtxTransform(&projected[1], const_cast<NUVEC *>(b), NuCameraGetVPMtx());
+        NuVec4MtxTransform(&projected[2], const_cast<NUVEC *>(c), NuCameraGetVPMtx());
+        if (unknown_158 > 0.0f) {
+            NUVEC ab = {projected[1].x - projected[0].x, projected[1].y - projected[0].y,
+                        projected[1].z - projected[0].z};
+            NUVEC ac = {projected[2].x - projected[0].x, projected[2].y - projected[0].y,
+                        projected[2].z - projected[0].z};
+            NUVEC normal = {ac.z * ab.y - ac.y * ab.z, ab.z * ac.x - ac.z * ab.x,
+                            ab.x * ac.y - ab.y * ac.x};
+            NuVecNorm(&normal, &normal);
+            if (unknown_158 > fabsf(normal.z)) return;
+        }
+        NuVec4MtxTransform(&projected[3], const_cast<NUVEC *>(d), NuCameraGetVPMtx());
+        float min_x = 1000000.0f, min_y = 1000000.0f;
+        float max_x = -1000000.0f, max_y = -1000000.0f;
+        for (u32 i = 0; i < 4; ++i) {
+            NUVEC4 &v = projected[i];
+            if (v.w < 0.001f) return;
+            v.x /= v.w;
+            v.y /= v.w;
+            v.z /= v.w;
+            min_x = v.x < min_x ? v.x : min_x;
+            min_y = v.y < min_y ? v.y : min_y;
+            max_x = v.x > max_x ? v.x : max_x;
+            max_y = v.y > max_y ? v.y : max_y;
+        }
+        if (unknown_15c > 0.0f && unknown_15c > (max_x - min_x) * (max_y - min_y) * 0.25f) return;
+    }
+    building_set->AddOccluder(a, b, c, d);
 }
 
 void OcclusionManager::BeginFrame() {
+    if (initialized && enabled) {
+        OccluderSet *completed = building_set;
+        building_set = current_set;
+        current_set = completed;
+        building_set->Clear();
+        unknown_160 = 0;
+        unknown_164 = 0;
+    }
 }
 
 void OcclusionManager::EndFrame() {
 }
 
-void OcclusionManager::Init(u32, variptr_u *, variptr_u) {
+void OcclusionManager::Init(u32 capacity, VARIPTR *buffer, VARIPTR buffer_end) {
+    if (capacity != 0) {
+        sets[0].Init(capacity, buffer, buffer_end);
+        sets[1].Init(capacity, buffer, buffer_end);
+        building_set = &sets[0];
+        current_set = &sets[1];
+        unknown_158 = 0.3f;
+        unknown_15c = -1.0f;
+        initialized = true;
+        enabled = true;
+    }
 }
 
-void OcclusionManager::IsOccludedOBB(nuvec_s const *, nuvec_s const *, numtx_s const *) {
+bool OcclusionManager::IsOccludedOBB(nuvec_s const *minimum, nuvec_s const *maximum, numtx_s const *matrix) {
+    if (!initialized || !enabled) return false;
+    if (!current_set->queries_prepared) {
+        NUMTX *projection = NuCameraGetVPMtx();
+        NUMTX *view = NuCameraGetViewMtx();
+        current_set->PrepareForQueries(view, projection);
+    }
+    ++unknown_164;
+    bool occluded = current_set->IsOccludedOBB(minimum, maximum, matrix);
+    if (occluded) ++unknown_160;
+    return occluded;
 }
 
-void OcclusionManager::IsOccludedSphere(nuvec_s const *, float) {
+bool OcclusionManager::IsOccludedSphere(nuvec_s const *center, float radius) {
+    if (!initialized || !enabled) return false;
+    if (!current_set->queries_prepared) {
+        NUMTX *projection = NuCameraGetVPMtx();
+        NUMTX *view = NuCameraGetViewMtx();
+        current_set->PrepareForQueries(view, projection);
+    }
+    ++unknown_164;
+    bool occluded = current_set->IsOccludedSphere(center, radius);
+    if (occluded) ++unknown_160;
+    return occluded;
 }
 
-OcclusionManager::OcclusionManager() {
+OcclusionManager::OcclusionManager() : initialized(false), enabled(true), building_set(NULL), current_set(NULL),
+    unknown_158(0.3f), unknown_15c(-1.0f) {
 }
 
 void OcclusionManager::OnCameraSet() {
+    if (initialized && enabled) current_set->OnCameraSet();
 }
 
 void OcclusionManager::RenderStats() const {
 }
 
 void OcclusionManager::RenderZPass() const {
+    if (initialized && enabled) current_set->RenderOccluders(true);
 }
 
-void OcclusionManager::SetEnabled(bool) {
+void OcclusionManager::SetEnabled(bool value) {
+    enabled = value;
 }
 
 OcclusionManager::~OcclusionManager() {

--- a/src/nu2api/nu3d/NuRenderDevice.cpp
+++ b/src/nu2api/nu3d/NuRenderDevice.cpp
@@ -89,31 +89,7 @@ NuRenderDevice::NuRenderDevice() : NuRenderDeviceGen() {
 // Optional GLES2 extensions (loaded via eglGetProcAddress)
 // ---------------------------------------------------------------------------
 
-extern "C" {
-void (*glGetProgramBinaryOES)(GLuint, GLsizei, GLsizei *, GLenum *, void *);
-void (*glProgramBinaryOES)(GLuint, GLenum, const void *, GLint);
-void (*glDiscardFramebufferEXT)(GLenum, GLsizei, const GLenum *);
-void (*glGenVertexArraysOES)(GLsizei, GLuint *);
-void (*glBindVertexArrayOES)(GLuint);
-void (*glDeleteVertexArraysOES)(GLsizei, const GLuint *);
-}
-
-__attribute__((weak)) void NuGLES2ExtensionsInit() {
-    glGetProgramBinaryOES = reinterpret_cast<decltype(glGetProgramBinaryOES)>(eglGetProcAddress("glGetProgramBinaryOES"));
-    glProgramBinaryOES = reinterpret_cast<decltype(glProgramBinaryOES)>(eglGetProcAddress("glProgramBinaryOES"));
-    glDiscardFramebufferEXT = reinterpret_cast<decltype(glDiscardFramebufferEXT)>(eglGetProcAddress("glDiscardFramebufferEXT"));
-    glGenVertexArraysOES = reinterpret_cast<decltype(glGenVertexArraysOES)>(eglGetProcAddress("glGenVertexArraysOES"));
-    glBindVertexArrayOES = reinterpret_cast<decltype(glBindVertexArrayOES)>(eglGetProcAddress("glBindVertexArrayOES"));
-    glDeleteVertexArraysOES = reinterpret_cast<decltype(glDeleteVertexArraysOES)>(eglGetProcAddress("glDeleteVertexArraysOES"));
-}
-
-extern "C" void glGenVertexArraysOESC(GLsizei count, GLuint *arrays) {
-    glGenVertexArraysOES(count, arrays);
-}
-
-extern "C" void glDeleteVertexArraysOESC(GLsizei count, const GLuint *arrays) {
-    glDeleteVertexArraysOES(count, arrays);
-}
+void NuGLES2ExtensionsInit();
 
 __attribute__((weak)) void NuRenderInspectEGLConfig(EGLDisplay display, EGLConfig config) {
     EGLint config_attribs[6] = {};

--- a/src/nu2api/nu3d/NuRenderDevice.cpp
+++ b/src/nu2api/nu3d/NuRenderDevice.cpp
@@ -2,6 +2,7 @@
 
 #include "decomp.h"
 #include "globals.h"
+#include "java/native_window.h"
 #include "nu2api/nu3d/nurndr.h"
 #include "nu2api/nu3d/android/nutex_ios_ex.h"
 #include "nu2api/nu3d/nutex.h"
@@ -88,10 +89,30 @@ NuRenderDevice::NuRenderDevice() : NuRenderDeviceGen() {
 // Optional GLES2 extensions (loaded via eglGetProcAddress)
 // ---------------------------------------------------------------------------
 
-// These extension entry points are currently not consumed by reconstructed
-// code. Keep the original initialization seam weak so a backend can restore
-// typed loading when it needs the functions.
+extern "C" {
+void (*glGetProgramBinaryOES)(GLuint, GLsizei, GLsizei *, GLenum *, void *);
+void (*glProgramBinaryOES)(GLuint, GLenum, const void *, GLint);
+void (*glDiscardFramebufferEXT)(GLenum, GLsizei, const GLenum *);
+void (*glGenVertexArraysOES)(GLsizei, GLuint *);
+void (*glBindVertexArrayOES)(GLuint);
+void (*glDeleteVertexArraysOES)(GLsizei, const GLuint *);
+}
+
 __attribute__((weak)) void NuGLES2ExtensionsInit() {
+    glGetProgramBinaryOES = reinterpret_cast<decltype(glGetProgramBinaryOES)>(eglGetProcAddress("glGetProgramBinaryOES"));
+    glProgramBinaryOES = reinterpret_cast<decltype(glProgramBinaryOES)>(eglGetProcAddress("glProgramBinaryOES"));
+    glDiscardFramebufferEXT = reinterpret_cast<decltype(glDiscardFramebufferEXT)>(eglGetProcAddress("glDiscardFramebufferEXT"));
+    glGenVertexArraysOES = reinterpret_cast<decltype(glGenVertexArraysOES)>(eglGetProcAddress("glGenVertexArraysOES"));
+    glBindVertexArrayOES = reinterpret_cast<decltype(glBindVertexArrayOES)>(eglGetProcAddress("glBindVertexArrayOES"));
+    glDeleteVertexArraysOES = reinterpret_cast<decltype(glDeleteVertexArraysOES)>(eglGetProcAddress("glDeleteVertexArraysOES"));
+}
+
+extern "C" void glGenVertexArraysOESC(GLsizei count, GLuint *arrays) {
+    glGenVertexArraysOES(count, arrays);
+}
+
+extern "C" void glDeleteVertexArraysOESC(GLsizei count, const GLuint *arrays) {
+    glDeleteVertexArraysOES(count, arrays);
 }
 
 __attribute__((weak)) void NuRenderInspectEGLConfig(EGLDisplay display, EGLConfig config) {
@@ -161,7 +182,10 @@ void NuRenderDevice::Initialize() {
 
     FrameEnd();
 
-    InitRecursiveMutex(&this->mutex2);
+    pthread_mutexattr_t attrs;
+    pthread_mutexattr_init(&attrs);
+    pthread_mutexattr_settype(&attrs, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&this->mutex2, &attrs);
     NuGLES2ExtensionsInit();
 
     BeginCriticalSection("none", -1);
@@ -172,7 +196,7 @@ void NuRenderDevice::Initialize() {
     //  0x3021 EGL_ALPHA_SIZE, 0x3025 EGL_DEPTH_SIZE, 0x3026 EGL_STENCIL_SIZE.
     NuRenderInspectEGLConfig(this->egl_display, this->egl_config);
 
-    DetermineNominalAspectRatio(this->width, this->height);
+    this->nominal_aspect_ratio = DetermineNominalAspectRatio(this->width, this->height);
     this->aspect_ratio = static_cast<f32>(this->width) / static_cast<f32>(this->height);
 
     glGetIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &this->max_texture_units);
@@ -188,10 +212,10 @@ void NuRenderDevice::Initialize() {
     if (this->extensions != nullptr) {
         const bool dxt1_ext = IsExtensionSupported("EXT_texture_compression_dxt1");
         const bool dxt1_gl = IsExtensionSupported("GL_EXT_texture_compression_dxt1");
-        has_dxt1 = dxt1_ext || dxt1_gl;
-        has_atc = IsExtensionSupported("GL_AMD_compressed_ATC_texture");
-        has_pvrtc = IsExtensionSupported("GL_IMG_texture_compression_pvrtc");
         has_etc1 = IsExtensionSupported("GL_OES_compressed_ETC1_RGB8_texture");
+        has_pvrtc = IsExtensionSupported("GL_IMG_texture_compression_pvrtc");
+        has_dxt1 = dxt1_ext | dxt1_gl;
+        has_atc = IsExtensionSupported("GL_AMD_compressed_ATC_texture");
     }
 
     memset(this->enabled_extensions, 0, sizeof(this->enabled_extensions));
@@ -308,7 +332,8 @@ void NuRenderDevice::OnWindowCreated(ANativeWindow *window) {
 EGLConfig __attribute__((weak)) NuRenderDevice::SelectEGLConfig() {
     // Preferred EGL config: 565 colour, 24-bit depth, GLES2 conformant,
     // pbuffer + window capable.
-    static const EGLint kPreferredAttribs[] = {
+    pthread_mutex_lock(&this->mutex);
+    EGLint attrib_list[] = {
         EGL_DEPTH_SIZE,
         24, //
         EGL_LEVEL,
@@ -332,13 +357,8 @@ EGLConfig __attribute__((weak)) NuRenderDevice::SelectEGLConfig() {
         EGL_NONE,
     };
 
-    pthread_mutex_lock(&this->mutex);
-
-    EGLint attrib_list[sizeof(kPreferredAttribs) / sizeof(kPreferredAttribs[0])];
-    memcpy(attrib_list, kPreferredAttribs, sizeof(kPreferredAttribs));
-
     EGLConfig configs[32];
-    i32 num_configs = 0;
+    i32 num_configs;
     EGLBoolean ok = eglChooseConfig(this->egl_display, attrib_list, configs, 32, &num_configs);
 
     if (num_configs == 0 || ok == EGL_FALSE) {
@@ -390,11 +410,6 @@ void __attribute__((weak)) NuRenderDevice::InitialiseOpenGLContext(ANativeWindow
         this->egl_config = SelectEGLConfig();
 
         this->pbuffers[3] = eglCreateWindowSurface(this->egl_display, this->egl_config, this->native_window, nullptr);
-        if (this->pbuffers[3] == EGL_NO_SURFACE) {
-            LOG_ERR("eglCreateWindowSurface failed: %d", eglGetError());
-            pthread_mutex_unlock(&this->mutex);
-            return;
-        }
 
         this->attrib_list[0] = EGL_CONTEXT_CLIENT_VERSION;
         this->attrib_list[1] = 2;
@@ -405,7 +420,6 @@ void __attribute__((weak)) NuRenderDevice::InitialiseOpenGLContext(ANativeWindow
         // Worker contexts share resources with the main context. When
         // field54_0x54 is set they each get a private 1x1 pbuffer so GL
         // calls don't need the window surface.
-        EGLContext main_ctx = this->contexts[3];
         if (this->field54_0x54) {
             const EGLint pbuffer_attribs[] = {
                 EGL_WIDTH,          1, //
@@ -415,20 +429,20 @@ void __attribute__((weak)) NuRenderDevice::InitialiseOpenGLContext(ANativeWindow
                 EGL_NONE,
             };
             this->pbuffers[0] = eglCreatePbufferSurface(this->egl_display, this->egl_config, pbuffer_attribs);
-            this->contexts[0] = eglCreateContext(this->egl_display, this->egl_config, main_ctx, this->attrib_list);
+            this->contexts[0] = eglCreateContext(this->egl_display, this->egl_config, this->contexts[3], this->attrib_list);
             this->pbuffers[1] = eglCreatePbufferSurface(this->egl_display, this->egl_config, pbuffer_attribs);
-            this->contexts[1] = eglCreateContext(this->egl_display, this->egl_config, main_ctx, this->attrib_list);
+            this->contexts[1] = eglCreateContext(this->egl_display, this->egl_config, this->contexts[3], this->attrib_list);
             this->pbuffers[2] = eglCreatePbufferSurface(this->egl_display, this->egl_config, pbuffer_attribs);
         } else {
             // Alias the window surface.
             this->pbuffers[0] = this->pbuffers[3];
-            this->contexts[0] = eglCreateContext(this->egl_display, this->egl_config, main_ctx, this->attrib_list);
+            this->contexts[0] = eglCreateContext(this->egl_display, this->egl_config, this->contexts[3], this->attrib_list);
             this->pbuffers[1] = this->pbuffers[3];
-            this->contexts[1] = eglCreateContext(this->egl_display, this->egl_config, main_ctx, this->attrib_list);
+            this->contexts[1] = eglCreateContext(this->egl_display, this->egl_config, this->contexts[3], this->attrib_list);
             this->pbuffers[2] = this->pbuffers[3];
         }
 
-        this->contexts[2] = eglCreateContext(this->egl_display, this->egl_config, main_ctx, this->attrib_list);
+        this->contexts[2] = eglCreateContext(this->egl_display, this->egl_config, this->contexts[3], this->attrib_list);
 
         // Make worker 0 current briefly to query the actual window size
         // and set up the nominal backbuffer dimensions.
@@ -441,9 +455,10 @@ void __attribute__((weak)) NuRenderDevice::InitialiseOpenGLContext(ANativeWindow
         this->height = static_cast<u32>(drawable_h);
         DetermineBackBufferResolution(drawable_w, drawable_h);
 
-        EGLint visual_id = 0;
+        EGLint visual_id;
         eglGetConfigAttrib(this->egl_display, this->egl_config, EGL_NATIVE_VISUAL_ID, &visual_id);
-        (void)visual_id;
+        ANativeWindow_setBuffersGeometry(reinterpret_cast<ANativeWindow *>(this->native_window),
+                                        this->backing_width, this->backing_height, visual_id);
         eglMakeCurrent(this->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 
         g_backingWidth = static_cast<i32>(this->backing_width);
@@ -454,12 +469,31 @@ void __attribute__((weak)) NuRenderDevice::InitialiseOpenGLContext(ANativeWindow
         this->context_valid = true;
 
     } else if (this->native_window != window) {
-        // Window was recreated (e.g. orientation change) — tear down the
-        // old window surface. A new one will be created on the next valid
-        // call.
+        // Keep the shared contexts and replace the Android window surface.
         eglMakeCurrent(this->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
         eglDestroySurface(this->egl_display, this->pbuffers[3]);
         eglGetError();
+        this->egl_config = SelectEGLConfig();
+        this->pbuffers[3] = eglCreateWindowSurface(this->egl_display, this->egl_config, window, nullptr);
+        this->native_window = window;
+        if (this->pbuffers[3] != EGL_NO_SURFACE) {
+            if (!eglMakeCurrent(this->egl_display, this->pbuffers[3], this->pbuffers[3], this->contexts[3])) {
+                eglGetError();
+            }
+        }
+        eglMakeCurrent(this->egl_display, this->pbuffers[3], this->pbuffers[3], this->contexts[3]);
+        eglQuerySurface(this->egl_display, this->pbuffers[3], EGL_WIDTH,
+                        reinterpret_cast<EGLint *>(&this->drawable_width));
+        eglQuerySurface(this->egl_display, this->pbuffers[3], EGL_HEIGHT,
+                        reinterpret_cast<EGLint *>(&this->drawable_height));
+        this->width = this->drawable_width;
+        this->height = this->drawable_height;
+        DetermineBackBufferResolution(this->width, this->height);
+        EGLint visual_id;
+        eglGetConfigAttrib(this->egl_display, this->egl_config, EGL_NATIVE_VISUAL_ID, &visual_id);
+        ANativeWindow_setBuffersGeometry(reinterpret_cast<ANativeWindow *>(this->native_window),
+                                        this->backing_width, this->backing_height, visual_id);
+        eglMakeCurrent(this->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
     }
 
     LOG_DEBUG("this->egl_display: %p, this->pbuffers = {%p, %p, %p, %p}, this->contexts = {%p, %p, %p, %p}",
@@ -473,8 +507,82 @@ void NuRenderDevice::CheckForRenderWindowInitialisation() {
     // Once the window is live and focused, transition the application
     // state machine so the engine starts submitting frames.
     if (g_appWindow != 0 && this->field48_0x45 == '\0' && this->focus) {
-        NuCore::GetApplicationState()->SetStatus(NUAPPLICATIONSTATUS{});
+        if (NuCore::GetApplicationState()->GetStatus() != NUAPPLICATIONSTATUS{}) {
+            NuCore::GetApplicationState()->SetStatus(NUAPPLICATIONSTATUS{});
+        }
     }
+}
+
+void NuRenderDevice::OnWindowDestroy() {
+    NuCore::GetApplicationState()->SetStatus(NUAPPLICATIONSTATUS_RENDERING);
+}
+
+void NuRenderDevice::OnAppResume() {
+    field48_0x45 = false;
+    CheckForRenderWindowInitialisation();
+}
+
+void NuRenderDevice::OnAppPaused() {
+    NuCore::GetApplicationState()->SetStatus(NUAPPLICATIONSTATUS_RENDERING);
+    field48_0x45 = true;
+}
+
+void NuRenderDevice::OnGainedFocus() {
+    focus = true;
+    CheckForRenderWindowInitialisation();
+}
+
+void NuRenderDevice::OnLostFocus() {
+    focus = false;
+    NuCore::GetApplicationState()->SetStatus(NUAPPLICATIONSTATUS_RENDERING);
+}
+
+void NuRenderDevice::OnAppStarted() {
+}
+
+void NuRenderDevice::OnAppRestarted() {
+    CheckForRenderWindowInitialisation();
+}
+
+void NuRenderDevice::OnAppStopped() {
+    NuCore::GetApplicationState()->SetStatus(NUAPPLICATIONSTATUS_RENDERING);
+}
+
+bool NuRenderDevice::IsContextValid() const {
+    return context_valid;
+}
+
+bool NuRenderDevice::MultiThreadRender() const {
+    return field50_0x50 == 1 || field50_0x50 == 2;
+}
+
+i32 NuRenderDevice::DetermineNominalAspectRatio(u32 w, u32 h) const {
+    f32 ratio = static_cast<f32>(w) / static_cast<f32>(h);
+    i32 result = 0;
+    f32 error = MIN(fabsf(ratio - 1.3333333730697632f), 1000.0f);
+    f32 widescreen_error = fabsf(ratio - 1.7777777910232544f);
+    if (error > widescreen_error) {
+        error = widescreen_error;
+        result = 1;
+    }
+    if (error > fabsf(ratio - 1.6f)) result = 2;
+    return result;
+}
+
+void NuRenderDevice::ResizeDevice(i32 w, i32 h, i32, bool, bool, bool, bool) {
+    g_renderDevice.BeginCriticalSection("none", -1);
+    width = w;
+    height = h;
+    DetermineBackBufferResolution(w, h);
+    nominal_aspect_ratio = DetermineNominalAspectRatio(width, height);
+    aspect_ratio = static_cast<f32>(width) / static_cast<f32>(height);
+    g_renderDevice.EndCriticalSection("i:/SagaTouch-Android_9176564/nu2api.saga/nu3d/android/NuRenderDevice_gles2.cpp", 0x452);
+}
+
+void NuRenderDevice::PreInitialize() {
+}
+
+void NuRenderDevice::OpenglErrorCallback(u32, u32, u32, u32, i32, char const *, void *) {
 }
 
 // ---------------------------------------------------------------------------
@@ -495,6 +603,10 @@ void EndCriticalSectionGL(const char *file, i32 line) {
 
 void NuRenderDeviceSwapBuffers() {
     g_renderDevice.SwapBuffers();
+}
+
+i32 NuRenderDeviceIsContextValid() {
+    return g_renderDevice.IsContextValid();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/nu2api/nu3d/NuRenderDevice.h
+++ b/src/nu2api/nu3d/NuRenderDevice.h
@@ -93,9 +93,9 @@ class NuRenderDevice : NuRenderDeviceGen {
     void PreInitialize();
     void ResizeDevice(i32 width, i32 height, i32 _a, bool _b, bool _c, bool _d, bool _e);
 
-    void IsContextValid() const;
-    void MultiThreadRender() const;
-    void DetermineNominalAspectRatio(u32 width, u32 height) const;
+    bool IsContextValid() const;
+    bool MultiThreadRender() const;
+    i32 DetermineNominalAspectRatio(u32 width, u32 height) const;
     void OpenglErrorCallback(u32 source, u32 type, u32 id, u32 severity, i32 len, char const *msg, void *user_param);
 };
 
@@ -107,6 +107,7 @@ extern "C" {
     void BeginCriticalSectionGL(const char *file, i32 line);
     void EndCriticalSectionGL(const char *file, i32 line);
     void NuRenderDeviceSwapBuffers(void);
+    i32 NuRenderDeviceIsContextValid(void);
 #ifdef __cplusplus
 }
 #endif

--- a/src/nu2api/nu3d/android/gles_extensions.cpp
+++ b/src/nu2api/nu3d/android/gles_extensions.cpp
@@ -1,0 +1,31 @@
+#include <EGL/egl.h>
+#include <GLES2/gl2.h>
+
+// Android stores these entry points as exported data symbols. Host GL libraries
+// can export functions with the same names, so this table is target-only.
+extern "C" {
+void (*glGetProgramBinaryOES)(GLuint, GLsizei, GLsizei *, GLenum *, void *);
+void (*glProgramBinaryOES)(GLuint, GLenum, const void *, GLint);
+void (*glDiscardFramebufferEXT)(GLenum, GLsizei, const GLenum *);
+void (*glGenVertexArraysOES)(GLsizei, GLuint *);
+void (*glBindVertexArrayOES)(GLuint);
+void (*glDeleteVertexArraysOES)(GLsizei, const GLuint *);
+}
+
+__attribute__((weak)) void NuGLES2ExtensionsInit() {
+    glGetProgramBinaryOES = reinterpret_cast<decltype(glGetProgramBinaryOES)>(eglGetProcAddress("glGetProgramBinaryOES"));
+    glProgramBinaryOES = reinterpret_cast<decltype(glProgramBinaryOES)>(eglGetProcAddress("glProgramBinaryOES"));
+    glDiscardFramebufferEXT = reinterpret_cast<decltype(glDiscardFramebufferEXT)>(eglGetProcAddress("glDiscardFramebufferEXT"));
+    glGenVertexArraysOES = reinterpret_cast<decltype(glGenVertexArraysOES)>(eglGetProcAddress("glGenVertexArraysOES"));
+    glBindVertexArrayOES = reinterpret_cast<decltype(glBindVertexArrayOES)>(eglGetProcAddress("glBindVertexArrayOES"));
+    glDeleteVertexArraysOES = reinterpret_cast<decltype(glDeleteVertexArraysOES)>(eglGetProcAddress("glDeleteVertexArraysOES"));
+}
+
+extern "C" void glGenVertexArraysOESC(GLsizei count, GLuint *arrays) {
+    glGenVertexArraysOES(count, arrays);
+}
+
+extern "C" void glDeleteVertexArraysOESC(GLsizei count, const GLuint *arrays) {
+    glDeleteVertexArraysOES(count, arrays);
+}
+

--- a/src/nu2api/nu3d/android/gles_extensions.cpp
+++ b/src/nu2api/nu3d/android/gles_extensions.cpp
@@ -28,4 +28,3 @@ extern "C" void glGenVertexArraysOESC(GLsizei count, GLuint *arrays) {
 extern "C" void glDeleteVertexArraysOESC(GLsizei count, const GLuint *arrays) {
     glDeleteVertexArraysOES(count, arrays);
 }
-

--- a/src/nu2api/nu3d/android/nuiosdl_gl.cpp
+++ b/src/nu2api/nu3d/android/nuiosdl_gl.cpp
@@ -53,9 +53,8 @@ u32 g_lastAlphaRef = 0;
 u32 g_lastAlphaBlend = 0;
 i32 g_renderingReflection = 0; // original bss @0x99b360 — flips cull when reflecting.
 
-// GLES2 has no VAOs; the original file-static at 0x2a3168 only cached the
-// last-bound handle to avoid redundant binds.
-static u32 g_lastBoundVAO = 0;
+// The original helper at 0x293168 updates the shared renderer cache.
+extern u32 g_lastBoundVAO;
 static void NuIOSBindVAO(u32 vao) {
     if (vao != g_lastBoundVAO) {
         g_lastBoundVAO = vao;
@@ -79,7 +78,7 @@ extern u32 g_readBufferIndex;
 // Refraction texture used by glass debris — lazily allocated.
 static i32 NuIOSDLMtlCallback_refractionRT = 0;                 // @0x99b480
 static NUNATIVETEX NuIOSDLMtlCallback_nativeRefractionTex = {}; // @0x99b4a0
-static i32 NuIOSDLMtlCallback_lastFrameCount = 0;
+static i32 NuIOSDLMtlCallback_lastFrameCount = -1;
 
 // ---------------------------------------------------------------------------
 // Cross-TU imports.
@@ -102,8 +101,8 @@ static inline isize PtrToArgInt(const void *p) {
 }
 
 static inline i32 NuApiFrameCount() {
-    // Original reads *(i32*)(&nuapi + 0x60) directly.
-    return *(i32 *)((u8 *)&nuapi + 0x60);
+    // Original 0x29c90e reads the counter at nuapi + 0x3c.
+    return nuapi.frame_count;
 }
 
 static inline usize ptrToUsize(const void *p) {

--- a/src/nu2api/nu3d/android/nuptl_flush.cpp
+++ b/src/nu2api/nu3d/android/nuptl_flush.cpp
@@ -21,9 +21,9 @@ void *g_DebriSysMemVB[2][64];
 void *g_debrisUploadBuffer;
 u32 g_VBMaxVertexCount;
 u32 g_writeBufferIndex;
-u32 g_readBufferIndex;
+u32 g_readBufferIndex = 1;
 u32 g_CurrentDebriVBIndex;
-u32 g_VBSize = 0x10000;
+u32 g_VBSize;
 u32 g_CurrentVBVertexCount;
 u32 g_FrameVertexCount;
 void *g_lastPartEffect;
@@ -32,8 +32,17 @@ NUMTX *NuRndr_DebrisRotMtxPtr;
 NUVEC4 NuRndr_DebrisPlane;
 nunativedebrisdata_s *g_ParticleGroup;
 
-extern "C" void NuInitDebrisRenderer(VARIPTR *buffer) {
-    const u32 ideal_dynamic_vb_size = 0x10000;
+extern u32 g_lastBoundVAO;
+static u32 g_IdealDynamicVBSize = 0xc800;
+
+static void NuIOSBindVAO(u32 vao) {
+    if (vao != g_lastBoundVAO) {
+        g_lastBoundVAO = vao;
+    }
+}
+
+extern "C" void NuInitDebrisRenderer(VARIPTR *buffer, VARIPTR buffer_end) {
+    u32 ideal_dynamic_vb_size = g_IdealDynamicVBSize;
     g_VBMaxVertexCount = ideal_dynamic_vb_size / 0x18;
     if (NuIOS_IsLowEndDevice() != 0) {
         g_VBMaxVertexCount >>= 1;
@@ -45,18 +54,21 @@ extern "C" void NuInitDebrisRenderer(VARIPTR *buffer) {
             g_DebriSysMemVB[frame][index] = buffer->void_ptr;
             buffer->addr += g_VBSize;
         }
+        BeginCriticalSectionGL("i:/SagaTouch-Android_9176564/nu2api.saga/nu3d/android/nuptl_android.c", 0x8c);
+        NuIOSBindVAO(0);
         glGenBuffers(4, &g_DebriVB[frame * 4]);
         for (i32 index = 0; index < 4; ++index) {
             glBindBuffer(GL_ARRAY_BUFFER, g_DebriVB[frame * 4 + index]);
             glBufferData(GL_ARRAY_BUFFER, g_VBSize, NULL, GL_STREAM_DRAW);
         }
+        EndCriticalSectionGL("i:/SagaTouch-Android_9176564/nu2api.saga/nu3d/android/nuptl_android.c", 0x96);
     }
     g_debrisUploadBuffer = buffer->void_ptr;
     buffer->addr += g_VBSize;
     g_pVBData = g_debrisUploadBuffer;
 }
 
-extern i32 g_forceSysMemVbs; // src/globals.h
+extern bool g_forceSysMemVbs; // src/globals.h
 
 i32 NuDebrisRendererNextBuffer() {
     if (g_UseSysMemVB == 0 && g_pVBData != NULL && g_CurrentVBVertexCount != 0) {
@@ -68,22 +80,26 @@ i32 NuDebrisRendererNextBuffer() {
         EndCriticalSectionGL("i:/SagaTouch-Android_9176564/nu2api.saga/nu3d/android/nuptl_android.c", 0xc9);
     }
 
-    if (g_UseSysMemVB == 0) {
-        if (g_CurrentDebriVBIndex + 1 < 4) {
-            g_CurrentDebriVBIndex = (g_CurrentDebriVBIndex + 1) & 3;
-        } else {
-            g_CurrentDebriVBIndex = 0;
-            g_UseSysMemVB = 1;
-        }
-    } else {
+    if (g_UseSysMemVB != 0) {
         if (g_CurrentDebriVBIndex + 1 >= 64) {
             return 0;
         }
         g_CurrentDebriVBIndex = (g_CurrentDebriVBIndex + 1) & 63;
+    } else {
+        if (g_CurrentDebriVBIndex + 1 >= 4) {
+            g_CurrentDebriVBIndex = 0;
+            g_UseSysMemVB = 1;
+        } else {
+            g_CurrentDebriVBIndex = (g_CurrentDebriVBIndex + 1) & 3;
+        }
     }
 
-    g_pVBData = g_UseSysMemVB == 0 ? g_debrisUploadBuffer : g_DebriSysMemVB[g_writeBufferIndex][g_CurrentDebriVBIndex];
     g_CurrentVBVertexCount = 0;
+    if (g_UseSysMemVB != 0) {
+        g_pVBData = g_DebriSysMemVB[g_writeBufferIndex][g_CurrentDebriVBIndex];
+    } else {
+        g_pVBData = g_debrisUploadBuffer;
+    }
     return 1;
 }
 
@@ -91,14 +107,17 @@ i32 NuDebrisRendererNextBuffer() {
 void NuDebrisRendererFlushBuffers(void) {
     if ((g_UseSysMemVB == 0) && (g_pVBData != NULL) && (g_CurrentVBVertexCount != 0)) {
         BeginCriticalSectionGL("i:/SagaTouch-Android_9176564/nu2api.saga/nu3d/android/nuptl_android.c", 0xa4);
-        glBindBuffer(GL_ARRAY_BUFFER, g_DebriVB[(g_writeBufferIndex * 4 + g_CurrentDebriVBIndex) % 8]);
-        glBufferData(GL_ARRAY_BUFFER, g_VBSize, NULL, GL_DYNAMIC_DRAW); // 0x88e0
+        glBindBuffer(GL_ARRAY_BUFFER, g_DebriVB[g_writeBufferIndex * 4 + g_CurrentDebriVBIndex]);
+        glBufferData(GL_ARRAY_BUFFER, g_VBSize, NULL, GL_STREAM_DRAW);
         glBufferSubData(GL_ARRAY_BUFFER, 0, g_CurrentVBVertexCount * 0x18, g_pVBData);
         EndCriticalSectionGL("i:/SagaTouch-Android_9176564/nu2api.saga/nu3d/android/nuptl_android.c", 0xab);
     }
     g_pVBData = NULL;
     g_CurrentDebriVBIndex = 0;
-    g_UseSysMemVB = (g_forceSysMemVbs != 0);
+    g_UseSysMemVB = 0;
+    if (g_forceSysMemVbs) {
+        g_UseSysMemVB = 1;
+    }
     g_CurrentVBVertexCount = 0;
     g_lastPartEffect = NULL;
     g_FrameVertexCount = 0;

--- a/src/nu2api/nu3d/android/nurenderthread.cpp
+++ b/src/nu2api/nu3d/android/nurenderthread.cpp
@@ -24,6 +24,7 @@
 #include "nu2api/nucore/nuthread.h"
 
 static volatile i32 renderThreadCS;
+i64 getCurrentTime();
 static i32 renderThreadIsLocked;
 pthread_t g_renderThread;
 

--- a/src/nu2api/nu3d/generic/nucamera_gen.cpp
+++ b/src/nu2api/nu3d/generic/nucamera_gen.cpp
@@ -11,6 +11,15 @@
 #include "nu2api/numath/nuvec4.h"
 
 NUCAMERA global_camera;
+NUMTX cmtx = {
+    1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f,
+};
+NUMTX psmtx = {
+    1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f,
+};
+NUMTX vpsmtx = {
+    1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f,
+};
 f32 nucamera_farclip_hack = 0.1f;
 NUMTX pc_vport_mtx = {
     1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f,

--- a/src/nu2api/nu3d/nucamera.h
+++ b/src/nu2api/nu3d/nucamera.h
@@ -23,6 +23,12 @@ typedef struct nucamera_s {
     NUVEC scale;
 } NUCAMERA;
 
+struct NuCameraReflect {
+    u32 unknown_00;
+    NUMTX mtx;
+    u32 unknown_44[16];
+};
+
 typedef struct nuclipplanes_s {
     NUMTX frustum_planes;
     NUMTX scissor_planes;
@@ -79,6 +85,13 @@ extern "C" {
     void NuCameraGetClipMtx(NUMTX *viewport, NUMTX *scissor);
     NUMTX *NuCameraGetProjectionMtx(void);
     NUMTX *NuCameraGetScalingMtx(void);
+    NUMTX *NuCameraGetClippingMtx(void);
+    NUMTX *NuCameraGetPCMtx(void);
+    NUMTX *NuCameraGetPCSMtx(void);
+    NUMTX *NuCameraGetVPCSMtx(void);
+    extern NUMTX cmtx;
+    extern NUMTX psmtx;
+    extern NUMTX vpsmtx;
     NUMTX *NuCameraGetViewMtx(void);
     NUMTX *NuCameraGetVPMtx(void);
     NUMTX *NuCameraGetVPCMtx(void);

--- a/src/nu2api/nu3d/numtl.cpp
+++ b/src/nu2api/nu3d/numtl.cpp
@@ -3,12 +3,15 @@
 #include <string.h>
 
 #include "decomp.h"
+#include "gamelib/util/gamelib_util_types.h"
+#include "nu2api/nu3d/NuRenderDevice.h"
 #include "nu2api/nu3d/android/nuvertexformat_android.h"
 #include "nu2api/nu3d/nurndr.h"
 #include "nu2api/nu3d/nushader.h"
 #include "nu2api/nu3d/nutex.h"
 #include "nu2api/nucore/common.h"
 #include "nu2api/nufile/nufile.h"
+#include "nu2api/nufile/nu2api_nufile_types.h"
 
 // Shader manager API (transcribed in nushadermanager_plain.cpp).
 extern "C" void *NuShaderManagerRetrieveShader(NUSHADERMTLDESC *desc, void *mtl);
@@ -34,11 +37,57 @@ void NuMtlInitEx(VARIPTR *buf, i32 mtl_count) {
     max_materials = mtl_count;
     material_list = (NUMTL *)ALIGN(buf->addr, 0x10);
     buf->addr = (usize)material_list + mtl_count * sizeof(NUMTL);
+    memset(material_list, 0, mtl_count * sizeof(NUMTL));
+    numtl_defaultmtl3d = NuMtlCreate3D(1);
+    numtl_defaultmtl2d = NuMtlCreate(1);
 
-    // Original 0x2f2773: platform texture setup is part of material-system
-    // initialization.  Besides the two environment maps this creates the
-    // 1x1 white fallback used whenever a display-list texture is absent.
+    NUSHADERMTLDESC desc2d;
+    memset(&desc2d, 0, sizeof(desc2d));
+    desc2d.byte4 |= 0x10;
+    desc2d.flags = 0x1000;
+    desc2d.diffuse_color[0] = 0xffffffff;
+    desc2d.unknown_24 = 1.0f;
+    desc2d.vtx_desc.has_position = 1;
+    desc2d.vtx_desc.has_diffuse = 1;
+    desc2d.vtx_desc.has_no_transform = 1;
+    NUSHADERMTLDESC desc3d;
+    memset(&desc3d, 0, sizeof(desc3d));
+    desc3d.byte4 |= 0x10;
+    desc3d.flags = 0x1000;
+    desc3d.diffuse_color[0] = 0xffffffff;
+    desc3d.unknown_24 = 1.0f;
+    desc3d.vtx_desc.has_position = 1;
+    desc3d.vtx_desc.has_diffuse = 1;
+    NuMtlSetShaderDescPS(numtl_defaultmtl2d, &desc2d);
+    NuMtlSetShaderDescPS(numtl_defaultmtl3d, &desc3d);
+
+    char package_path[512];
+    i32 package = AndroidOBBUtils::LookupPackagePath(package_path, NuFileDeviceAndroidOBBType::MAIN);
+    if (package == 1) {
+        NuDatSet(NuDatOpen(package_path, buf, NULL));
+    } else if (package == 2) {
+        if (g_apkFileDevice == NULL) {
+            NuFile::InitData init = {};
+            g_apkFileDevice = new NuFileDeviceAndroidAPK("apk:", init);
+            NuDatSet(NuDatOpen(package_path, buf, NULL));
+        }
+    }
+    package = AndroidOBBUtils::LookupPackagePath(package_path, NuFileDeviceAndroidOBBType::PATCH);
+    if (package == 1) {
+        NuDatSet(NuDatOpen(package_path, buf, NULL));
+    } else if (package == 2) {
+        if (g_apkFileDevice == NULL) {
+            NuFile::InitData init = {};
+            g_apkFileDevice = new NuFileDeviceAndroidAPK("apk:", init);
+            NuDatSet(NuDatOpen(package_path, buf, NULL));
+        }
+    }
+    BeginCriticalSectionGL("i:/SagaTouch-Android_9176564/nu2api.saga/nu3d/numtl_gen.c", 0xd5);
     NuTexInitExPS(buf);
+    numtl_defaultmtl2d->attribs.alpha_mode = 1;
+    NuMtlUpdate(numtl_defaultmtl2d);
+    NuMtlUpdate(numtl_defaultmtl3d);
+    EndCriticalSectionGL("i:/SagaTouch-Android_9176564/nu2api.saga/nu3d/numtl_gen.c", 0xee);
 }
 
 void DefaultMtl(NUMTL *mtl) {

--- a/src/nu2api/nu3d/nuocclusion.cpp
+++ b/src/nu2api/nu3d/nuocclusion.cpp
@@ -1,6 +1,8 @@
 #include "nu2api/nu3d/nuocclusion.h"
 
 #include "decomp.h"
+#include "legoapi/legoapi_types.h"
 
 void NuOcclusionManagerBeginFrame(void) {
+    g_OcclusionManager.BeginFrame();
 }

--- a/src/nu2api/nu3d/nuocclusion.h
+++ b/src/nu2api/nu3d/nuocclusion.h
@@ -1,9 +1,12 @@
 #pragma once
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
     void NuOcclusionManagerBeginFrame(void);
+    bool NuOcclusionManagerIsInitialised(void);
+    void NuOcclusionManagerOnCameraSet(void);
 #ifdef __cplusplus
 }
 #endif

--- a/src/nu2api/nu3d/nuqfnt.cpp
+++ b/src/nu2api/nu3d/nuqfnt.cpp
@@ -433,6 +433,8 @@ u8 sysfont[] = {
 NUQFNT *system_qfont;
 
 NUQFNT_CSMODE NuQFntCSMode;
+i32 NuQFntCSModeStackIndex;
+NUQFNT_CSMODE NuQFntCSModeStack[16];
 
 f32 qfnt_rezscale_w = 1.0f;
 f32 qfnt_rezscale_h = 1.0f;

--- a/src/nu2api/nu3d/nuqfnt.h
+++ b/src/nu2api/nu3d/nuqfnt.h
@@ -77,6 +77,11 @@ i32 NuQFntReadPS(VUFNT *font, i32 tex_id, i32 flags, i32 render_plane, VARIPTR *
 extern "C" {
 #endif
     extern NUQFNT_CSMODE NuQFntCSMode;
+    extern i32 NuQFntCSModeStackIndex;
+    extern NUQFNT_CSMODE NuQFntCSModeStack[16];
+    NUQFNT_CSMODE NuQFntGetCoordinateSystem(void);
+    void NuQFntPushCoordinateSystem(NUQFNT_CSMODE mode);
+    void NuQFntPopCoordinateSystem(void);
 
     extern f32 qfnt_rezscale_w;
     extern f32 qfnt_rezscale_h;
@@ -120,6 +125,11 @@ extern "C" {
     void NuQFntPrintU(NUQFNT *font, char *text);
     void NuQFntPushPrintMode(u32 mode);
     void NuQFntPopPrintMode(void);
+    f32 NuQFntHeightScale(void);
+    f32 NuQFntLenScale(void);
+    void NuQFntMove2d(NUQFNT *font, f32 x, f32 y, f32 z);
+    void NuQFntPrint2dU(NUQFNT *font, char *text);
+    void NuQFntSetColour2d(NUQFNT *font, u32 colour);
     void NuQFntSetSpaceWidth(NUQFNT *font, f32 width);
     u16 NuQFntEncodeUnicodeChar(NUQFNT *font, u16 character);
     NUQFNT *NuQFntLoadPtr(char *path, char *name, i32 flags, i32 render_plane, VARIPTR *buf, VARIPTR *buf_end);

--- a/src/nu2api/nu3d/nurndr.h
+++ b/src/nu2api/nu3d/nurndr.h
@@ -59,7 +59,7 @@ extern "C" {
     i32 NuRndrSetDirectionalLightsPS(const NUVEC *dir0, const NUCOLOUR3 *colour0, const NUVEC *dir1,
                                      const NUCOLOUR3 *colour1, const NUVEC *dir2, const NUCOLOUR3 *colour2);
     i32 NuRndrSetFxMtx(NUMTX *matrix);
-    void NuRndrSetSpecularLightPS(const NUVEC *direction, const NUCOLOUR4 *intensity);
+    i32 NuRndrSetSpecularLightPS(const NUVEC *direction, const NUCOLOUR4 *intensity);
     void NuRndrStartReflectionRender(i32 clear_depth);
     void NuRndrEndReflectionRender(void);
 

--- a/src/nu2api/nu3d/nurndr_plain.cpp
+++ b/src/nu2api/nu3d/nurndr_plain.cpp
@@ -23,6 +23,8 @@
 // recovered, so they are left as `void(void)`.
 
 #include <string.h>
+#include <float.h>
+#include "nu2api/numath/nufloat.h"
 
 #include "decomp.h"
 #include "legoapi/legoapi_types.h"
@@ -67,7 +69,7 @@ extern "C" {
 } // extern "C"
 
 // Swap/present pacing flags (original BSS).
-i32 g_isBlockedInSwapScreen = 0;
+volatile bool g_isBlockedInSwapScreen = false;
 i32 rndr_blend_shape_deformer_wt_cnt = 0;
 i32 rndr_blend_shape_deformer_wt_ptrs_cnt = 0;
 
@@ -324,7 +326,7 @@ extern "C" void NuRndrEndSceneEx(i32) {
 
 // Original 0x2967db — swap display-list and stream buffers, kick the render
 // thread, then pace the game thread until the app leaves the running state.
-extern "C" __attribute__((weak)) i32 NuRndrSwapScreen(void) {
+extern "C" __attribute__((weak)) i32 NuRndrSwapScreen(i32 /*mode*/) {
     NuRenderThreadLock();
     rndr_blend_shape_deformer_wt_cnt = 0x3f00;
     rndr_blend_shape_deformer_wt_ptrs_cnt = 0x800;
@@ -339,7 +341,7 @@ extern "C" __attribute__((weak)) i32 NuRndrSwapScreen(void) {
     NuRenderThreadUnlock();
     NuRenderThreadStartRender();
 
-    // Spin until the application status is no longer "running" (1).
+    // Status 1 suspends presentation until the lifecycle makes the app active.
     // On Android this is released by the activity lifecycle
     // (nativeSetSurface / nativeOnPause flip NUAPPLICATIONSTATUS).
     for (;;) {
@@ -356,11 +358,11 @@ extern "C" __attribute__((weak)) i32 NuRndrSwapScreen(void) {
 }
 
 // Original 0x296888
-extern "C" void NuRndrSwapScreenEx(i32 /*mode*/, void (*callback)(void)) {
+extern "C" i32 NuRndrSwapScreenEx(i32 mode, void (*callback)(void)) {
     if (callback != nullptr) {
         callback();
     }
-    NuRndrSwapScreen();
+    return NuRndrSwapScreen(mode);
 }
 
 // ---------------------------------------------------------------------------
@@ -781,8 +783,8 @@ extern "C" void NuRndrSetGlobalMipMapBias(void) {
 extern "C" void NuRndrSetParticleRotation(NUMTX *rotation) {
     NuRndr_DebrisRotMtxPtr = rotation;
 }
-extern "C" void NuRndrSetSpecularLightPS(const NUVEC *, const NUCOLOUR4 *) {
-}
+extern "C" void NuRndrStateSetSpecularLightEx(NUVEC *, NUMTX *, const NUCOLOUR4 *);
+
 extern "C" void NuRndrSetWind(void) {
 }
 extern "C" void NuRndrShadPolys(void *) {
@@ -811,7 +813,15 @@ extern "C" void NuRndrStateInit(void) {
 }
 extern "C" void NuRndrStateSetSpecularLight(void) {
 }
-extern "C" void NuRndrStateSetSpecularLightEx(void) {
+extern "C" void NuRndrStateSetSpecularLightEx(NUVEC *direction, NUMTX *matrix, const NUCOLOUR4 *colour) {
+    render_state.specular_mtx = *matrix;
+    render_state.specular_colour.r = colour->r;
+    render_state.specular_colour.g = colour->g;
+    render_state.specular_colour.b = colour->b;
+    render_state.specular_intensity = *direction;
+    render_state.light_state = NULL;
+    render_state.state.global_id++;
+    render_state.state.lights_id++;
 }
 extern "C" void NuRndrStateUpdateCameraState(void) {
     NUMTX *projection = NuCameraGetProjectionMtx();
@@ -889,7 +899,7 @@ extern "C" void DisplayListUpdateRenderState(void *display_list, void *state) {
             VARIPTR *buffer = NuDisplayListGetBuffer();
             auto *packet = static_cast<CameraPacket *>(buffer->void_ptr);
             global->camera_state = packet;
-            packet->id = *reinterpret_cast<i32 *>(&nuapi.field19_0x3c) +
+            packet->id = nuapi.frame_count +
                          (global->state.camera_id + 5) * (global->state.global_id + 13);
             packet->view = global->view;
             memset(&packet->projection, 0, sizeof(packet->projection));

--- a/src/nu2api/nu3d/nurndr_specular.cpp
+++ b/src/nu2api/nu3d/nurndr_specular.cpp
@@ -1,0 +1,73 @@
+#include "nu2api/nu3d/nurndr.h"
+#include "nu2api/nu3d/nucamera.h"
+#include "nu2api/numath/numtx.h"
+#include "nu2api/numath/nuvec.h"
+#include "nu2api/numath/nufloat.h"
+#include <float.h>
+extern "C" void NuRndrStateSetSpecularLightEx(NUVEC *, NUMTX *, const NUCOLOUR4 *);
+
+extern "C" i32 NuRndrSetSpecularLightPS(const NUVEC *direction, const NUCOLOUR4 *intensity) {
+    static NUVEC rndrstream_specular_dir = {0.0f, 0.0f, 1.0f};
+    static NUCOLOUR4 rndrstream_specular_intensity = {1.0f, 1.0f, 1.0f, 1.0f};
+    static NUVEC camvec = {0.0f, 0.0f, -1.0f};
+    if (direction != NULL) rndrstream_specular_dir = *direction;
+    if (intensity != NULL) rndrstream_specular_intensity = *intensity;
+    NUVEC view_direction, half_direction, light_direction, eye_direction;
+    NuVecInvMtxRotate(&view_direction, &rndrstream_specular_dir, &global_camera.mtx);
+    NuVecLerp(&half_direction, &view_direction, &camvec, 0.5f);
+    NuVecMtxRotate(&half_direction, &half_direction, &global_camera.mtx);
+    NuVecNorm(&half_direction, &half_direction);
+    NuVecNorm(&light_direction, &rndrstream_specular_dir);
+    eye_direction.x = -global_camera.mtx.m20;
+    eye_direction.y = -global_camera.mtx.m21;
+    eye_direction.z = -global_camera.mtx.m22;
+    f32 facing = NuVecDot(&eye_direction, &light_direction);
+    NUVEC axis = half_direction;
+    NUMTX matrix = numtx_identity;
+    f32 horizontal = NuFsqrt(axis.x * axis.x + axis.z * axis.z);
+    if (horizontal > FLT_MIN) {
+        matrix.m00 = axis.z / horizontal;
+        matrix.m10 = (axis.x * axis.y) / horizontal;
+        matrix.m20 = -axis.x;
+        matrix.m01 = 0.0f;
+        matrix.m11 = horizontal;
+        matrix.m21 = axis.y;
+        matrix.m02 = axis.x / horizontal;
+        matrix.m12 = (axis.z * -axis.y) / horizontal;
+        matrix.m22 = axis.z;
+    } else {
+        matrix.m22 = matrix.m11 = 0.0f;
+        matrix.m21 = axis.y;
+        matrix.m12 = -axis.y;
+    }
+    matrix.m30 = matrix.m31 = 0.5f;
+    if (0.0f > facing) {
+        f32 weight = facing * facing;
+        weight *= weight;
+        weight *= weight;
+        weight *= weight;
+        weight *= weight;
+        f32 remainder = 1.0f - weight;
+        if (matrix.m00 * light_direction.x + matrix.m10 * light_direction.y + matrix.m20 * light_direction.z >= 0.0f) {
+            matrix.m00 = matrix.m00 * remainder + light_direction.x * weight;
+            matrix.m10 = matrix.m10 * remainder + light_direction.y * weight;
+            matrix.m20 = matrix.m20 * remainder + light_direction.z * weight;
+        } else {
+            matrix.m00 = matrix.m00 * remainder - light_direction.x * weight;
+            matrix.m10 = matrix.m10 * remainder - light_direction.y * weight;
+            matrix.m20 = matrix.m20 * remainder - light_direction.z * weight;
+        }
+        if (matrix.m01 * light_direction.x + matrix.m11 * light_direction.y + matrix.m21 * light_direction.z >= 0.0f) {
+            matrix.m01 = matrix.m01 * remainder + light_direction.x * weight;
+            matrix.m11 = matrix.m11 * remainder + light_direction.y * weight;
+            matrix.m21 = matrix.m21 * remainder + light_direction.z * weight;
+        } else {
+            matrix.m01 = matrix.m01 * remainder - light_direction.x * weight;
+            matrix.m11 = matrix.m11 * remainder - light_direction.y * weight;
+            matrix.m21 = matrix.m21 * remainder - light_direction.z * weight;
+        }
+    }
+    NuVecNeg(&view_direction, &view_direction);
+    NuRndrStateSetSpecularLightEx(&view_direction, &matrix, &rndrstream_specular_intensity);
+    return 1;
+}

--- a/src/nu2api/nu3d/nuscreen.hpp
+++ b/src/nu2api/nu3d/nuscreen.hpp
@@ -13,6 +13,7 @@ class NuScreen {
     ~NuScreen();
 
     static bool Exists();
+    static NuScreen *Get() { return ms_instance; }
     static void Create();
 
     void Destroy();

--- a/src/nu2api/nuandroid/ios_graphics.cpp
+++ b/src/nu2api/nuandroid/ios_graphics.cpp
@@ -135,16 +135,16 @@ static i32 g_awaitingRenderWake;
 static i32 g_wakeRenderThread;
 static i32 g_renderThreadDoneThread;
 
-// Timestamp (ms) when the current frame's render was kicked — original
+// Timestamp when the current frame's render was kicked — original
 // @0x66c9a8, set in NuIOS_WakeRenderThread and sampled in
 // NuIOS_WaitForRenderThreadCompletion for 60 Hz pacing.
 i64 g_renderStartTime;
 
-// original 0xe3450 — monotonic millisecond clock.
-i64 getCurrentTime(void) {
+// Original 0xe3450 adds raw nanoseconds to seconds scaled by 1000.
+extern "C" i64 getCurrentTime(void) {
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
-    return (i64)ts.tv_sec * 1000 + (i64)ts.tv_nsec / 1000000;
+    return (i64)ts.tv_sec * 1000 + (i64)ts.tv_nsec;
 }
 
 void NuIOS_InitRenderThread() {

--- a/src/nu2api/nuandroid/ios_graphics.h
+++ b/src/nu2api/nuandroid/ios_graphics.h
@@ -31,8 +31,6 @@ extern "C" {
     void NuIOS_WaitForRenderThreadCompletion(void);
     void NuIOS_WakeRenderThread(void);
 
-    // original 0xe3450
-    i64 getCurrentTime(void);
     extern i64 g_renderStartTime; // @0x66c9a8
 #ifdef __cplusplus
 }

--- a/src/nu2api/nucore/NuDeviceSpecs.h
+++ b/src/nu2api/nucore/NuDeviceSpecs.h
@@ -1,7 +1,3 @@
 #pragma once
 
-struct NuDeviceSpecs {
-    void Exists();
-    NuDeviceSpecs();
-    ~NuDeviceSpecs();
-};
+#include "nu2api/nuplatform/nudevicespecs.hpp"

--- a/src/nu2api/nucore/NuInputDevice.h
+++ b/src/nu2api/nucore/NuInputDevice.h
@@ -218,5 +218,5 @@ namespace NuInputDevicePS {
     void GetIdentifierPS(u32);
     void HandleGamePadAxis_ANDROID_SPECIFIC(float, float, float, float, float, float);
     void HandleSensor_ANDROID_SPECIFIC(i32, float, float, float);
-    void HandleTouch_ANDROID_SPECIFIC(i32, i32, i32, float, float);
+    i32 HandleTouch_ANDROID_SPECIFIC(i32, i32, i32, float, float);
 }; // namespace NuInputDevicePS

--- a/src/nu2api/nucore/NuMemoryManager.h
+++ b/src/nu2api/nucore/NuMemoryManager.h
@@ -274,7 +274,9 @@ class NuMemoryManager {
     void StatsAddFragment(FreeHeader *header);
     void StatsRemoveFragment(FreeHeader *header);
 
+  public:
     u32 CalculateLargestFragmentSize();
+  private:
     u32 CalculateFreeBytes();
 
     FreeHeader *FindLargestFragment();

--- a/src/nu2api/nucore/NuVoiceAndroid.h
+++ b/src/nu2api/nucore/NuVoiceAndroid.h
@@ -1,27 +1,3 @@
 #pragma once
 
-struct NuSoundSource;
-struct NuSoundBuffer;
-struct SLPlayItf_;
-
-struct NuVoiceAndroid {
-    void ApplyHardwareVoiceMix();
-    void CreateHardwareVoice();
-    void DestroyHardwareVoice();
-    void GetInterfaces();
-    void GetPlaybackPositionSamples();
-    NuVoiceAndroid(NuSoundSource *, bool);
-    void OnPlayerEvent(u32);
-    void PauseHardwareVoice();
-    void PlayerCallback(SLPlayItf_ const *const *, void *, u32);
-    void RealiseObject();
-    void ResumeHardwareVoice();
-    void StartHardwareVoice();
-    void StopHardwareVoice();
-    void SubmitBuffer(NuSoundBuffer *);
-    void UpdateHardwareVoice(float);
-    void UpdateQueue();
-    void UpdateSamplePlaybackCount();
-    void UpdateState();
-    virtual ~NuVoiceAndroid();
-};
+class NuVoiceAndroid;

--- a/src/nu2api/nucore/android/NuInputDevice_android.cpp
+++ b/src/nu2api/nucore/android/NuInputDevice_android.cpp
@@ -1,6 +1,9 @@
 #include "nu2api/nucore/android/NuInputDevice_android.h"
 
 #include <pthread.h>
+#include <math.h>
+#include "globals.h"
+#include "java/native_window.h"
 
 #include "nu2api/nucore/NuInputDevice.h"
 #include "nu2api/nucore/common.h"
@@ -12,15 +15,75 @@ namespace NuInputDevicePS {
     u32 m_padButtons;
 
     pthread_mutex_t m_touchEventQueueCriticalSection;
+    struct TouchEvent {
+        i32 type;
+        i32 device;
+        i32 touch;
+        f32 x;
+        f32 y;
+    };
+    TouchEvent m_touchEventQueue[256];
+    i32 m_touchEventQueueSize;
+    bool m_classInitCalled;
+    NuInputTouchData m_touchDataR;
+    NuInputTouchData m_touchDataW;
+    bool m_touchActive[10];
+    f32 m_gamePadAxis[8];
+    f32 m_acceleration[3];
+    f32 m_sensorPitch;
+    f32 m_sensorRoll;
 
     u32 ClassInitPS(void) {
-        return 0;
+        memset(&m_touchDataR, 0, sizeof(m_touchDataR));
+        memset(&m_touchDataW, 0, sizeof(m_touchDataW));
+        memset(m_touchActive, 0, sizeof(m_touchActive));
+        m_classInitCalled = true;
+        for (i32 i = 0; i < 8; ++i) m_gamePadAxis[i] = 0.0f;
+        return 2;
     }
 
     void ClassShutdownPS(void) {
     }
 
     void UpdateAllPS(f32 delta_time) {
+        if (g_appWindow != NULL) {
+            f32 width = ANativeWindow_getWidth(g_appWindow);
+            f32 height = ANativeWindow_getHeight(g_appWindow);
+            pthread_mutex_lock(&m_touchEventQueueCriticalSection);
+            for (i32 i = 0; i != m_touchEventQueueSize; ++i) {
+                const TouchEvent &event = m_touchEventQueue[i];
+                switch (event.type) {
+                case 0:
+                    m_touchDataW.touch_events[event.device].unknown_14 = event.touch;
+                    m_touchDataW.touch_events[event.device].unknown_04 = event.x / width;
+                    m_touchDataW.touch_events[event.device].unknown_08 = event.y / height;
+                    m_touchActive[event.device] = true;
+                    break;
+                case 1:
+                    m_touchActive[event.device] = false;
+                    break;
+                case 2:
+                    m_touchDataW.touch_events[event.device].unknown_04 = event.x / width;
+                    m_touchDataW.touch_events[event.device].unknown_08 = event.y / height;
+                    break;
+                }
+            }
+            m_touchEventQueueSize = 0;
+            pthread_mutex_unlock(&m_touchEventQueueCriticalSection);
+            m_touchDataR.touch_count = 0;
+            u32 count = 0;
+            for (i32 i = 0; i < 10; ++i) {
+                if (m_touchActive[i]) {
+                    m_touchDataR.touch_events[count].unknown_04 = m_touchDataW.touch_events[i].unknown_04;
+                    m_touchDataR.touch_events[count].unknown_08 = m_touchDataW.touch_events[i].unknown_08;
+                    m_touchDataR.touch_events[count].unknown_14 = m_touchDataW.touch_events[i].unknown_14;
+                    ++count;
+                }
+            }
+            m_touchDataR.touch_count = count;
+        }
+        m_sensorPitch = atan2f(m_acceleration[0], m_acceleration[2]) * 0.31830987334251404f * -0.5f;
+        m_sensorRoll = asin(m_acceleration[1]) * 0.15915493667125702;
     }
 
     void HandleGamepPadStatusConnect(bool is_connected) {
@@ -79,19 +142,76 @@ namespace NuInputDevicePS {
     }
 
     void ReadAnalogValuesPS(u32 port, f32 *values) {
+        if (port == 1) {
+            memset(values, 0, 12 * sizeof(f32));
+            values[10] = m_gamePadAxis[2];
+            values[11] = m_gamePadAxis[3];
+            f32 x = m_gamePadAxis[0] + m_gamePadAxis[6];
+            values[8] = MAX(-1.0f, (MIN(x, 1.0f)));
+            f32 y = m_gamePadAxis[1] + m_gamePadAxis[7];
+            values[9] = MAX(-1.0f, (MIN(y, 1.0f)));
+            values[6] = m_gamePadAxis[4];
+            values[7] = m_gamePadAxis[5];
+        }
     }
 
     void ReadMotionValuesPS(u32 port, f32 *values) {
+        if (port == 1) {
+            memset(values, 0, 20 * sizeof(f32));
+            values[1] = m_sensorPitch;
+            values[0] = m_sensorRoll;
+        }
     }
 
     void ReadTouchDataPS(u32 port, NuInputTouchData *data) {
+        if (port == 0) memcpy(data, &m_touchDataR, sizeof(*data));
     }
 
     void ReadMouseDataPS(u32 port, NuInputMouseData *data) {
+        memset(data, 0, sizeof(*data));
     }
 
     u32 GetGamePadButtonIndex(i32 key, i32 *port) {
-        return {};
+        *port = 0;
+        u32 button = 0;
+        switch (key) {
+        case 3: case 108: *port = 1; button = 0x800; break;
+        case 4: button = 0x80000000; break;
+        case 19: case 20: case 21: case 22:
+        case 102: case 103: case 106: case 107: *port = 1; break;
+        case 96: *port = 1; button = 0x40; break;
+        case 97: *port = 1; button = 0x20; break;
+        case 99: *port = 1; button = 0x80; break;
+        case 100: *port = 1; button = 0x10; break;
+        }
+        return button;
+    }
+
+    i32 HandleTouch_ANDROID_SPECIFIC(i32 type, i32 device, i32 touch, f32 x, f32 y) {
+        pthread_mutex_lock(&m_touchEventQueueCriticalSection);
+        TouchEvent &event = m_touchEventQueue[m_touchEventQueueSize];
+        event.type = type;
+        event.device = device;
+        event.touch = touch;
+        event.x = x;
+        event.y = y;
+        ++m_touchEventQueueSize;
+        pthread_mutex_unlock(&m_touchEventQueueCriticalSection);
+        return 0;
+    }
+
+    void HandleGamePadAxis_ANDROID_SPECIFIC(f32 x, f32 y, f32 z, f32 rz, f32 left, f32 right) {
+        pthread_mutex_lock(&m_touchEventQueueCriticalSection);
+        m_gamePadAxis[0] = z;
+        m_gamePadAxis[1] = rz;
+        m_gamePadAxis[2] = left;
+        m_gamePadAxis[3] = right;
+        m_gamePadAxis[6] = x;
+        m_gamePadAxis[7] = y;
+        pthread_mutex_unlock(&m_touchEventQueueCriticalSection);
+    }
+
+    void HandleSensor_ANDROID_SPECIFIC(i32, f32, f32, f32) {
     }
 
     void HandleKeyDown_ANDROID_SPECIFIC(i32 key) {

--- a/src/nu2api/nucore/android/NuThread_android.cpp
+++ b/src/nu2api/nucore/android/NuThread_android.cpp
@@ -95,8 +95,8 @@ void *NuThread::ThreadMain(void *thread) {
 
     jni_env = NULL;
 
-    g_javaVM.GetEnv((void **)&jni_env, JNI_VERSION_1_4);
-    g_javaVM.AttachCurrentThread(&jni_env, NULL);
+    g_javaVM->GetEnv((void **)&jni_env, JNI_VERSION_1_4);
+    g_javaVM->AttachCurrentThread(&jni_env, NULL);
 
     self = ((NuThread *)thread);
     g_currentThread = self;
@@ -112,7 +112,7 @@ void *NuThread::ThreadMain(void *thread) {
 
     delete self;
 
-    g_javaVM.DetachCurrentThread();
+    g_javaVM->DetachCurrentThread();
 
     return NULL;
 }

--- a/src/nu2api/nucore/android/nuapi_android.cpp
+++ b/src/nu2api/nucore/android/nuapi_android.cpp
@@ -11,7 +11,7 @@
 #include "nu2api/nusound/nusound.h"
 
 extern "C" void NuRenderContextInit(void);
-extern "C" void NuInitDebrisRenderer(VARIPTR *buffer);
+extern "C" void NuInitDebrisRenderer(VARIPTR *buffer, VARIPTR buffer_end);
 extern "C" void NuIOSMtlInit(void);
 
 void InitializeGLMutex(void) {
@@ -30,7 +30,7 @@ i32 NuInitHardwarePS(VARIPTR *buf, VARIPTR *buf_end, i32 heap_size) {
 
     BeginCriticalSectionGL("i:/SagaTouch-Android_9176564/nu2api.saga/nucore/android/nuapi_android.c", 0xf9);
     NuIOSMtlInit();
-    NuInitDebrisRenderer(buf);
+    NuInitDebrisRenderer(buf, *buf_end);
     EndCriticalSectionGL("i:/SagaTouch-Android_9176564/nu2api.saga/nucore/android/nuapi_android.c", 0xfe);
 
     NuRenderThreadCreate();

--- a/src/nu2api/nucore/nu2api_nucore_misc.cpp
+++ b/src/nu2api/nucore/nu2api_nucore_misc.cpp
@@ -14,6 +14,8 @@
 
 #include <GLES2/gl2.h>
 #include <string.h>
+#include <stdio.h>
+#include <math.h>
 
 extern "C" void BeginCriticalSectionGL(const char *, i32);
 extern "C" void EndCriticalSectionGL(const char *, i32);
@@ -52,7 +54,8 @@ void NuMemDumpFn(i32) {
 void NuDDSGetSize(char const *) {
 }
 
-void NuErrorPrint(char *) {
+void NuErrorPrint(char *message) {
+    printf("%s", message);
 }
 
 void NuFntFindEnd(nutex_s *, i32 *, i32 *, i32, i32) {
@@ -64,7 +67,10 @@ void NuMemFlushFn() {
 void NuBridgeAlloc() {
 }
 
-void NuWindFreeGrp(NuWindGType *) {
+void NuWindFreeGrp(NuWindGType *group) {
+    if (group != NULL) {
+        group->in_use = 0;
+    }
 }
 
 extern "C" void *NuAnimBuffCreate(i32 max_joints, variptr_u *buf);
@@ -92,7 +98,8 @@ void NuASin_Accurate(float) {
 void NuBez3EvaluateX(nuvec4_s *, float) {
 }
 
-void NuDebugMsgPrint(char *) {
+void NuDebugMsgPrint(char *message) {
+    printf("%s", message);
 }
 
 // original 0x2955ee -- lightmap display-list packet.  Mode 1 installs one
@@ -184,8 +191,6 @@ void NuLgtArcLaserDraw(i32) {
 void NuVpSetSourceRect(float, float, float, float) {
 }
 
-void NuWindAllocateGrp() {
-}
 
 void NuFadeObjAllocData(i32) {
 }
@@ -870,7 +875,8 @@ void NuOnlineSetDefaultPresenceModeProfilePS(i32, i32) {
 void NuATanf(float) {
 }
 
-void NuATan2f(float, float) {
+f32 NuATan2f(float y, float x) {
+    return atan2f(y, x);
 }
 
 void NuFntSave(nufnt_s *, i32, char *) {

--- a/src/nu2api/nucore/nu2api_nucore_types.h
+++ b/src/nu2api/nucore/nu2api_nucore_types.h
@@ -128,7 +128,7 @@ struct NuInputTouchData;
 struct NuSoundBuffer;
 struct NuSoundSource;
 struct NuSymbolQuery {};
-struct NuWindGType {};
+#include "gamelib/nuwind/nuwind.h"
 struct SLPlayItf_ {};
 struct ShaderObjectKey;
 struct VuMtx;
@@ -194,7 +194,7 @@ struct NuInputDevicePS {
     void GetIdentifierPS(u32);
     void HandleGamePadAxis_ANDROID_SPECIFIC(float, float, float, float, float, float);
     void HandleSensor_ANDROID_SPECIFIC(i32, float, float, float);
-    void HandleTouch_ANDROID_SPECIFIC(i32, i32, i32, float, float);
+    i32 HandleTouch_ANDROID_SPECIFIC(i32, i32, i32, float, float);
 };
 struct NuInputManager {
     void GetDevice(u32) const;
@@ -284,22 +284,7 @@ struct NuMemory {
     void MoveFreeMem2IntoMem1();
     void SetSoakTestMode();
 };
-struct NuRenderDevice {
-    void DetermineNominalAspectRatio(u32, u32) const;
-    void IsContextValid() const;
-    void MultiThreadRender() const;
-    void OnAppPaused();
-    void OnAppRestarted();
-    void OnAppResume();
-    void OnAppStarted();
-    void OnAppStopped();
-    void OnGainedFocus();
-    void OnLostFocus();
-    void OnWindowDestroy();
-    void OpenglErrorCallback(u32, u32, u32, u32, i32, char const *, void *);
-    void PreInitialize();
-    void ResizeDevice(i32, i32, i32, bool, bool, bool, bool);
-};
+class NuRenderDevice;
 struct NuThread {
     void Resume();
     void SetDebugName(char const *);

--- a/src/nu2api/nucore/nuapi.h
+++ b/src/nu2api/nucore/nuapi.h
@@ -23,10 +23,7 @@ typedef struct nuapi_s {
     NUTIME time;
     NUTIME time2;
     f32 frametime;
-    char field19_0x3c;
-    char field20_0x3d;
-    char field21_0x3e;
-    char field22_0x3f;
+    i32 frame_count;
 
     f32 forced_frame_time;
     i32 max_fps;

--- a/src/nu2api/nucore/nucore.cpp
+++ b/src/nu2api/nucore/nucore.cpp
@@ -91,9 +91,6 @@ void NuPostFilter::renderFrustum(numtx_s *) {
 void NuDeviceSpecs::Exists() {
 }
 
-NuDeviceSpecs::NuDeviceSpecs() {
-}
-
 NuDeviceSpecs::~NuDeviceSpecs() {
 }
 
@@ -158,48 +155,6 @@ void NuDynamicLight::testShadowExtrusions(VuVec const &, VuVec const &) {
 }
 
 void NuMotionFilter::initResources() {
-}
-
-void NuRenderDevice::DetermineNominalAspectRatio(u32, u32) const {
-}
-
-void NuRenderDevice::IsContextValid() const {
-}
-
-void NuRenderDevice::MultiThreadRender() const {
-}
-
-void NuRenderDevice::OnAppPaused() {
-}
-
-void NuRenderDevice::OnAppRestarted() {
-}
-
-void NuRenderDevice::OnAppResume() {
-}
-
-void NuRenderDevice::OnAppStarted() {
-}
-
-void NuRenderDevice::OnAppStopped() {
-}
-
-void NuRenderDevice::OnGainedFocus() {
-}
-
-void NuRenderDevice::OnLostFocus() {
-}
-
-void NuRenderDevice::OnWindowDestroy() {
-}
-
-void NuRenderDevice::OpenglErrorCallback(u32, u32, u32, u32, i32, char const *, void *) {
-}
-
-void NuRenderDevice::PreInitialize() {
-}
-
-void NuRenderDevice::ResizeDevice(i32, i32, i32, bool, bool, bool, bool) {
 }
 
 NuMainFilterGen::NuMainFilterGen() {

--- a/src/nu2api/nucore/nucore_frame.cpp
+++ b/src/nu2api/nucore/nucore_frame.cpp
@@ -1,0 +1,99 @@
+#include "nu2api/nucore/nuapi.h"
+#include "nu2api/nucore/nuthread.h"
+#include "nu2api/nu3d/nuocclusion.h"
+#include "gamelib/nuwind/nuwind.h"
+void bgSuspendMain(i32);
+void NuPadRecordEndFrame();
+extern "C" {
+i32 NuHasError();
+void NuMtlAnimate(f32);
+void NuTexAnimProcess(f32);
+void NuWindAnimate(NUWIND *, f32);
+void NuOcclusionManagerEndFrame();
+void NuTimeBarSetRender(i32);
+void NuPad_Interface_Render();
+void NuPadUpdatePads();
+void NuRndrSwapScreenEx(i32, void (*)());
+extern void (*preRenderFlashingHack)();
+extern void (*postRenderFlashingHack)();
+extern void (*nuapi_endframe_callbackfn)();
+static i32 min_delay = 20;
+    f32 NuFrameEnd(void) {
+        static i32 ShowingError = 0; // _ZZ10NuFrameEndE12ShowingError
+
+        i32 done = 0;
+        i32 has_error = NuHasError();
+
+
+        if (nuapi.max_fps != 0) {
+            // Wait until at least 1/max_fps seconds have elapsed since frame
+            // begin (nuapi.time), then record the elapsed time.
+            f32 target = 1.0f / (f32)nuapi.max_fps;
+
+            NUTIME now;
+            NUTIME delta;
+            NuTimeGet(&now);
+            NuTimeSub(&delta, &now, &nuapi.time);
+            while (target > NuTimeSeconds(&delta)) {
+                NuTimeGet(&now);
+                NuTimeSub(&delta, &now, &nuapi.time);
+            }
+
+            nuapi.frametime = NuTimeSeconds(&delta);
+        }
+
+        NuMtlAnimate(nuapi.frametime);
+        NuTexAnimProcess(nuapi.frametime);
+        NuWindAnimate(nuapi.wind, nuapi.frametime);
+        NuOcclusionManagerEndFrame();
+        NuPadRecordEndFrame();
+        NuTimeBarSetRender(-1);
+        NuPad_Interface_Render();
+
+        done = 1;
+
+        if (preRenderFlashingHack != NULL) {
+            preRenderFlashingHack();
+        }
+
+        NuRndrSwapScreenEx(-1, nuapi_endframe_callbackfn);
+
+        NUTIME end;
+        NUTIME delta2;
+        NuTimeGet(&end);
+        NuTimeSub(&delta2, &end, &nuapi.time);
+        nuapi.frametime = NuTimeSeconds(&delta2);
+        nuapi.time = end;
+
+        if (nuapi.frametime > 0.1f) {
+            nuapi.frametime = 0.1f;
+        }
+
+        NuTimeGet(&nuapi.time2);
+
+        if (done) {
+            bgSuspendMain(min_delay);
+        }
+
+        if (postRenderFlashingHack != NULL) {
+            postRenderFlashingHack();
+        }
+
+        NuPadUpdatePads();
+        nuapi.frame_count++;
+        nuapi.nuframe_begin_cnt--;
+
+        if (ShowingError == 0 && has_error != 0) {
+            ShowingError = 1;
+            // Original shows an error dialog here.
+        } else if (ShowingError != 0) {
+            ShowingError = 0;
+        }
+
+        nuapi.disable_os_menu_freeze = 0;
+        return nuapi.frametime;
+    }
+    void NuFrameSetMinDelay(i32 delay) {
+        min_delay = delay;
+    }
+}

--- a/src/nu2api/nucore/nucore_plain.cpp
+++ b/src/nu2api/nucore/nucore_plain.cpp
@@ -31,6 +31,15 @@ extern "C" NUGCUTLOCATORFNENTRY_s *locatorfns;
 // alphabetical; every stub is an empty body that matches the original linkage.
 
 #include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include "nu2api/nucore/nustring.h"
+#include "nu2api/numath/nufloat.h"
+#include "nu2api/nu3d/nutex.h"
+#include "nu2api/nu3d/nuqfnt.h"
+
+void NuErrorPrint(char *);
+void NuDebugMsgPrint(char *);
 
 #include "decomp.h"
 #include "java/java.h"
@@ -49,6 +58,7 @@ extern "C" NUGCUTLOCATORFNENTRY_s *locatorfns;
 #include "nu2api/nu3d/nurndrstat.h"
 #include "nu2api/nu3d/nuspecial.h"
 #include "nu2api/nu3d/nuvport.h"
+#include "nu2api/nu3d/nuocclusion.h"
 #include "nu2api/nu3d/nurndr.h"
 #include "nu2api/numath/nutrig.h"
 #include "nu2api/numath/nufloat.h"
@@ -151,11 +161,11 @@ extern "C" {
     // Display-list bootstrap (original nucore TU file-statics)
     // ---------------------------------------------------------------------------
 
-    void NuHasError(void);
+    i32 NuHasError(void);
     void NuMtlAnimate(f32 frame_time);
     void NuTexAnimProcess(f32 frame_time);
-    void NuWindAnimate(void);
-    void NuTimeBarSetRender(void);
+    void NuWindAnimate(NUWIND *wind, f32 frametime);
+    void NuTimeBarSetRender(i32 set);
     void NuRndrSwapScreenEx(i32 mode, void (*callback)(void));
     void NuShaderManagerSetfv(i32 semantic, const f32 *values);
     void *NuScratchAlloc32(i32 size);
@@ -278,25 +288,46 @@ extern "C" {
     }
     void NuCameraGetAxes(void) {
     }
-    void NuCameraGetClippingMtx(void) {
+    NUMTX *NuCameraGetClippingMtx(void) {
+        return &cmtx;
     }
     void NuCameraGetClippingRatios(void) {
     }
-    void NuCameraGetPCMtx(void) {
+    NUMTX *NuCameraGetPCMtx(void) {
+        return &pc_vport_mtx;
     }
-    void NuCameraGetPCSMtx(void) {
+    NUMTX *NuCameraGetPCSMtx(void) {
+        return &psmtx;
     }
-    void NuCameraGetVPCSMtx(void) {
+    NUMTX *NuCameraGetVPCSMtx(void) {
+        return &vpsmtx;
     }
     void NuCameraIntersectsAABB(void) {
     }
-    void NuCameraLock(i32) {
+    i32 prev_lock;
+    NUCAMERA locked_camera;
+    NUCAMERA cam_copy;
+    i32 camfx;
+    NuCameraReflect global_reflect;
+    DECOMP_ASSERT(sizeof(NuCameraReflect) == 0x84, "camera reflection state size");
+    DECOMP_ASSERT(__builtin_offsetof(NuCameraReflect, mtx) == 4, "camera reflection matrix offset");
+
+    void NuCameraLock(i32 lock) {
+        if (lock != prev_lock && prev_lock == 0) {
+            locked_camera = *NuCameraGetCam();
+        }
+        if (lock != 0) {
+            cam_copy = *NuCameraGetCam();
+            NuCameraSet(&locked_camera);
+        }
+        prev_lock = lock;
     }
     void NuCameraMotionBlurEffect(void) {
     }
     void NuCameraMotionBlurParams(void) {
     }
     void NuCameraRelock(void) {
+        if (prev_lock == 1) NuCameraSet(&locked_camera);
     }
     void NuCameraRestoreState(void) {
     }
@@ -307,15 +338,35 @@ extern "C" {
     }
     void NuCameraSetAxes(void) {
     }
+    i32 PS2_REZ_W = 1280;
+    i32 PS2_REZ_H = 720;
+    i32 PS2_SREZ_W = 4096;
+    i32 PS2_SREZ_H = 4096;
+    static volatile i32 current_clip_scissor_to_viewport;
     void NuCameraSetEx(NUCAMERA *cam, i32 fast) {
         global_camera = *cam;
+        FaceYDirStream(NuAtan2D(-global_camera.mtx.m20, -global_camera.mtx.m22));
 
         if (fast == 0) {
             NuVpUpdate();
         }
 
-        NuMtxInv(&vmtx, &global_camera.mtx);
-        NuMtxScale(&vmtx, &global_camera.scale);
+        if (camfx == 0) {
+            NuMtxInv(&vmtx, &global_camera.mtx);
+            NuMtxScale(&vmtx, &global_camera.scale);
+        } else {
+            NUMTX mirror;
+            NUMTX camera_inverse;
+            NUMTX reflect_inverse;
+            NuMtxSetIdentity(&mirror);
+            mirror.m11 = -1.0f;
+            NuMtxInv(&camera_inverse, &global_camera.mtx);
+            NuMtxInv(&reflect_inverse, &global_reflect.mtx);
+            vmtx = reflect_inverse;
+            if (camfx == 1) NuMtxMul(&vmtx, &vmtx, &mirror);
+            NuMtxMul(&vmtx, &vmtx, &global_reflect.mtx);
+            NuMtxMul(&vmtx, &vmtx, &camera_inverse);
+        }
 
         if (fast == 0) {
             NuCameraSetProjectionMtx(&pmtx, global_camera.fov, global_camera.aspect, global_camera.near_clip,
@@ -327,8 +378,15 @@ extern "C" {
         }
 
         NuCameraSetVPortClipMtx(&vpc_vport_mtx, &vmtx, &global_camera, fast);
+        if (current_clip_scissor_to_viewport != 0) {
+            current_clip_scissor_to_viewport = 0;
+            fast = 0;
+        }
         NuCameraSetScissorClipMtx(&vpc_sci_mtx, &vmtx, &global_camera, fast);
+        NuVpGetScalingMtx(&smtx);
         NuMtxMulH(&vpmtx, &vmtx, &pmtx);
+        NuMtxMulH(&vpsmtx, &vpmtx, &smtx);
+        NuMtxMulH(&psmtx, &pmtx, &smtx);
 
         if (fast == 0) {
             i32 angle = static_cast<i32>(global_camera.fov * 0.5f * 10430.378f);
@@ -339,8 +397,8 @@ extern "C" {
 
             // PS2_SREZ_W/H are 4096; PS2_REZ_W/H track the current render
             // dimensions. These ratios define the scissor frustum.
-            zxs = nurndr_pixel_width != 0 ? 4096.0f * zx / static_cast<f32>(nurndr_pixel_width) : zx;
-            zys = nurndr_pixel_height != 0 ? 4096.0f * zy / static_cast<f32>(nurndr_pixel_height) : zy;
+            zxs = static_cast<f32>(PS2_SREZ_W) * zx / static_cast<f32>(PS2_REZ_W);
+            zys = static_cast<f32>(PS2_SREZ_H) * zy / static_cast<f32>(PS2_REZ_H);
 
             clip_planes.m13 = -clip_planes.m12;
             clip_planes.m02 = 0.0f;
@@ -361,8 +419,12 @@ extern "C" {
             NuCameraBuildClipPlanes();
         }
 
-        NuRndrSetViewMtx(&vpmtx, &vpc_vport_mtx, &vpc_sci_mtx);
+        NuRndrSetViewMtx(&vpsmtx, &vpc_vport_mtx, &vpc_sci_mtx);
+        NuRndrLightingStateCurrent.field_0x60 = 1;
+        NuRndrLightingStateCurrent.field_0x74 = 0;
+        NuRndrSetSpecularLightPS(NULL, NULL);
         NuRndrStateUpdateCameraState();
+        if (NuOcclusionManagerIsInitialised()) NuOcclusionManagerOnCameraSet();
     }
     void NuCameraSetProjectionMtx(NUMTX *mtx, f32 fov, f32 aspect, f32 near_clip, f32 far_clip) {
         if (near_clip < 0.1f) {
@@ -378,7 +440,10 @@ extern "C" {
         mtx->m23 = 1.0f;
         mtx->m32 = -depth * near_clip;
     }
-    void NuCameraSetReflect(void) {
+    void NuCameraSetReflect(NUCAMERA *camera, NuCameraReflect *reflect) {
+        global_reflect = *reflect;
+        NuCameraSet(camera);
+        *reflect = global_reflect;
     }
     static void NuCameraBuildClipProjection(NUMTX *projection, NUCAMERA *camera, f32 x_scale, f32 y_scale) {
         f32 far_clip = camera->unknown_64;
@@ -426,6 +491,7 @@ extern "C" {
     void NuCameraTransformView(void) {
     }
     void NuCameraUnlock(void) {
+        if (prev_lock == 1) NuCameraSet(&cam_copy);
     }
 
     // ---------------------------------------------------------------------------
@@ -901,90 +967,13 @@ extern "C" {
     extern void (*postRenderFlashingHack)(void);
     extern void (*nuapi_endframe_callbackfn)(void);
 
-    static f32 NuFrameEnd_min_delay = 0;
+
 
     // Faithful transcription of the original frame-end pump. Waits for the
     // target frame interval, ticks material/tex/wind anims, swaps screens
     // via NuRndrSwapScreenEx, then advances nuapi clocks and pad state.
-    f32 NuFrameEnd(void) {
-        static i32 ShowingError = 0; // _ZZ10NuFrameEndE12ShowingError
 
-        i32 done = 0;
-        NuHasError(); // original records the result for the error dialog
-        i32 has_error = 0;
 
-        static int dbg_fe = 0;
-        if (dbg_fe++ < 3 || dbg_fe % 1000 == 0) {
-            LOG_INFO("NuFrameEnd #%d max_fps=%d time=%u.%u", dbg_fe, nuapi.max_fps, nuapi.time.high, nuapi.time.low);
-        }
-
-        if (nuapi.max_fps != 0) {
-            // Wait until at least 1/max_fps seconds have elapsed since frame
-            // begin (nuapi.time), then record the elapsed time.
-            f32 target = 1.0f / (f32)nuapi.max_fps;
-
-            NUTIME now;
-            NUTIME delta;
-            do {
-                NuTimeGet(&now);
-                NuTimeSub(&delta, &now, &nuapi.time);
-            } while (target > NuTimeSeconds(&delta));
-
-            nuapi.frametime = NuTimeSeconds(&delta);
-        }
-
-        NuMtlAnimate(nuapi.frametime);
-        NuTexAnimProcess(nuapi.frametime);
-        NuWindAnimate(); // original: (wind, frametime)
-        NuOcclusionManagerEndFrame();
-        NuPadRecordEndFrame();
-        NuTimeBarSetRender(); // original passes -1
-        NuPad_Interface_Render();
-
-        done = 1;
-
-        if (preRenderFlashingHack != NULL) {
-            preRenderFlashingHack();
-        }
-
-        NuRndrSwapScreenEx(-1, nuapi_endframe_callbackfn);
-
-        NUTIME end;
-        NUTIME delta2;
-        NuTimeGet(&end);
-        NuTimeSub(&delta2, &end, &nuapi.time);
-        nuapi.frametime = NuTimeSeconds(&delta2);
-        nuapi.time = end;
-
-        if (nuapi.frametime > 0.1f) {
-            nuapi.frametime = 0.1f;
-        }
-
-        NuTimeGet(&nuapi.time2);
-
-        if (done && NuFrameEnd_min_delay != 0) {
-            bgSuspendMain((i32)NuFrameEnd_min_delay);
-        }
-
-        if (postRenderFlashingHack != NULL) {
-            postRenderFlashingHack();
-        }
-
-        NuPadUpdatePads();
-        nuapi.field19_0x3c++;
-        nuapi.nuframe_begin_cnt--;
-
-        if (ShowingError == 0 && has_error != 0) {
-            ShowingError = 1;
-            // Original shows an error dialog here.
-        } else if (ShowingError != 0) {
-            ShowingError = 0;
-        }
-
-        return nuapi.frametime;
-    }
-    void NuFrameSetMinDelay(void) {
-    }
 
     // ---------------------------------------------------------------------------
     // iOS / platform
@@ -1078,7 +1067,7 @@ extern "C" {
     }
     void NuIOS_RecordFlurryEvent(char *event_name) {
         JNIEnv *env = NULL;
-        if (g_javaVM.functions->GetEnv(&g_javaVM, (void **)&env, JNI_VERSION_1_6) < 0) {
+        if (g_javaVM->functions->GetEnv(g_javaVM, (void **)&env, JNI_VERSION_1_6) < 0) {
             return;
         }
 
@@ -1992,19 +1981,32 @@ extern "C" {
     }
     void NuQFntEncodeUnicodeString(void) {
     }
-    void NuQFntGetCoordinateSystem(void) {
+    NUQFNT_CSMODE NuQFntGetCoordinateSystem(void) {
+        return NuQFntCSMode;
     }
     void NuQFntGetPrintMode(void) {
     }
-    void NuQFntHeightScale(void) {
+    f32 NuQFntHeightScale(void) {
+        return qfnt_height_scale;
     }
-    void NuQFntLenScale(void) {
+    f32 NuQFntLenScale(void) {
+        return qfnt_len_scale;
     }
-    void NuQFntMove2d(void) {
+    void NuQFntMove2d(NUQFNT *font, f32 x, f32 y, f32 z) {
+        NuQFntPushPrintMode(2);
+        NuQFntMove(font, x, y, z);
+        NuQFntPopPrintMode();
     }
     void NuQFntPopCoordinateSystem(void) {
+        if (NuQFntCSModeStackIndex > 0) {
+            --NuQFntCSModeStackIndex;
+            NuQFntSetCoordinateSystem(NuQFntCSModeStack[NuQFntCSModeStackIndex]);
+        }
     }
-    void NuQFntPrint2dU(void) {
+    void NuQFntPrint2dU(NUQFNT *font, char *text) {
+        NuQFntPushPrintMode(2);
+        NuQFntPrintU(font, text);
+        NuQFntPopPrintMode();
     }
     void NuQFntPrint2dW(void) {
     }
@@ -2018,11 +2020,19 @@ extern "C" {
     }
     void NuQFntPrintV(void) {
     }
-    void NuQFntPushCoordinateSystem(void) {
+    void NuQFntPushCoordinateSystem(NUQFNT_CSMODE mode) {
+        if (NuQFntCSModeStackIndex < 16) {
+            NuQFntCSModeStack[NuQFntCSModeStackIndex] = NuQFntCSMode;
+            ++NuQFntCSModeStackIndex;
+        }
+        NuQFntSetCoordinateSystem(mode);
     }
     void NuQFntSet2d(void) {
     }
-    void NuQFntSetColour2d(void) {
+    void NuQFntSetColour2d(NUQFNT *font, u32 colour) {
+        NuQFntPushPrintMode(2);
+        NuQFntSetColour(font, colour);
+        NuQFntPopPrintMode();
     }
     void NuQFntSetPointSize(void) {
     }
@@ -2327,8 +2337,6 @@ extern "C" {
         NuShaderManagerSetfv(0x4a, frustum);
     }
     void NuRenderContextSetViewport(void) {
-    }
-    void NuRenderDeviceIsContextValid(void) {
     }
     void NuSpecialAddShadowLight(void) {
     }
@@ -2657,34 +2665,76 @@ extern "C" {
     }
     void NuDynamicLightTestShadowExtrusionsSpecial(void) {
     }
-    void NuWindAnimate(void) {
+    void NuWindAnimate(NUWIND *wind, f32 frametime) {
+        if (wind != NULL) {
+            wind->unk2.z += (1.0f / 256.0f) * wind->unk2.y * frametime;
+            if (wind->unk2.z >= 1.0f) {
+                wind->unk2.z = NuFmod(wind->unk2.z, 1.0f);
+            }
+            f32 scaled_time = 5.0f * frametime;
+            wind->unk2.w = frametime + wind->unk2.w;
+            wind->unk3 = scaled_time + wind->unk3;
+        }
     }
-    void NuWindCreateMtx(void) {
+    extern "C++" NuWindGType *NuWindAllocateGrp();
+    extern "C++" void NuWindFreeGrp(NuWindGType *group);
+
+
+    i32 NuWindCurrent(NUWIND *wind) {
+        return wind != NULL && wind->unk1 >= 0 ? wind->unk0[wind->unk1] : -1;
     }
-    void NuWindCurrent(void) {
+
+
+
+
+
+    i32 NuWindLoad(NUWIND *wind, i32 index, char *name, VARIPTR *buffer, VARIPTR *buffer_end) {
+        if (wind != NULL && (u32)index < 8) {
+            if (wind->unk0[index] >= 0) {
+                NuTexDestroy(wind->unk0[index]);
+            }
+            i32 texture = NuTexRead(name, buffer, buffer_end);
+            if (texture != 0) {
+                wind->unk0[index] = texture;
+                return texture;
+            }
+            wind->unk0[index] = -1;
+        }
+        return -1;
     }
-    void NuWindDraw(void) {
+
+
+
+    void NuWindSetCurrent(NUWIND *wind, i32 index) {
+        if ((u32)index > 7 || wind == NULL) {
+            nuapi.wind = NULL;
+        } else if (wind->unk0[index] >= 0) {
+            wind->unk1 = index;
+            nuapi.wind = wind;
+        }
     }
-    void NuWindInit(void) {
+    void NuWindSetSpeed(NUWIND *wind, f32 speed) {
+        if (wind != NULL) {
+            wind->unk2.y = 1.0f <= speed ? speed : 1.0f;
+        }
     }
-    void NuWindLoad(void) {
+    void NuWindSetWorldSize(NUWIND *wind, f32 size) {
+        if (wind != NULL) {
+            wind->unk2.x = 1.0f <= size ? size : 1.0f;
+        }
     }
-    void NuWindRand(void) {
+
+
+
+    void NuWindUnload(NUWIND *wind, i32 index) {
+        if (wind != NULL && wind->unk0[index] >= 0) {
+            NuTexDestroy(wind->unk0[index]);
+            wind->unk0[index] = -1;
+        }
     }
-    void NuWindSetCurrent(void) {
-    }
-    void NuWindSetSpeed(void) {
-    }
-    void NuWindSetWorldSize(void) {
-    }
-    void NuWindSetup(void) {
-    }
-    void NuWindUnload(void) {
-    }
-    void NuWindUpdate(void) {
-    }
-    void NuWindUpdateArray(void *) {
-    }
+    void NuWindUpdateArray(NUVEC **);
+
+
     void NuPartEnableRayCasts(void) {
     }
     void NuPartGetSeed(void) {
@@ -3219,35 +3269,49 @@ extern "C" {
     }
     void NuVisiOctree(void) {
     }
-    void NuOcclusionManagerAddOccluderOBB(void) {
+    void NuOcclusionManagerAddOccluderOBB(const NUVEC *minimum, const NUVEC *maximum, const NUMTX *matrix) {
+        g_OcclusionManager.AddOccluder(minimum, maximum, matrix);
     }
-    void NuOcclusionManagerAddOccluderQuad(void) {
+    void NuOcclusionManagerAddOccluderQuad(const NUVEC *a, const NUVEC *b, const NUVEC *c, const NUVEC *d) {
+        g_OcclusionManager.AddOccluder(a, b, c, d);
     }
-    void NuOcclusionManagerAddOccluderSphere(void) {
+    void NuOcclusionManagerAddOccluderSphere(const NUVEC *center, f32 radius) {
+        g_OcclusionManager.AddOccluder(center, radius);
     }
     void NuOcclusionManagerEndFrame(void) {
+        g_OcclusionManager.EndFrame();
     }
-    void NuOcclusionManagerInit(void) {
+    void NuOcclusionManagerInit(u32 capacity, VARIPTR *buffer, VARIPTR buffer_end) {
+        g_OcclusionManager.Init(capacity, buffer, buffer_end);
     }
-    void NuOcclusionManagerIsEnabled(void) {
+    bool NuOcclusionManagerIsEnabled(void) {
+        return g_OcclusionManager.initialized && g_OcclusionManager.enabled;
     }
-    void NuOcclusionManagerIsInitialised(void) {
+    bool NuOcclusionManagerIsInitialised(void) {
+        return g_OcclusionManager.initialized;
     }
-    void NuOcclusionManagerIsOccludedOBB(void) {
+    i32 NuOcclusionManagerIsOccludedOBB(const NUVEC *minimum, const NUVEC *maximum, const NUMTX *matrix) {
+        return g_OcclusionManager.IsOccludedOBB(minimum, maximum, matrix);
     }
-    void NuOcclusionManagerIsOccludedSphere(void) {
+    i32 NuOcclusionManagerIsOccludedSphere(const NUVEC *center, f32 radius) {
+        return g_OcclusionManager.IsOccludedSphere(center, radius);
     }
     void NuOcclusionManagerOnCameraSet(void) {
+        g_OcclusionManager.OnCameraSet();
     }
     void NuOcclusionManagerRenderStats(void) {
     }
     void NuOcclusionManagerRenderZPass(void) {
+        g_OcclusionManager.RenderZPass();
     }
-    void NuOcclusionManagerSetEnabled(void) {
+    void NuOcclusionManagerSetEnabled(i32 enabled) {
+        g_OcclusionManager.SetEnabled(enabled != 0);
     }
-    void NuOcclusionManagerSetOccluderDotProductThreshold(void) {
+    void NuOcclusionManagerSetOccluderDotProductThreshold(f32 threshold) {
+        g_OcclusionManager.unknown_158 = threshold;
     }
-    void NuOcclusionManagerSetOccluderScreenSpaceThreshold(void) {
+    void NuOcclusionManagerSetOccluderScreenSpaceThreshold(f32 threshold) {
+        g_OcclusionManager.unknown_15c = threshold;
     }
     void NuInvalidateClipRanges(void) {
     }
@@ -3466,28 +3530,23 @@ extern "C" {
     // Debug / error / html / profiling
     // ---------------------------------------------------------------------------
 
-    void NuClearError(void) {
-    }
+
     void NuErrorCheck(void) {
     }
-    void NuErrorProlog(void) {
-    }
+
+
     void NuErrorSetFilter(void) {
     }
     void NuErrorSleep(void) {
     }
-    void NuHasError(void) {
-    }
+
     void NuDebugMsgProlog(void) {
     }
     void NuDebugMsgPrologTTY(void) {
     }
-    void NuGetErrN(void) {
-    }
-    void NuGetError(void) {
-    }
-    void NuSevereWarning(const char *, ...) {
-    }
+
+
+
     void NuWarningProlog(void) {
     }
     void NuHtmlBanner(void) {
@@ -3527,7 +3586,7 @@ extern "C" {
     void NuTimeBarResetPeaks(void) {
         NuTimeBar_PeakReset = 1;
     }
-    void NuTimeBarSetRender(void) {
+    void NuTimeBarSetRender(i32) {
     }
     void NuTimeBarSetRenderHorizontal(void) {
     }

--- a/src/nu2api/nucore/nuerror.cpp
+++ b/src/nu2api/nucore/nuerror.cpp
@@ -1,0 +1,75 @@
+#include "nu2api/nucore/nustring.h"
+#include <stdio.h>
+#include <stdarg.h>
+void NuErrorPrint(char *);
+void NuDebugMsgPrint(char *);
+extern "C" {
+typedef void (*NuErrorFunctionPtr)(char *, ...);
+    static i32 bHaveErr;
+    static char ErrMsg[1024];
+    static char *nufile;
+    static i32 nuline;
+    static char txt[16384];
+    static char captxt[16384];
+    void (*nuerror_handler)(char *);
+    void (*nudebug_handler)(char *);
+
+    extern "C++" {
+        static void NuErrorFunction(char *format, ...) {
+            sprintf(captxt, "NuError - %s(%d) : ", nufile, nuline);
+            va_list args;
+            va_start(args, format);
+            vsprintf(txt, format, args);
+            va_end(args);
+            NuStrCat(captxt, txt);
+            NuStrCat(captxt, "\n");
+            if (nuerror_handler != NULL) {
+                nuerror_handler(captxt);
+            }
+            NuErrorPrint(captxt);
+        }
+    }
+
+    void NuClearError(void) {
+        bHaveErr = 0;
+    }
+    NuErrorFunctionPtr NuErrorProlog(char *file, i32 line) {
+        nufile = file;
+        nuline = line;
+        return NuErrorFunction;
+    }
+    i32 NuHasError(void) {
+        return bHaveErr;
+    }
+    char *NuGetErrN(i32 entry) {
+        i32 offset = 0;
+        i32 current = 0;
+        while (current < entry && offset < bHaveErr) {
+            if (ErrMsg[offset++] == '\0') {
+                ++current;
+            }
+        }
+        return ErrMsg + offset;
+    }
+    char *NuGetError(void) {
+        return bHaveErr != 0 ? ErrMsg : NULL;
+    }
+    void NuSevereWarning(const char *format, ...) {
+        sprintf(captxt, " ");
+        va_list args;
+        va_start(args, format);
+        vsprintf(txt, format, args);
+        va_end(args);
+        NuStrCat(captxt, txt);
+        NuStrCat(captxt, "\n");
+        if (nudebug_handler != NULL) {
+            nudebug_handler(captxt);
+        }
+        NuDebugMsgPrint(captxt);
+        char *message = captxt;
+        while (*message != '\0' && bHaveErr < 1023) {
+            ErrMsg[bHaveErr++] = *message++;
+        }
+        ErrMsg[bHaveErr++] = '\0';
+    }
+}

--- a/src/nu2api/nucore/nupad_interface.cpp
+++ b/src/nu2api/nucore/nupad_interface.cpp
@@ -202,15 +202,6 @@ void NuInputDevicePS::EnableDPDPS(u32) {
 void NuInputDevicePS::GetIdentifierPS(u32) {
 }
 
-void NuInputDevicePS::HandleGamePadAxis_ANDROID_SPECIFIC(float, float, float, float, float, float) {
-}
-
-void NuInputDevicePS::HandleSensor_ANDROID_SPECIFIC(i32, float, float, float) {
-}
-
-void NuInputDevicePS::HandleTouch_ANDROID_SPECIFIC(i32, i32, i32, float, float) {
-}
-
 NuTouchInputStick::NuTouchInputStick(NuTouchInputElement::TYPE, i32, u32, float, float, float, float) {
 }
 

--- a/src/nu2api/nufile/NuFileDeviceAndroidAPK.cpp
+++ b/src/nu2api/nufile/NuFileDeviceAndroidAPK.cpp
@@ -1,9 +1,15 @@
 #include "nu2api_nufile_types.h"
 
-void NuFileDeviceAndroidAPK::CreateNuFile(char const *, NuFile::OpenMode::T) const {
+NuFileBase *NuFileDeviceAndroidAPK::CreateNuFile(char const *path, NuFile::OpenMode::T mode) const {
+    return NuFileAndroidAPK::Open(path, mode);
 }
 
-NuFileDeviceAndroidAPK::NuFileDeviceAndroidAPK(char const *, NuFile::InitData const &) {
+NuFileDeviceAndroidAPK::NuFileDeviceAndroidAPK(char const *name, NuFile::InitData const &) {
+    device_type = NUFILE_DEVICE_ANDROID_APK;
+    separator = "/";
+    label = name;
+    flags = 9;
+    mount_name = "";
 }
 
 NuFileDeviceAndroidAPK::~NuFileDeviceAndroidAPK() {

--- a/src/nu2api/nufile/android/nufile_android.cpp
+++ b/src/nu2api/nufile/android/nufile_android.cpp
@@ -11,6 +11,8 @@
 #include "nu2api/nucore/nuthread.h"
 #include "nu2api/nufile/nufile.h"
 #include "nu2api/nufile/tmclient.h"
+#include "java/asset_manager.h"
+#include "java/android.h"
 
 char g_datfileMode = 1;
 
@@ -22,12 +24,52 @@ NuFileAndroidAPK::~NuFileAndroidAPK() {
     Close();
 }
 
-i64 NuFileAndroidAPK::Seek(i64 offset, NuFile::SeekOrigin::T) {
-    return {};
+i64 NuFileAndroidAPK::Seek(i64 offset, NuFile::SeekOrigin::T origin) {
+    i32 next;
+    switch (origin) {
+        case NuFile::SeekOrigin::START: next = offset; break;
+        case NuFile::SeekOrigin::CURRENT: next = position + offset; break;
+        case NuFile::SeekOrigin::END: next = file_size + offset; break;
+        default: next = position; break;
+    }
+    position = MIN(file_size, (MAX(0, next)));
+    return position;
 }
 
 isize NuFileAndroidAPK::Read(void *buf, usize size) {
-    return {};
+    if (chunk_size != 0) {
+        u64 remaining = size < static_cast<usize>(file_size - position) ? size : file_size - position;
+        i32 start = position;
+        u8 *output = static_cast<u8 *>(buf);
+        while (position < file_size) {
+            u32 index = static_cast<u32>(position) / chunk_size;
+            if (asset_index != index) {
+                char next_path[256];
+                strcpy(next_path, asset_path);
+                char *part = strstr(next_path, ".0000.jpg");
+                sprintf(part, ".%04d.jpg", index);
+                AAsset_close(asset);
+                asset = AAssetManager_open(g_assetManager, next_path, AASSET_MODE_UNKNOWN);
+                asset_index = index;
+            }
+            i32 current = position;
+            i32 chunk = chunk_size;
+            AAsset_seek(asset, current - index * chunk, SEEK_SET);
+            i32 amount = ((current & -chunk) + chunk) - current;
+            if (static_cast<i64>(amount) > static_cast<i64>(remaining)) {
+                amount = remaining;
+            }
+            u32 count = AAsset_read(asset, output, amount);
+            remaining -= count;
+            position += count;
+            output += count;
+            if (remaining == 0) break;
+        }
+        return position - start;
+    } else {
+        AAsset_seek(asset, position, SEEK_SET);
+        return AAsset_read(asset, buf, size);
+    }
 }
 
 isize NuFileAndroidAPK::Write(const void *buf, usize size) {
@@ -35,36 +77,10 @@ isize NuFileAndroidAPK::Write(const void *buf, usize size) {
 }
 
 void NuFileAndroidAPK::Close() {
-}
-
-SAGA_NOMATCH i32 NuFileAndroidAPK::OpenFile(const char *filepath, NuFile::OpenMode::T mode) {
-    UNIMPLEMENTED("android specific");
-    return {};
-}
-
-SAGA_NOMATCH i32 NuFileAndroidAPK::CloseFile(NUFILE file) {
-    UNIMPLEMENTED("android specific");
-    return {};
-}
-
-SAGA_NOMATCH i64 NuFileAndroidAPK::SeekFile(NUFILE file, i64 offset, NuFile::SeekOrigin::T mode) {
-    UNIMPLEMENTED("android specific");
-    return {};
-}
-
-SAGA_NOMATCH i32 NuFileAndroidAPK::ReadFile(NUFILE file, void *buf, u32 size) {
-    UNIMPLEMENTED("android specific");
-    return {};
-}
-
-SAGA_NOMATCH i64 NuFileAndroidAPK::GetFilePos(NUFILE file) {
-    UNIMPLEMENTED("android specific");
-    return {};
-}
-
-SAGA_NOMATCH i64 NuFileAndroidAPK::GetFileSize(NUFILE file) {
-    UNIMPLEMENTED("android specific");
-    return {};
+    if (asset != NULL) {
+        AAsset_close(asset);
+        asset = NULL;
+    }
 }
 
 static FILE *g_fileHandles[32] = {NULL};

--- a/src/nu2api/nufile/android/nufile_android.h
+++ b/src/nu2api/nufile/android/nufile_android.h
@@ -1,29 +1,60 @@
 #pragma once
+#include "decomp_assert.h"
 
 #include "nu2api/nufile/nufile.h"
 
-class NuFileDeviceAndroidAPK {};
+class NuFileDeviceAndroidAPK;
+struct AAsset;
 
 extern NuFileDeviceAndroidAPK *g_apkFileDevice;
 
 class NuFileAndroidAPK : public NuFileBase {
   public:
     NuFileAndroidAPK(const char *filepath, NuFile::OpenMode::T mode);
+    static NuFileAndroidAPK *ms_fileId[0x400];
+    static void Init();
+    static NuFileAndroidAPK *Open(const char *filepath, NuFile::OpenMode::T mode);
+    static void ResetId(i32 id);
+    static i32 SetFileId(NuFileAndroidAPK *file);
+    static NuFileAndroidAPK *GetFile(i32 id) { return ms_fileId[id - 0x2000]; }
 
     virtual i64 Seek(i64 offset, NuFile::SeekOrigin::T) override;
     virtual isize Read(void *buf, usize size) override;
     virtual isize Write(const void *buf, usize size) override;
     virtual void Close() override;
 
-    static NUFILE OpenFile(const char *filepath, NuFile::OpenMode::T mode);
-    static i32 CloseFile(NUFILE file);
+    static NUFILE OpenFile(const char *filepath, NuFile::OpenMode::T mode) {
+        NuFileAndroidAPK *file = Open(filepath, mode);
+        i32 id = SetFileId(file);
+        return id;
+    }
+    static void CloseFile(NUFILE file) {
+        NuFileAndroidAPK *object = GetFile(file);
+        ResetId(file);
+        object->Close();
+        delete object;
+    }
 
-    static i64 SeekFile(NUFILE file, i64 offset, NuFile::SeekOrigin::T mode);
-    static i32 ReadFile(NUFILE file, void *buf, u32 size);
+    static i64 SeekFile(NUFILE file, i64 offset, NuFile::SeekOrigin::T mode) {
+        return GetFile(file)->Seek(offset, mode);
+    }
+    static i32 ReadFile(NUFILE file, void *buf, u32 size) {
+        return GetFile(file)->Read(buf, size);
+    }
 
-    static i64 GetFilePos(NUFILE file);
-    static i64 GetFileSize(NUFILE file);
+    static i64 GetFilePos(NUFILE file) { return GetFile(file)->GetPos(); }
+    static i64 GetFileSize(NUFILE file) { return GetFile(file)->GetSize(); }
 
   protected:
     virtual ~NuFileAndroidAPK() override;
+
+  private:
+    char asset_path[256];
+    i32 file_size;
+    u32 chunk_size;
+    i32 position;
+    AAsset *asset;
+    u32 asset_index;
 };
+
+DECOMP_ASSERT(sizeof(NuFileAndroidAPK) == 0x224, "NuFileAndroidAPK target layout");

--- a/src/nu2api/nufile/nu2api_nufile_types.h
+++ b/src/nu2api/nufile/nu2api_nufile_types.h
@@ -3,59 +3,82 @@
 #pragma once
 
 #include "nu2api/nucore/common.h"
+#include "nu2api/nufile/android/nufile_android.h"
 
-struct NuFile;
 struct NuFileAndroidAPK;
 struct NuFileBase;
 struct NuFileDevice;
 struct NuFileDeviceAndroidAPK;
-struct NuFileDeviceType;
+enum NuFileDeviceType { NUFILE_DEVICE_UNKNOWN = 1, NUFILE_DEVICE_ANDROID_APK = 3 };
+struct nufile_info_s;
 
-struct NuFileDeviceType {};
-
-struct NuFile {
-    struct InitData {};
-    struct OpenMode {
-        struct T {};
-    };
-};
-struct NuFileAndroidAPK {
-    static NuFileAndroidAPK *ms_fileId[0x400];
-
-    void Init();
-    void Open(char const *, NuFile::OpenMode::T);
-    static void ResetId(i32 id);
-    static i32 SetFileId(NuFileAndroidAPK *file);
-};
-struct NuFileBase {
-    void Closedown();
-    void Init();
-};
+namespace NuFile {
+    struct InitData { u32 flags; u32 unknown; };
+}
 struct NuFileDevice {
-    void AddDevice(NuFileDevice *);
+    static void AddDevice(NuFileDevice *);
     void AddPathRule(NuFileDeviceType, char const *);
     void AllocDirectoryHandle(char const *);
-    void ClearPathRules();
-    void FileOpen(char const *, NuFile::OpenMode::T) const;
-    void FileSize(char const *) const;
-    void FormatName(char *, i32, char const *) const;
+    static void ClearPathRules();
     void FreeDirectoryHandle(i32);
     void GetDeviceByType(NuFileDeviceType);
-    void GetDeviceFromDirectoryHandle(i32);
+    static NuFileDevice *GetDeviceFromDirectoryHandle(i32);
     void GetDeviceFromPath(char const *);
-    void Interrogate();
     NuFileDevice();
-    void QueryInstallProgress();
-    void SetCurrentDir(char const *);
-    void SetDefaultDevice(NuFileDeviceType);
+    static void SetDefaultDevice(NuFileDeviceType);
     void SetLabel(char *);
     void SetMountName(char *);
+    virtual NuFileBase *FileOpen(char const *, NuFile::OpenMode::T) const;
+    virtual i64 FileSize(char const *) const;
+    // The original base implementations report unsupported operations.
+    virtual bool FileRename(char const *, char const *) { return false; }
+    virtual bool FileGetInfo(char const *, nufile_info_s *) { return false; }
+    virtual bool FileDelete(char const *) { return false; }
+    virtual bool FileTouch(char const *) { return false; }
+    virtual i32 DirOpen(char const *) { return 0; }
+    virtual void DirClose(i32) {}
+    virtual bool DirExists(char const *) { return false; }
+    virtual bool DirRead(i32, nufile_info_s *) { return false; }
+    virtual bool DirCreatePath(char const *) { return false; }
+    virtual bool DirRemove(char const *) { return false; }
+    virtual bool DirRemoveRecursive(char const *, bool) { return false; }
+    virtual bool DirRename(char const *, char const *) { return false; }
+    virtual bool GetPositionOnDisc(char const *, i64 &) const { return false; }
+    virtual i32 FormatName(char *, i32, char const *) const;
+    virtual void SetCurrentDir(char const *);
     virtual ~NuFileDevice();
+    virtual void Interrogate();
+    virtual i32 QueryInstallProgress();
+    virtual NuFileBase *CreateNuFile(char const *, NuFile::OpenMode::T) const = 0;
+
+    static NuFileDevice *sm_Devices[16];
+    static i32 sm_NumDevices;
+    static NuFileDevice *sm_DefaultDevice;
+    static NuFileDevice *sm_HostDevice;
+    static i32 sm_NumRules;
+    struct DirectoryHandle {
+        NuFileDevice *device;
+        i32 handle;
+    };
+    static DirectoryHandle sm_DirectoryHandles[16];
+
+  protected:
+    i32 device_id;
+    NuFileDeviceType device_type;
+    u32 flags;
+    i32 status;
+    const char *separator;
+    const char *label;
+    const char *mount_name;
+    char current_dir[128];
 };
-struct NuFileDeviceAndroidAPK {
-    void CreateNuFile(char const *, NuFile::OpenMode::T) const;
+struct NuFileDeviceAndroidAPK : NuFileDevice {
+    virtual NuFileBase *CreateNuFile(char const *, NuFile::OpenMode::T) const override;
     NuFileDeviceAndroidAPK(char const *, NuFile::InitData const &);
     virtual ~NuFileDeviceAndroidAPK();
 };
+
+DECOMP_ASSERT(sizeof(NuFileDevice) == 0xa0, "NuFileDevice target layout");
+DECOMP_ASSERT(sizeof(NuFileDeviceAndroidAPK) == 0xa0, "APK device target layout");
 
 #endif // NU2API_NUFILE_TYPES_H

--- a/src/nu2api/nufile/nufile.cpp
+++ b/src/nu2api/nufile/nufile.cpp
@@ -1457,6 +1457,25 @@ i32 NuPPLoadBuffer(NUFILE file, void *buf, i32 buf_size) {
 static FILEEXTINFO extensions[64];
 static i32 num_extensions;
 
+i32 NuFileExtGetExt(char *dest, i32 capacity, NUFILETYPE type) {
+    FILEEXTINFO *info = extensions;
+    while (info != NULL) {
+        if (info->platform == 4 && static_cast<signed char>(info->type) == static_cast<i32>(type)) {
+            if (static_cast<signed char>(info->len) > capacity) return 0;
+            char *source = reinterpret_cast<char *>(info) + static_cast<signed char>(info->len);
+            i32 index = 0;
+            while (index < static_cast<signed char>(info->len)) {
+                --source;
+                dest[index++] = *source;
+            }
+            dest[index] = '\0';
+            return 1;
+        }
+        ++info;
+    }
+    return 0;
+}
+
 static i32 MatchExtension(char *extension, char *path_end, i32 path_len) {
     while (*extension != '\0') {
         --path_end;

--- a/src/nu2api/nufile/nufile.h
+++ b/src/nu2api/nufile/nufile.h
@@ -291,6 +291,7 @@ extern "C" {
     i32 NuFileExists(char *name);
     i64 NuFileSize(char *filepath);
     i32 NuFileExtConvert(char *dest, char *path);
+    i32 NuFileExtGetExt(char *dest, i32 capacity, NUFILETYPE type);
     i64 NuFilePos(NUFILE file);
     void NuFileUpCase(NUFILE_DEVICE *device, char *filepath);
 

--- a/src/nu2api/nufile/nufile_android.cpp
+++ b/src/nu2api/nufile/nufile_android.cpp
@@ -1,11 +1,49 @@
 #include "nu2api_nufile_types.h"
+#include <stdio.h>
+#include <string.h>
+#include "java/asset_manager.h"
+#include "java/android.h"
 
 NuFileAndroidAPK *NuFileAndroidAPK::ms_fileId[0x400];
 
 void NuFileAndroidAPK::Init() {
+    for (i32 i = 0; i < 0x400; ++i) {
+        ms_fileId[i] = NULL;
+    }
 }
 
-void NuFileAndroidAPK::Open(char const *, NuFile::OpenMode::T) {
+NuFileAndroidAPK *NuFileAndroidAPK::Open(const char *path, NuFile::OpenMode::T mode) {
+    if (mode == 1 || mode == 2) {
+        return NULL;
+    }
+    AAsset *first_asset = AAssetManager_open(g_assetManager, path, AASSET_MODE_UNKNOWN);
+    if (first_asset == NULL) {
+        return NULL;
+    }
+    NuFileAndroidAPK *file = new NuFileAndroidAPK(path, mode);
+    strcpy(file->asset_path, path);
+    file->file_size = AAsset_getLength(first_asset);
+    file->chunk_size = 0;
+    file->position = 0;
+    file->asset = first_asset;
+    file->asset_index = 0;
+    char next_path[256];
+    strcpy(next_path, file->asset_path);
+    char *part = strstr(next_path, ".0000.jpg");
+    if (part != NULL) {
+        file->chunk_size = file->file_size;
+        u32 index = 0;
+        for (;;) {
+            sprintf(part, ".%04d.jpg", ++index);
+            AAsset *next = AAssetManager_open(g_assetManager, next_path, AASSET_MODE_UNKNOWN);
+            if (next == NULL) {
+                break;
+            }
+            file->file_size += AAsset_getLength(next);
+            AAsset_close(next);
+        }
+    }
+    return file;
 }
 
 void NuFileAndroidAPK::ResetId(i32 id) {

--- a/src/nu2api/nufile/nufile_plain.cpp
+++ b/src/nu2api/nufile/nufile_plain.cpp
@@ -37,8 +37,6 @@ extern "C" {
     }
     void NuFileExistQuiet(void) {
     }
-    void NuFileExtGetExt(void) {
-    }
     void NuFileExtGetType(void) {
     }
     void NuFileExtRemove(void) {

--- a/src/nu2api/nufile/nufiledevice.cpp
+++ b/src/nu2api/nufile/nufiledevice.cpp
@@ -1,6 +1,16 @@
 #include "nu2api_nufile_types.h"
+#include "nu2api/nucore/nustring.h"
 
-void NuFileDevice::AddDevice(NuFileDevice *) {
+NuFileDevice *NuFileDevice::sm_Devices[16];
+i32 NuFileDevice::sm_NumDevices;
+NuFileDevice *NuFileDevice::sm_DefaultDevice;
+NuFileDevice *NuFileDevice::sm_HostDevice;
+i32 NuFileDevice::sm_NumRules;
+NuFileDevice::DirectoryHandle NuFileDevice::sm_DirectoryHandles[16];
+
+void NuFileDevice::AddDevice(NuFileDevice *device) {
+    device->device_id = sm_NumDevices;
+    sm_Devices[sm_NumDevices++] = device;
 }
 
 void NuFileDevice::AddPathRule(NuFileDeviceType, char const *) {
@@ -10,15 +20,70 @@ void NuFileDevice::AllocDirectoryHandle(char const *) {
 }
 
 void NuFileDevice::ClearPathRules() {
+    sm_NumRules = 0;
 }
 
-void NuFileDevice::FileOpen(char const *, NuFile::OpenMode::T) const {
+NuFileBase *NuFileDevice::FileOpen(char const *path, NuFile::OpenMode::T mode) const {
+    char formatted[1024];
+    NuFileBase *file = NULL;
+    if (path[0] && FormatName(formatted, sizeof(formatted), path))
+        file = CreateNuFile(formatted, mode);
+    return file;
 }
 
-void NuFileDevice::FileSize(char const *) const {
+i64 NuFileDevice::FileSize(char const *path) const {
+    if (!path || !path[0]) return -1;
+    NuFileBase *file = FileOpen(path, NuFile::OpenMode::READ);
+    if (!file) return -1;
+    file->Seek(0, NuFile::SeekOrigin::END);
+    i64 size = file->GetPos();
+    file->Close();
+    return size;
 }
 
-void NuFileDevice::FormatName(char *, i32, char const *) const {
+i32 NuFileDevice::FormatName(char *output, i32 size, char const *path) const {
+    char relative[512] = "";
+    output[0] = 0;
+    char *normalized;
+    if (((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z')) &&
+        path[1] == ':' && (path[2] == '/' || path[2] == '\\')) {
+        NuStrCat(output, path);
+        normalized = output + 3;
+    } else {
+        const char *colon = path;
+        for (i32 i = 0; *colon != ':' && *colon && i < 8; ++i) ++colon;
+        if (*colon == ':') path = colon + 1;
+        if (*mount_name > 0) {
+            NuStrCat(output, mount_name);
+            char *last = output + NuStrLen(mount_name) - 1;
+            if (*last == '/' || *last == '\\') *last = 0;
+        }
+        i32 length = NuStrLen(output);
+        normalized = output + length;
+        if ((((path[0] >= 'a' && path[0] <= 'z') || (path[0] >= 'A' && path[0] <= 'Z')) &&
+             path[1] == ':' && (path[2] == '/' || path[2] == '\\')) ||
+            path[0] == '/' || path[0] == '\\') {
+            NuStrCat(relative, path);
+        } else {
+            if (length > 0 && current_dir[0] != '\\' && current_dir[0] != '/')
+                NuStrCat(relative, separator);
+            NuStrCat(relative, current_dir);
+            NuStrCat(relative, path);
+        }
+    }
+    if (flags & 2) NuStrUpr(relative, relative);
+    if (*relative) NuFileNormalise(normalized, size, relative);
+    char *source = normalized;
+    while (*source) {
+        if (*source == '/' || *source == '\\') {
+            *normalized++ = *separator;
+            do { ++source; } while (*source == '/' || *source == '\\');
+        } else {
+            *normalized++ = *source++;
+        }
+    }
+    *normalized = 0;
+    return 1;
 }
 
 void NuFileDevice::FreeDirectoryHandle(i32) {
@@ -27,32 +92,64 @@ void NuFileDevice::FreeDirectoryHandle(i32) {
 void NuFileDevice::GetDeviceByType(NuFileDeviceType) {
 }
 
-void NuFileDevice::GetDeviceFromDirectoryHandle(i32) {
+NuFileDevice *NuFileDevice::GetDeviceFromDirectoryHandle(i32 handle) {
+    return sm_DirectoryHandles[handle].device;
 }
 
 void NuFileDevice::GetDeviceFromPath(char const *) {
 }
 
 void NuFileDevice::Interrogate() {
+    status = 1;
 }
 
 NuFileDevice::NuFileDevice() {
+    device_type = NUFILE_DEVICE_UNKNOWN;
+    flags = 0;
+    status = 0;
+    separator = "\\";
+    label = "";
+    current_dir[0] = 0;
+    device_id = -1;
 }
 
-void NuFileDevice::QueryInstallProgress() {
+i32 NuFileDevice::QueryInstallProgress() {
+    return 100;
 }
 
-void NuFileDevice::SetCurrentDir(char const *) {
+void NuFileDevice::SetCurrentDir(char const *path) {
+    char suffix[2] = "\\";
+    if (!path || !*path) {
+        current_dir[0] = 0;
+        return;
+    }
+    i32 length = NuStrCpy(current_dir, path);
+    if (length && path[length - 1] != '/' && path[length - 1] != '\\') {
+        suffix[0] = *separator;
+        NuStrCat(current_dir, suffix);
+    }
 }
 
-void NuFileDevice::SetDefaultDevice(NuFileDeviceType) {
+void NuFileDevice::SetDefaultDevice(NuFileDeviceType type) {
+    for (i32 i = 0; i < sm_NumDevices; ++i) {
+        NuFileDevice *device = sm_Devices[i];
+        if (device != NULL && device->device_type == type) {
+            sm_DefaultDevice = device;
+            return;
+        }
+    }
 }
 
-void NuFileDevice::SetLabel(char *) {
+void NuFileDevice::SetLabel(char *name) {
+    label = name;
 }
 
-void NuFileDevice::SetMountName(char *) {
+void NuFileDevice::SetMountName(char *name) {
+    mount_name = name;
 }
 
 NuFileDevice::~NuFileDevice() {
+    if (device_id >= 0) sm_Devices[device_id] = NULL;
+    if (this == sm_DefaultDevice) sm_DefaultDevice = NULL;
+    if (this == sm_HostDevice) sm_HostDevice = NULL;
 }

--- a/src/nu2api/nuplatform/nudevicespecs.cpp
+++ b/src/nu2api/nuplatform/nudevicespecs.cpp
@@ -9,6 +9,10 @@
 
 NuDeviceSpecs *NuDeviceSpecs::ms_instance = NULL;
 
+NuDeviceSpecs::NuDeviceSpecs() : specs(-2) {
+    DetermineDeviceSpecs();
+}
+
 void NuDeviceSpecs::Create() {
     if (ms_instance != NULL) {
         return;

--- a/src/nu2api/nuplatform/nudevicespecs.hpp
+++ b/src/nu2api/nuplatform/nudevicespecs.hpp
@@ -9,6 +9,9 @@ class NuDeviceSpecs {
 
     static void Create();
     static void Destroy();
+    void Exists();
+    NuDeviceSpecs();
+    ~NuDeviceSpecs();
 
   private:
     void DetermineDeviceSpecs();

--- a/src/nu2api/nusound/nu2api_nusound_misc.cpp
+++ b/src/nu2api/nusound/nu2api_nusound_misc.cpp
@@ -1,4 +1,5 @@
 #include "nu2api_nusound_types.h"
+#include <float.h>
 
 void SetSoundFadeDist(WORLDINFO_s *, OPTIONSSAVE_s *) {
 }
@@ -11,13 +12,4 @@ void edanimSoundCreate(nuvec_s *) {
 
 f32 GameSetSoundVolume(OPTIONSSAVE_s *) {
     return 0.0f;
-}
-
-NuSoundListener *NuSoundSystem::GetNearestRealListener(NuEList<NuSoundListener, DefaultElist> const &, VuVec const &) {
-    return NULL;
-}
-
-NuSoundListener *NuSoundSystem::GetNearestFocusListener(NuEList<NuSoundListener, DefaultElist> const &, VuVec const &,
-                                                        float &) {
-    return NULL;
 }

--- a/src/nu2api/nusound/nulist.hpp
+++ b/src/nu2api/nusound/nulist.hpp
@@ -7,6 +7,8 @@ class NuSoundHandle;
 
 class NuListNodeBase {
     friend class NuSoundHandle;
+    friend class NuSoundVoice;
+    friend class NuSoundBus;
 
     NuListNodeBase *prev;
     NuListNodeBase *next;
@@ -52,6 +54,8 @@ template <typename T> class NuListNode : public NuListNodeBase {
 
 template <typename T> class NuList {
     friend class NuSoundHandle;
+    friend class NuSoundVoice;
+    friend class NuSoundBus;
 
     NuListNodeBase start;
     NuListNodeBase end;

--- a/src/nu2api/nusound/nusound3_include.cpp
+++ b/src/nu2api/nusound/nusound3_include.cpp
@@ -3,6 +3,7 @@
 #include "decomp.h"
 
 #include "nu2api/nuandroid/ios_graphics.h"
+#include "nu2api/nu3d/nucamera.h"
 #include "nu2api/nucore/nucore.hpp"
 #include "nu2api/nucore/nutime.h"
 #include "nu2api/nucore/numemory.h"
@@ -26,15 +27,15 @@
 
 // Stereo stream slot (0x10 bytes in the original):
 //   +0x0 stream            the streaming sample playing in this slot
-//   +0x4 volume            the PS2 volume (0..16383) as raw bits
-//   +0x8 loop              PENDING-START flag: PlayStereoV sets it to 1, and
+//   +0x4 loop              PENDING-START flag: PlayStereoV sets it to 1, and
 //                          NuSound3Update clears it once the voice is created
+//   +0x8 volume            the PS2 volume (0..16383) as raw bits
 //   +0xc field_0xc         the voice/loader loop flag (PlayStereoV key 0xb)
 //   +0xd field_0xd         started flag: set once the voice began playing
 struct NuSoundStream {
     NuSoundStreamingSample *stream;
+    u8 loop;
     i32 ps2volume;
-    i32 loop;
     u8 field_0xc;
     u8 field_0xd;
 };
@@ -46,14 +47,10 @@ class NuSound3Stream {
     static NuSoundWeakPtr<NuSoundVoice> mVoice;
 };
 
-NuSoundWeakPtr<NuSoundVoice> NuSound3Stream::mVoice;
+
 
 DECOMP_ASSERT(sizeof(NuSound3Stream::mVoice) == 0x10, "NuSound3Stream voice pointer size");
 
-static NuSoundListener g_NuSoundListener;
-static NuEListNode<NuSoundListener> g_NuSoundListenerNode;
-static NuEList<NuSoundListener> g_NuSoundListenerList;
-static NUMTX g_NuSoundHeadMatrix;
 // The original focused the listener on the player object; the title screen
 // runs before gameplay, where it is NULL and the focus stays disabled.
 static void *g_NuSoundFocusPlayer = NULL;
@@ -63,11 +60,65 @@ extern "C" {
     const char *audio_ps2_music_ext = ".vag";
 }
 
+template <> class NuVector<nusound_filename_info_s> {
+  public:
+    nusound_filename_info_s *data;
+    u32 capacity;
+    u32 length;
+    NuVector() : data(NULL), capacity(0), length(0) {}
+    ~NuVector() {
+        if (length != 0) length = 0;
+        if (data != NULL) {
+            NuMemoryGet()->GetThreadMem()->BlockFree(data, 0);
+            capacity = 0;
+            data = NULL;
+        }
+    }
+    void PushBack(const nusound_filename_info_s &value) {
+        if (length + 1 > capacity) {
+            u32 new_capacity = (length + 4) & ~3u;
+            nusound_filename_info_s *replacement = static_cast<nusound_filename_info_s *>(
+                NuMemoryGet()->GetThreadMem()->_BlockReAlloc(data, new_capacity * sizeof(*data),
+                                                            4, 0x41, "", NUMEMORY_CATEGORY_NONE));
+            if (replacement != data) {
+                nusound_filename_info_s *previous = data;
+                for (u32 i = 0; i < length; ++i) replacement[i] = previous[i];
+                NuMemoryGet()->GetThreadMem()->BlockFree(previous, 0);
+            }
+            capacity = new_capacity;
+            data = replacement;
+        }
+        data[length++] = value;
+    }
+};
+
 static NuVector<nusound_filename_info_s> g_NuSoundSamples;
+
+extern "C" bool NuSound3IsSampleLoaded(i32 index) {
+    return g_NuSoundSamples.data[index].sample->GetLoadState() == NuSoundSample::LoadState::LOADED;
+}
+
+extern "C" NuSoundVoice *NuSound3FindOldestVoice(i32 index, f32 &age) {
+    NuSoundSample *sample = g_NuSoundSamples.data[index].sample;
+    return sample != NULL ? NuSound.GetOldestVoice(sample, age) : NULL;
+}
+
+extern "C" NuSoundVoice *NuSound3FindQuietestVoice(i32 index, f32 &volume) {
+    NuSoundSample *sample = g_NuSoundSamples.data[index].sample;
+    return sample != NULL ? NuSound.GetQuietestVoice(sample, volume) : NULL;
+}
 
 static NuSoundStream *g_NuSoundStreams[4] = {0};
 
+extern "C" f32 NuSound3GetStreamPlaybackTime(i32 index) {
+    if (g_NuSoundStreams[index] != NULL && NuSound3Stream::mVoice.obj != NULL) {
+        return reinterpret_cast<NuSoundVoice *>(NuSound3Stream::mVoice.obj)->GetPlaybackPositionSeconds();
+    }
+    return 0.0f;
+}
+
 static NuSoundLoadTrigger g_NuSoundLoadTrigger;
+static NuCriticalSection g_NuSoundLoadCriticalSection("NuSoundCriticalSection::mCriticalSection");
 
 // 0x44-byte voice wrapper the NuSound3 API keeps per playing source. The
 // elists link these while they are pending playback / active / pending
@@ -81,42 +132,73 @@ struct NuSound3Voice {
     f32 falloff_b; // +0x28
     bool has_3d;
     nuvec_s position;
-    f32 pan;
-    f32 rnd;
-    f32 rumble;
+    nuvec_s *position_source;
     i32 pause_counter; // frames in the update sweep
 };
 
-DECOMP_ASSERT(sizeof(NuSound3Voice) == 0x44, "NuSound3Voice size");
+DECOMP_ASSERT(sizeof(NuSound3Voice) == 0x3c, "NuSound3Voice payload size");
+
+template <> class NuEListNode<NuSound3Voice, DefaultElist> {
+  public:
+    NuEListNode *prev;
+    NuEListNode *next;
+    NuSound3Voice data;
+};
+
+DECOMP_ASSERT(sizeof(NuSoundStream) == 0x10, "stream slot size");
+DECOMP_ASSERT(offsetof(NuSoundStream, loop) == 4, "stream pending flag offset");
+DECOMP_ASSERT(offsetof(NuSoundStream, ps2volume) == 8, "stream volume offset");
+
+template <> class NuEList<NuSound3Voice, DefaultElist> {
+  public:
+    typedef NuEListNode<NuSound3Voice> Node;
+    struct VoiceQueueLinks { Node *prev; Node *next; } start, end;
+    Node *head;
+    Node *tail;
+    u32 length;
+    NuEList() {
+        head = reinterpret_cast<Node *>(&start);
+        tail = reinterpret_cast<Node *>(&end);
+        start.prev = NULL;
+        end.next = NULL;
+        start.next = tail;
+        end.prev = head;
+        length = 0;
+    }
+    ~NuEList() {
+        while (length != 0) {
+            Node *node = head->next;
+            if (node->prev != NULL) node->prev->next = node->next;
+            if (node->next != NULL) node->next->prev = node->prev;
+            --length;
+            node->next = NULL;
+            node->prev = NULL;
+            delete node;
+        }
+    }
+};
+
+DECOMP_ASSERT(sizeof(NuEList<NuSound3Voice>) == 0x1c, "voice queue size");
+DECOMP_ASSERT(sizeof(NuEListNode<NuSound3Voice>) == 0x44, "voice node size");
 
 namespace {
 
     // NuEList append/remove, done here as local helpers so the list header keeps
     // emitting no inline code into every translation unit that pulls it in.
     void StreamListPushBack(NuEList<NuSound3Voice> *list, NuEListNode<NuSound3Voice> *node) {
-        node->prev = list->tail;
-        node->next = NULL;
-        if (list->tail != NULL) {
-            list->tail->next = node;
-        } else {
-            list->head = node;
-        }
-        list->tail = node;
-        list->length++;
+        node->prev = list->tail->prev;
+        node->next = list->tail;
+        list->tail->prev->next = node;
+        list->tail->prev = node;
+        ++list->length;
     }
 
     void StreamListRemove(NuEList<NuSound3Voice> *list, NuEListNode<NuSound3Voice> *node) {
-        if (node->prev != NULL) {
-            node->prev->next = node->next;
-        } else {
-            list->head = node->next;
-        }
-        if (node->next != NULL) {
-            node->next->prev = node->prev;
-        } else {
-            list->tail = node->prev;
-        }
-        list->length--;
+        if (node->prev != NULL) node->prev->next = node->next;
+        if (node->next != NULL) node->next->prev = node->prev;
+        --list->length;
+        node->prev = NULL;
+        node->next = NULL;
     }
 
 } // namespace
@@ -124,8 +206,54 @@ namespace {
 static NuEList<NuSound3Voice> g_NuSoundVoicesPendingPlayback{};
 static NuEList<NuSound3Voice> g_NuSoundVoicesActive{};
 static NuEList<NuSound3Voice> g_NuSoundVoicesPendingDestruction{};
+static i32 g_NuSoundNumReplaceableVoices;
+
+NuSoundWeakPtr<NuSoundVoice> NuSound3Stream::mVoice;
+
+extern "C" void NuSound3StopVoice(NuSoundVoice *voice) {
+    if (voice == NULL) return;
+    voice->Stop(false);
+    for (NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesActive.head->next;
+         node != g_NuSoundVoicesActive.tail; node = node->next) {
+        if (reinterpret_cast<NuSoundVoice *>(node->data.weak_ptr.obj) != voice) continue;
+        if (node->next != g_NuSoundVoicesActive.tail || node != NULL) {
+            if (node->next != NULL || node->prev != NULL) {
+                --g_NuSoundVoicesActive.length;
+                if (node->prev != NULL) node->prev->next = node->next;
+                if (node->next != NULL) node->next->prev = node->prev;
+                node->next = NULL;
+                node->prev = NULL;
+            }
+            StreamListPushBack(&g_NuSoundVoicesPendingDestruction, node);
+            ++g_NuSoundNumReplaceableVoices;
+        }
+        return;
+    }
+}
+
+extern "C" i32 NuSound3CountVoices(i32 index) {
+    NuSoundSample *sample = g_NuSoundSamples.data[index].sample;
+    if (sample == NULL) return 0;
+    i32 count = sample->field_0x18;
+    for (NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesPendingPlayback.head->next;
+         node != g_NuSoundVoicesPendingPlayback.tail; node = node->next) {
+        if (node->data.source == sample) ++count;
+    }
+    return count;
+}
 
 static NuSoundBuffer g_NuSoundStreamBuffers[4];
+
+static NuSoundListener g_NuSoundListener;
+
+extern "C" void NuSound3Listener(const VuMtx *matrix) {
+    g_NuSoundListener.SetHeadMatrix(matrix);
+}
+
+extern "C" const VuMtx *NuSound3GetListener() {
+    return g_NuSoundListener.GetHeadMatrix();
+}
+
 
 static NuSoundStreamer *g_NuSoundStreamer = NULL;
 
@@ -133,7 +261,7 @@ __attribute__((visibility("hidden"))) u16 *g_NuSoundLoadBits asm("_ZL17g_NuSound
 __attribute__((visibility("hidden"))) u16 *g_NuSoundLoadBitsCache asm("_ZL22g_NuSoundLoadBitsCache") = NULL;
 __attribute__((visibility("hidden"))) i32 g_NuSoundNumLoadBitShorts asm("_ZL25g_NuSoundNumLoadBitShorts") = 0;
 static NuThread *g_NuSoundLoadThread = NULL;
-static pthread_mutex_t g_NuSoundLoadCriticalSection = PTHREAD_MUTEX_INITIALIZER;
+
 
 void NuSound3SampleLoadThread(void *arg) {
     (void)arg;
@@ -150,7 +278,7 @@ void NuSound3SampleLoadThread(void *arg) {
             continue;
         }
 
-        pthread_mutex_lock(&g_NuSoundLoadCriticalSection);
+        pthread_mutex_lock(&g_NuSoundLoadCriticalSection.mutex);
 
         for (u32 i = 0; i < g_NuSoundSamples.length; i++) {
             nusound_filename_info_s &info = g_NuSoundSamples.data[i];
@@ -158,15 +286,15 @@ void NuSound3SampleLoadThread(void *arg) {
                 continue;
             }
 
-            u16 request = g_NuSoundLoadBits[i >> 4] & static_cast<u16>(1 << (i & 0xf));
-            NuSoundSample *sample = reinterpret_cast<NuSoundSample *>(info.sample);
-            NuSoundSample::LoadState load_state = sample->GetLoadState();
-            sample->GetLastErrorState();
+            i32 request = static_cast<u16>(g_NuSoundLoadBits[i >> 4] & (1 << (i & 0xf)));
+            NuSoundSample::LoadState load_state = info.sample->GetLoadState();
+            info.sample->GetLastErrorState();
+            NuSoundSample *sample = info.sample;
 
             if (request == 0 && load_state != NuSoundSample::LoadState::NOT_LOADED && sample != NULL &&
                 sample->field_0x18 == 0) {
                 sample->Release();
-                sample->Unload();
+                info.sample->Unload();
             }
         }
 
@@ -176,19 +304,19 @@ void NuSound3SampleLoadThread(void *arg) {
                 continue;
             }
 
-            u16 request = g_NuSoundLoadBits[i >> 4] & static_cast<u16>(1 << (i & 0xf));
-            NuSoundSample *sample = reinterpret_cast<NuSoundSample *>(info.sample);
-            NuSoundSample::LoadState load_state = sample->GetLoadState();
-            NuSoundSample::ErrorState error = sample->GetLastErrorState();
+            i32 request = static_cast<u16>(g_NuSoundLoadBits[i >> 4] & (1 << (i & 0xf)));
+            NuSoundSample::LoadState load_state = info.sample->GetLoadState();
+            NuSoundSample::ErrorState error = info.sample->GetLastErrorState();
+            NuSoundSample *sample = info.sample;
 
             if (request != 0 && error != NuSoundSample::ErrorState::FILE_NOT_FOUND &&
                 load_state == NuSoundSample::LoadState::NOT_LOADED && sample != NULL) {
                 sample->Reference();
-                sample->Load(NULL, 0, NULL);
+                info.sample->Load(NULL, 0, NULL);
             }
         }
 
-        pthread_mutex_unlock(&g_NuSoundLoadCriticalSection);
+        pthread_mutex_unlock(&g_NuSoundLoadCriticalSection.mutex);
     }
 }
 
@@ -245,11 +373,11 @@ NuSoundLoader *NuSoundSystem::CreateFileLoader(FileType type) {
 }
 
 void NuSound3Init(i32 zero) {
-    bool is_crappy = NuIOS_IsLowEndDevice();
+    i32 extra_memory = NuIOS_IsLowEndDevice() ? 0 : 0x1ccccd;
 
     NuCore::Initialize();
 
-    NuSound.Initialise(0x633333 + (is_crappy ? 0 : 0x1ccccd));
+    NuSound.Initialise(0x633333 + extra_memory);
     // libTTapp.so 0x3109af: NuSound3Init brings up the decoder singleton
     // thread right after the sound system.
     NuSoundDecoder::Initialise();
@@ -271,7 +399,7 @@ void NuSound3Init(i32 zero) {
     // NuSound3Init registers the single 3D listener with the head matrix of
     // the title screen camera.
     NuSound.AddListener(&g_NuSoundListener);
-    g_NuSoundListener.SetHeadMatrix((const VuMtx *)&g_NuSoundHeadMatrix);
+    g_NuSoundListener.SetHeadMatrix(reinterpret_cast<const VuMtx *>(&global_camera.mtx));
     g_NuSoundListener.Enable();
 
     g_NuSoundStreamBuffers[0].Allocate(NuSoundSystem::GetStreamBufferSize() / 2,
@@ -405,14 +533,19 @@ void NuSound3StopStereoStream(i32 stream_index) {
     if (NuSound3Stream::mVoice.obj != NULL && stream->field_0xd != 0) {
         ((NuSoundVoice *)NuSound3Stream::mVoice.obj)->Stop(true);
         NuSound.ReleaseVoice((NuSoundVoice *)NuSound3Stream::mVoice.obj);
-        NuSound3Stream::mVoice.Set(NULL);
+        NuSoundWeakPtrListNode::sPtrListLock.Lock();
+        if (NuSound3Stream::mVoice.obj != NULL) {
+            NuSound3Stream::mVoice.obj->Unlink(&NuSound3Stream::mVoice);
+            NuSound3Stream::mVoice.obj = NULL;
+        }
+        NuSoundWeakPtrListNode::sPtrListLock.Unlock();
         stream->field_0xd = 0;
     }
 
     NuSoundStreamingSample *sample = stream->stream;
     if (sample != NULL && sample->GetResourceCount() > 0) {
-        sample->Release();
-        g_NuSoundStreamer->RequestClose(sample);
+        stream->stream->Release();
+        g_NuSoundStreamer->RequestClose(stream->stream);
     }
 }
 
@@ -430,70 +563,72 @@ void NuSound3ResumeStereoStream(i32 stream_index) {
     }
 }
 
-// NuSound3CreateVoice wraps a one-shot 3D sound source into a NuSound3Voice
-// and queues it for voice creation in NuSound3Update. Sources are limited to
-// three pending plays each, sixteen in flight overall, and the oldest active
-// voice gets stolen first when the budget is exhausted.
-void NuSound3CreateVoice(nuvec_s *pos, i32 index, f32 volume, f32 pitch, i32 falloff_a, i32 falloff_b, f32 pan,
-                         bool has_3d) {
-    if (NuSound.GetNumAvailableOutputDevices() < 1 || index < 0 || g_NuSoundSamples.length <= index) {
-        LOG_INFO("NuSound3 rejected one-shot sample=%d devices=%d samples=%d", index,
-                 NuSound.GetNumAvailableOutputDevices(), g_NuSoundSamples.length);
-        return;
+// Queue a source using the reference per-source replacement policy.
+void NuSound3CreateVoice(nuvec_s *pos, i32 index, f32 falloff_a, f32 falloff_b,
+                        i32 volume, i32 unused, f32 pitch, bool has_3d) {
+    if (NuSound.GetNumAvailableOutputDevices() < 1 || index < 0 ||
+        index >= static_cast<i32>(g_NuSoundSamples.length)) return;
+    NuSoundSample *sample = g_NuSoundSamples.data[index].sample;
+    if (sample == NULL || sample->GetLoadState() != NuSoundSample::LoadState::LOADED) return;
+    if (sample->GetResourceCount() <= 0) return;
+    i32 total = g_NuSoundVoicesPendingPlayback.length + g_NuSoundVoicesActive.length;
+    i32 count = sample->field_0x18;
+    for (NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesPendingPlayback.head->next;
+         node != g_NuSoundVoicesPendingPlayback.tail; node = node->next) {
+        if (node->data.source == sample) ++count;
     }
-
-    NuSoundSource *source = g_NuSoundSamples.data[index].sample;
-    NuSoundSample *sample = (NuSoundSample *)source;
-    if (sample == NULL || sample->GetLoadState() != NuSoundSample::LoadState::LOADED ||
-        sample->GetResourceCount() < 1) {
-        LOG_INFO("NuSound3 rejected unloaded one-shot sample=%d source=%p state=%d resources=%d", index,
-                 static_cast<void *>(sample), sample != NULL ? static_cast<i32>(sample->GetLoadState()) : -1,
-                 sample != NULL ? sample->GetResourceCount() : -1);
-        return;
+    if (count > 2 || total > 15) {
+        if (has_3d || g_NuSoundSamples.data[index].field7_0x1c == 0 || count <= 2) return;
+        f32 age = 0.0f;
+        NuSoundVoice *oldest = NuSound.GetOldestVoice(sample, age);
+        if (oldest != NULL) NuSound3StopVoice(oldest);
     }
-
-    // Per-source pending limit: three wrappers already queued for this source.
-    i32 pending = 0;
-    for (NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesPendingPlayback.head; node != NULL; node = node->next) {
-        if (node->data->source == source) {
-            pending++;
-        }
-    }
-    if (pending >= 3) {
-        return;
-    }
-
-    // Total in-flight budget (pending + active); steal the oldest otherwise.
-    while (g_NuSoundVoicesPendingPlayback.length + g_NuSoundVoicesActive.length >= 16) {
-        NuEListNode<NuSound3Voice> *oldest = g_NuSoundVoicesActive.head;
-        if (oldest == NULL) {
-            return;
-        }
-        if (oldest->data->weak_ptr.obj != NULL) {
-            ((NuSoundVoice *)oldest->data->weak_ptr.obj)->Stop(true);
-            NuSound.ReleaseVoice((NuSoundVoice *)oldest->data->weak_ptr.obj);
-            oldest->data->weak_ptr.Set(NULL);
-        }
-        StreamListRemove(&g_NuSoundVoicesActive, oldest);
-        delete oldest->data;
-        delete oldest;
-    }
-
-    NuSound3Voice *voice = new NuSound3Voice();
-    voice->source = source;
-    voice->pitch = pitch;
-    voice->volume = *(i32 *)&volume;
-    voice->falloff_a = (f32)falloff_a;
-    voice->falloff_b = (f32)falloff_b;
-    voice->has_3d = has_3d;
-    voice->position = *pos;
-    voice->pan = pan;
-    voice->pause_counter = 0;
-
     NuEListNode<NuSound3Voice> *node = new NuEListNode<NuSound3Voice>();
-    node->data = voice;
+    node->data.source = sample;
+    node->data.falloff_a = falloff_a;
+    node->data.falloff_b = falloff_b;
+    node->data.volume = volume;
+    node->data.pitch = pitch;
+    node->data.has_3d = has_3d;
+    node->data.position_source = pos;
+    if (pos != NULL) node->data.position = *pos;
     StreamListPushBack(&g_NuSoundVoicesPendingPlayback, node);
-    LOG_INFO("NuSound3 queued one-shot sample=%d pending=%d", index, g_NuSoundVoicesPendingPlayback.length);
+}
+
+extern "C" void NuSound3Play(i32 index, i32 volume, i32 unused, f32 pitch) {
+    NuSound3CreateVoice(NULL, index, 0.0f, 0.0f, volume, unused, pitch, false);
+}
+
+extern "C" void NuSound3Play3d(nuvec_s *position, i32 index, f32 near_distance, f32 far_distance,
+                                i32 volume, i32 unused, f32 pitch) {
+    NuSound3CreateVoice(position, index, near_distance, far_distance, volume, unused, pitch, false);
+}
+
+extern "C" void NuSound3Play3dPri(nuvec_s *position, i32 index, f32 unused_near, f32 unused_far,
+                                   i32 volume, i32 unused, f32 pitch) {
+    NuSound3CreateVoice(position, index, 0.0f, 0.0f, volume, unused, pitch, false);
+}
+
+extern "C" void NuSound3PlayPri(i32 index, i32 volume, i32 unused, f32 pitch) {
+    NuSound3CreateVoice(NULL, index, 0.0f, 0.0f, volume, unused, pitch, false);
+}
+
+extern "C" void NuSound3Play3dLoopSfx(nuvec_s *position, i32 index, f32 near_distance,
+                                     f32 far_distance, i32 volume, i32 unused, f32 pitch) {
+    for (NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesActive.head->next;
+         node != g_NuSoundVoicesActive.tail; node = node->next) {
+        if (node->data.position_source != position) continue;
+        node->data.pause_counter = 0;
+        if (node->data.weak_ptr.obj != NULL) {
+            reinterpret_cast<NuSoundVoice *>(node->data.weak_ptr.obj)->SetPosition(reinterpret_cast<VuVec *>(position));
+            reinterpret_cast<NuSoundVoice *>(node->data.weak_ptr.obj)->SetVolume(PS2VolumeToScalar(volume));
+            reinterpret_cast<NuSoundVoice *>(node->data.weak_ptr.obj)->SetPitch(pitch);
+            reinterpret_cast<NuSoundVoice *>(node->data.weak_ptr.obj)->SetFalloff(
+                near_distance, far_distance, static_cast<NuSoundSystem::FalloffType>(0));
+        }
+        return;
+    }
+    NuSound3CreateVoice(position, index, near_distance, far_distance, volume, unused, pitch, true);
 }
 
 void NuSound3Update(void) {
@@ -513,68 +648,66 @@ void NuSound3Update(void) {
     pthread_mutex_lock(&NuSound.mutex);
 
     // (a) Voices queued for destruction: release and unlink.
-    for (NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesPendingDestruction.head; node != NULL;) {
+    for (NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesPendingDestruction.head->next; node != g_NuSoundVoicesPendingDestruction.tail;) {
         NuEListNode<NuSound3Voice> *next = node->next;
-        if (node->data->weak_ptr.obj != NULL) {
-            NuSound.ReleaseVoice((NuSoundVoice *)node->data->weak_ptr.obj);
-            node->data->weak_ptr.Set(NULL);
+        if (node->data.weak_ptr.obj != NULL) {
+            NuSound.ReleaseVoice((NuSoundVoice *)node->data.weak_ptr.obj);
+            node->data.weak_ptr.Set(NULL);
         }
         StreamListRemove(&g_NuSoundVoicesPendingDestruction, node);
-        delete node->data;
         delete node;
         node = next;
     }
 
-    // (b) Active sweep: release stopped voices and long-paused ones.
-    for (NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesActive.head; node != NULL;) {
+    // (b) Active sweep: release stopped voices and unrefreshed loops.
+    for (NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesActive.head->next; node != g_NuSoundVoicesActive.tail;) {
         NuEListNode<NuSound3Voice> *next = node->next;
-        NuSoundVoice *voice = (NuSoundVoice *)node->data->weak_ptr.obj;
+        NuSoundVoice *voice = (NuSoundVoice *)node->data.weak_ptr.obj;
 
         if (voice != NULL) {
             NuSoundVoice::PlayState state = voice->GetState();
-            if (state != NuSoundVoice::PLAYSTATE_STOPPED && node->data->pause_counter < 16) {
+            if (state != NuSoundVoice::PLAYSTATE_STOPPED && node->data.pause_counter < 16) {
                 if ((voice->flags & 8) != 0) {
-                    node->data->pause_counter++;
+                    node->data.pause_counter++;
                 }
                 node = next;
                 continue;
             }
             voice->Stop(true);
-            NuSound.ReleaseVoice(voice);
-            node->data->weak_ptr.Set(NULL);
+            NuSound.ReleaseVoice(reinterpret_cast<NuSoundVoice *>(node->data.weak_ptr.obj));
         }
 
         StreamListRemove(&g_NuSoundVoicesActive, node);
-        delete node->data;
         delete node;
         node = next;
     }
 
     // (c) Pending playback: create voices while the budget allows.
     while (NuSound.voice_count < 30) {
-        NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesPendingPlayback.head;
-        if (node == NULL) {
+        NuEListNode<NuSound3Voice> *node = g_NuSoundVoicesPendingPlayback.head->next;
+        if (node == g_NuSoundVoicesPendingPlayback.tail) {
             break;
         }
 
-        NuSoundVoice *voice = NuSound.CreateVoice(node->data->source, false);
+        StreamListRemove(&g_NuSoundVoicesPendingPlayback, node);
+        NuSoundVoice *voice = NuSound.CreateVoice(node->data.source, node->data.has_3d);
         if (voice == NULL) {
-            break;
+            delete node;
+            continue;
         }
 
-        node->data->weak_ptr.Set(voice);
+        node->data.weak_ptr.Set(voice);
         voice->SetAutoDelete(true);
-        voice->SetVolume(PS2VolumeToScalar(node->data->volume));
-        voice->SetPitch(node->data->pitch);
-        if (node->data->has_3d) {
-            voice->SetFalloff(node->data->falloff_a, node->data->falloff_b, NuSoundSystem::FalloffType::LINEAR);
-            voice->SetPosition((VuVec *)&node->data->position);
+        voice->SetVolume(PS2VolumeToScalar(node->data.volume));
+        voice->SetPitch(node->data.pitch);
+        if (node->data.position_source != NULL) {
+            voice->SetFalloff(node->data.falloff_a, node->data.falloff_b, NuSoundSystem::FalloffType::LINEAR);
+            voice->SetPosition((VuVec *)&node->data.position);
             voice->SetSurroundMode(NuSoundSystem::SurroundMode::ZERO);
-            voice->SetListeners(&g_NuSoundListenerList);
+            voice->SetListeners(NuSound.GetListeners());
         }
         voice->Play();
 
-        StreamListRemove(&g_NuSoundVoicesPendingPlayback, node);
         StreamListPushBack(&g_NuSoundVoicesActive, node);
     }
 
@@ -588,32 +721,30 @@ void NuSound3Update(void) {
             continue;
         }
 
-        if (stream->loop != 0) {
-            if (NuSound3Stream::mVoice.obj == NULL) {
+        if (stream->loop != 0 && NuSound3Stream::mVoice.obj == NULL) {
                 NuSoundStreamingSample *sample = stream->stream;
                 if (sample != NULL && sample->GetLoadState() == NuSoundSample::LoadState::STREAM_READY &&
-                    sample->GetResourceCount() >= 1 && sample->GetThreadQueueCount() == 0) {
-                    NuSoundVoice *voice = NuSound.CreateVoice(sample, stream->field_0xc != 0);
-                    if (voice != NULL) {
-                        NuSound3Stream::mVoice.Set(voice);
-                        voice->SetAutoDelete(false);
-                        voice->SetVolume(PS2VolumeToScalar(stream->ps2volume));
-                        voice->Play();
+                    stream->stream->GetResourceCount() >= 1 && stream->stream->GetThreadQueueCount() == 0) {
+                    NuSound3Stream::mVoice.Set(NuSound.CreateVoice(stream->stream, stream->field_0xc != 0));
+                    if (NuSound3Stream::mVoice.obj != NULL) {
+                        ((NuSoundVoice *)NuSound3Stream::mVoice.obj)->SetAutoDelete(false);
+                        ((NuSoundVoice *)NuSound3Stream::mVoice.obj)->SetVolume(PS2VolumeToScalar(stream->ps2volume));
+                        ((NuSoundVoice *)NuSound3Stream::mVoice.obj)->Play();
                         stream->loop = 0;
                         stream->field_0xd = 1;
                     }
                 }
-            }
         } else if (stream->field_0xd != 0) {
             if (NuSound3Stream::mVoice.obj != NULL) {
                 ((NuSoundVoice *)NuSound3Stream::mVoice.obj)->SetVolume(PS2VolumeToScalar(stream->ps2volume));
                 if (((NuSoundVoice *)NuSound3Stream::mVoice.obj)->GetState() == NuSoundVoice::PLAYSTATE_STOPPED) {
                     NuSound3StopStereoStream(i);
                 }
-            } else {
-                // The voice was released elsewhere; retire the stream.
-                NuSound3StopStereoStream(i);
             }
+        }
+
+        if (stream->field_0xd != 0 && NuSound3Stream::mVoice.obj == NULL) {
+            NuSound3StopStereoStream(i);
         }
 
         // Slot cleanup: fully unloaded streams free their node.
@@ -679,9 +810,6 @@ i32 NuSound3StreamKeyStatus(i32 stream_index) {
 // Volume arrives as the PS2-style 0..16383 fixed point computed by
 // NuMusic::Process. The streamer applies it when mixing.
 void NuSound3SetStereoStreamVolume(i32 stream_index, i32 volume) {
-    if (stream_index < 0 || stream_index >= 4) {
-        return;
-    }
     NuSoundStream *stream = g_NuSoundStreams[stream_index];
     if (stream != NULL) {
         stream->ps2volume = volume;
@@ -693,6 +821,10 @@ void NuSound3SetStereoStreamVolume(i32 stream_index, i32 volume) {
 
 // Decibel attenuation from music.cfg (DUCK/ATTENUATION/GLOBALATTENUATION with
 // negative values): -100 dB and below is silence, 0 dB and above is unity.
+extern "C" f32 NuSound3AmplitudeTodB(f32 amplitude) {
+    return NuSoundSystem::AmplitudeTodB(amplitude);
+}
+
 f32 NuSound3dBToAmplitude(f32 db) {
     if (db <= -100.0f) {
         return 0.0f;
@@ -708,14 +840,14 @@ void NuSound3SetSampleTable(nusound_filename_info_s *info, variptr_u *buffer_sta
         return;
     }
 
-    for (; info->index != -1; info++) {
+    for (; info != NULL && info->index != -1; info++) {
         // TODO: dont cast classes
-        if (info->index < 0x1000) {
-            info->sample = (NuSoundStreamingSample *)NuSound.AddSample(info->filename, NuSoundSystem::FileType::OGG,
-                                                                       NuSoundSource::FeedType::STREAMING);
-        } else {
+        if (info->index > 0xfff) {
             info->sample = (NuSoundStreamingSample *)NuSound.AddSample(info->filename, NuSoundSystem::FileType::WAV,
                                                                        NuSoundSource::FeedType::ZERO);
+        } else {
+            info->sample = (NuSoundStreamingSample *)NuSound.AddSample(info->filename, NuSoundSystem::FileType::OGG,
+                                                                       NuSoundSource::FeedType::STREAMING);
         }
 
         g_NuSoundSamples.PushBack(*info);

--- a/src/nu2api/nusound/nusound_android.cpp
+++ b/src/nu2api/nusound/nusound_android.cpp
@@ -19,9 +19,8 @@ i32 NuSoundAndroid::m_workerThreadCount = 0;
 void NuSoundAndroid::AndroidNuSoundClockThread(void *) {
     // 5 ms tick driving the audio clock callbacks (the callback list is
     // empty in practice on the title screen).
-    NuSoundAndroid *system = &NuSound;
     while (NuSoundAndroid::m_workerThreadCount != 0) {
-        system->clock.HandleCallbacks();
+        NuSoundSystem::Get()->clock.HandleCallbacks();
         NuThreadSleep(5);
     }
 }
@@ -33,7 +32,8 @@ NuSoundAndroid::NuSoundAndroid() : NuSoundSystem() {
     this->factory_list.RegisterFactory(factory, NuSoundStreamDesc::DataFormat::ZERO);
 }
 
-void NuSoundAndroid::CreateEffect(NuSoundEffect::EffectType) {
+NuSoundEffect *NuSoundAndroid::CreateEffect(NuSoundEffect::EffectType) {
+    return NULL;
 }
 
 NuSoundVoice *NuSoundAndroid::CreateVoice(NuSoundSource *source, bool loop) {
@@ -41,26 +41,15 @@ NuSoundVoice *NuSoundAndroid::CreateVoice(NuSoundSource *source, bool loop) {
 }
 
 bool NuSoundAndroid::IsValidBitRate(u32 bits) {
-    // OpenSL PCM supports 8 / 16 / 24 bit containers.
-    return bits == 8 || bits == 16 || bits == 24;
+    return bits == 16 || bits == 8;
 }
 
 bool NuSoundAndroid::IsValidSampleRate(u32 rate_millis) {
-    // OpenSL accepts the standard rates, expressed in milli Hertz.
-    switch (rate_millis / 1000) {
-        case 8000:
-        case 11025:
-        case 12000:
-        case 16000:
-        case 22050:
-        case 24000:
-        case 32000:
-        case 44100:
-        case 48000:
-            return true;
-        default:
-            return false;
-    }
+    return rate_millis == 8000000 || rate_millis == 11025000 || rate_millis == 12000000
+        || rate_millis == 16000000 || rate_millis == 22050000 || rate_millis == 24000000
+        || rate_millis == 32000000 || rate_millis == 44100000 || rate_millis == 48000000
+        || rate_millis == 64000000 || rate_millis == 88200000 || rate_millis == 96000000
+        || rate_millis == 192000000;
 }
 
 u32 NuSoundAndroid::ReportErrorCode(u32 error, const char *message) {
@@ -77,7 +66,7 @@ namespace {
     typedef u32 (*EngineCreateOutputMixFn)(void *, void **, u32, const void **, const u32 *);
     typedef u32 (*QuerySupportedProfilesFn)(void *, u16 *);
     typedef u32 (*QueryAvailableVoicesFn)(void *, u32, i16 *, u32 *, i16 *);
-    typedef u32 (*VolumeSetVolumeLevelFn)(void *, i32);
+    typedef u32 (*VolumeSetMuteFn)(void *, u32);
     typedef u32 (*EnvironmentalReverbSetPropertiesFn)(void *, const void *);
 
 #define SL_SLOT(itf, fn_type, byte_offset) (*(fn_type *)((char *)(*(void **)(itf)) + (byte_offset)))
@@ -96,36 +85,36 @@ bool NuSoundAndroid::InitAudioDevice() {
     }
 
     error = SL_SLOT(this->engine_object, ObjectRealizeFn, 0)(this->engine_object, 0);
-    if (ReportErrorCode(error, "Realize the engine object") != 0) {
+    if (ReportErrorCode(error, "Engine realize") != 0) {
         return false;
     }
 
     void *capabilities = NULL;
     error = SL_SLOT(this->engine_object, ObjectGetInterfaceFn, 0xc)(this->engine_object, SL_IID_ENGINECAPABILITIES,
                                                                     &capabilities);
-    if (ReportErrorCode(error, "Get the engine capabilities interface") == 0) {
+    if (ReportErrorCode(error, "Get engine capabilities interface") == 0) {
         u16 profiles = 0;
         error = SL_SLOT(capabilities, QuerySupportedProfilesFn, 0)(capabilities, &profiles);
-        if (ReportErrorCode(error, "QuerySupportedProfiles") == 0 && (profiles & 4) != 0) {
+        bool supports_3d = ReportErrorCode(error, "QuerySupportedProfiles") == 0 && (profiles & 4) != 0;
+        i16 max_voices = 0;
+        u32 absolute_max = 0;
+        i16 free_voices = 0;
+        error = SL_SLOT(capabilities, QueryAvailableVoicesFn, 4)(capabilities, 1, &max_voices, &absolute_max,
+                                                                 &free_voices);
+        ReportErrorCode(error, "QueryAvailableVoices(SL_VOICETYPE_2D_AUDIO)");
+        if (supports_3d) {
             i16 max_voices = 0;
             u32 absolute_max = 0;
             i16 free_voices = 0;
-            error = SL_SLOT(capabilities, QueryAvailableVoicesFn, 4)(capabilities, 1, &max_voices, &absolute_max,
-                                                                     &free_voices);
-            ReportErrorCode(error, "QueryAvailableVoices (2D audio)");
-
-            max_voices = 0;
-            absolute_max = 0;
-            free_voices = 0;
             error = SL_SLOT(capabilities, QueryAvailableVoicesFn, 4)(capabilities, 4, &max_voices, &absolute_max,
                                                                      &free_voices);
-            ReportErrorCode(error, "QueryAvailableVoices (vibra)");
+            ReportErrorCode(error, "QueryAvailableVoices(SL_VOICETYPE_3D_AUDIO)");
         }
     }
 
     error = SL_SLOT(this->engine_object, ObjectGetInterfaceFn, 0xc)(this->engine_object, SL_IID_ENGINE,
                                                                     &this->audio_engine);
-    if (ReportErrorCode(error, "Get the engine interface") != 0) {
+    if (ReportErrorCode(error, "Get engine interface") != 0) {
         return false;
     }
 
@@ -133,27 +122,25 @@ bool NuSoundAndroid::InitAudioDevice() {
     const u32 mix_required[2] = {0, 0};
     error = SL_SLOT(this->audio_engine, EngineCreateOutputMixFn, 0x1c)(this->audio_engine, &this->output_mix, 2,
                                                                        mix_iids, mix_required);
-    if (ReportErrorCode(error, "Create the output mix object") != 0) {
+    if (ReportErrorCode(error, "Create output mix") != 0) {
         return false;
     }
 
     error = SL_SLOT(this->output_mix, ObjectRealizeFn, 0)(this->output_mix, 0);
-    if (ReportErrorCode(error, "Realize the output mix object") != 0) {
+    if (ReportErrorCode(error, "Realize output mix") != 0) {
         return false;
     }
 
     error = SL_SLOT(this->output_mix, ObjectGetInterfaceFn, 0xc)(this->output_mix, SL_IID_VOLUME, &this->mix_volume);
-    if (ReportErrorCode(error, "Get the output mix volume interface") == 0) {
-        error = SL_SLOT(this->mix_volume, VolumeSetVolumeLevelFn, 0xc)(this->mix_volume, 0);
-        ReportErrorCode(error, "Set the output mix volume");
+    if (ReportErrorCode(error, "Get output volume interface") == 0) {
+        SL_SLOT(this->mix_volume, VolumeSetMuteFn, 0xc)(this->mix_volume, 0);
     }
 
     error = SL_SLOT(this->output_mix, ObjectGetInterfaceFn, 0xc)(this->output_mix, SL_IID_ENVIRONMENTALREVERB,
                                                                  &this->mix_reverb);
-    if (ReportErrorCode(error, "Get the environmental reverb interface") == 0) {
-        error = SL_SLOT(this->mix_reverb, EnvironmentalReverbSetPropertiesFn, 0x50)(this->mix_reverb,
+    if (ReportErrorCode(error, "Get output environmental reverb interface") == 0) {
+        SL_SLOT(this->mix_reverb, EnvironmentalReverbSetPropertiesFn, 0x50)(this->mix_reverb,
                                                                                     this->reverb_properties);
-        ReportErrorCode(error, "Set the environmental reverb properties");
     }
 
     NuSoundSystem::sOutputConfig = this->GetClosestSupportedConfig(2);

--- a/src/nu2api/nusound/nusound_android.hpp
+++ b/src/nu2api/nusound/nusound_android.hpp
@@ -16,12 +16,12 @@ struct NuSoundAndroid : public NuSoundSystem {
     static i32 m_workerThreadCount;
 
     static void AndroidNuSoundClockThread(void *);
-    void CreateEffect(NuSoundEffect::EffectType);
-    NuSoundVoice *CreateVoice(NuSoundSource *, bool) override;
+    NuSoundEffect *CreateEffect(NuSoundEffect::EffectType) override;
+    virtual NuSoundVoice *CreateVoice(NuSoundSource *, bool);
     static bool IsValidBitRate(u32 bits);
     static bool IsValidSampleRate(u32 rate_millis);
     static u32 ReportErrorCode(u32 error, const char *message);
-    void ShutdownAudioDevice();
+    void ShutdownAudioDevice() override;
     void UpdateAudioDevice() override;
 };
 

--- a/src/nu2api/nusound/nusound_buffer.hpp
+++ b/src/nu2api/nusound/nusound_buffer.hpp
@@ -11,12 +11,15 @@ class __attribute__((packed, aligned(4))) NuSoundBuffer {
         u64 size2;
         u64 size3;
         i32 field5_0x18;
-        i32 flags;
+        u8 flags;
+        u8 reserved_0x1d[3];
         i32 field5_0x20;
 
-        Context() : read_size(0), size2(0), size3(0), field5_0x18(0), flags(1), field5_0x20(0) {
-        }
     };
+
+    static_assert(sizeof(Context) == 0x24, "sound buffer context size");
+    static_assert(__builtin_offsetof(Context, flags) == 0x1c, "sound buffer flag byte");
+    static_assert(__builtin_offsetof(Context, field5_0x20) == 0x20, "sound buffer context tail");
 
   private:
     u64 size;

--- a/src/nu2api/nusound/nusound_bus.cpp
+++ b/src/nu2api/nusound/nusound_bus.cpp
@@ -2,17 +2,22 @@
 
 #include "nu2api/nucore/nustring.h"
 #include "nu2api/nusound/nusound_system.hpp"
+#include <string.h>
 
 const char *NuSoundBus::GetName() {
     return this->name;
 }
 
 NuSoundBus *NuSoundSystem::GetBus(const char *name) {
-    LOG_WARN("NuSoundSystem::GetBus is not implemented");
+    for (NuSoundBus *bus = bus_head->next; bus != bus_tail; bus = bus->next) {
+        if (NuStrICmp(bus->GetName(), name) == 0) return bus;
+    }
     return NULL;
 }
 
 NuSoundBus::NuSoundBus(const char *name, bool is_master) {
+    previous = next = NULL;
+
     // this->field15_0x3c = (undefined *)&this->field11_0x2c;
     // this->field13_0x34 = (undefined *)&this->field11_0x2c;
     // this->field1_0x4 = (i32 *)0x0;
@@ -26,6 +31,7 @@ NuSoundBus::NuSoundBus(const char *name, bool is_master) {
     this->parent_bus = NULL;
 
     NuStrCpy(this->name, name);
+    for (unsigned int i = 0; i < 8; ++i) output_mix[i] = 1.0f;
     // this->field2_0x8 = 0x3f800000;
     // this->field3_0xc = 0x3f800000;
     // this->field4_0x10 = 0x3f800000;
@@ -41,29 +47,88 @@ NuSoundBus::NuSoundBus(const char *name, bool is_master) {
 }
 
 NuSoundBus::NuSoundBus(const char *name, NuSoundBus *parent) {
+    previous = next = NULL;
+
     this->parent_bus = parent;
+    NuStrCpy(this->name, name);
+    for (unsigned int i = 0; i < 8; ++i) output_mix[i] = 1.0f;
+    if (parent == NULL) parent_bus = NuSoundSystem::sMasterBus;
 }
 
-NuSoundBus::~NuSoundBus() {
+NuSoundBus::~NuSoundBus() {}
+
+bool NuSoundBus::AddEffect(NuSoundEffect *effect) {
+    if (effects.length != 0) {
+        NuListNodeBase *last = effects.tail->GetPrev();
+        NuListNodeBase *node = effects.Head();
+        for (;;) {
+            if (static_cast<NuListNode<NuSoundEffect *> *>(node)->value == effect) return false;
+            if (node == last) break;
+            node = node->GetNext();
+        }
+    }
+    bool attached = effect->AttachBus(this);
+    if (attached) NuSoundMemory::PushNuListNode(effects, effect);
+    return attached;
 }
 
-void NuSoundBus::AddEffect(NuSoundEffect *) {
+void NuSoundBus::RemoveEffect(NuSoundEffect *effect) {
+    NuListNodeBase *found = effects.Head();
+    while (found != effects.tail && static_cast<NuListNode<NuSoundEffect *> *>(found)->value != effect) found = found->next;
+    if (found == effects.tail) return;
+    effect->DetachBus(this);
+    if (effects.length != 0) {
+        NuListNodeBase *last = effects.tail->prev;
+        NuListNodeBase *node = effects.Head();
+        unsigned int removed = 0;
+        for (;;) {
+            if (static_cast<NuListNode<NuSoundEffect *> *>(node)->value == effect) {
+                bool is_last = node == last;
+                NuListNodeBase *next = node->next;
+                NuListNodeBase *previous = node->prev;
+                if (previous != NULL) previous->next = next;
+                if (next != NULL) next->prev = previous;
+                NuMemoryGet()->GetThreadMem()->BlockFree(node, 0);
+                ++removed;
+                if (is_last) break;
+                node = next;
+                if (node == last) break;
+                // The original advances again after removing a non-final node.
+                node = node->next;
+            } else {
+                if (node == last) break;
+                node = node->next;
+            }
+        }
+        effects.length -= removed;
+    }
+    NuSoundSystem::sAllocdMemory[0] -= sizeof(NuListNode<NuSoundEffect *>);
 }
 
-void NuSoundBus::RemoveEffect(NuSoundEffect *) {
+void NuSoundBus::ApplyFinalMix(float *mix) {
+    NuSoundBus *bus = this;
+    do {
+        float attenuation = 1.0f;
+        for (NuListNodeBase *node = bus->effects.Head(); node != bus->effects.tail; node = node->next) {
+            attenuation *= static_cast<NuListNode<NuSoundEffect *> *>(node)->value->attenuation;
+        }
+        for (unsigned int i = 0; i < 8; ++i) mix[i] *= bus->output_mix[i] * attenuation;
+        bus = bus->parent_bus;
+    } while (bus != NULL);
 }
 
-void NuSoundBus::ApplyFinalMix(float *) {
+void NuSoundBus::GetOutputMix(float *mix) {
+    memmove(mix, output_mix, sizeof(output_mix));
 }
 
-void NuSoundBus::GetOutputMix(float *) {
+void NuSoundBus::SetOutputMix(float mix) {
+    for (unsigned int i = 0; i < 8; ++i) output_mix[i] = mix;
 }
 
-void NuSoundBus::SetOutputMix(float) {
+void NuSoundBus::SetOutputMix(float *mix) {
+    memmove(output_mix, mix, sizeof(output_mix));
 }
 
-void NuSoundBus::SetOutputMix(float *) {
-}
-
-void NuSoundBus::SetOutputBus(NuSoundBus *) {
+void NuSoundBus::SetOutputBus(NuSoundBus *bus) {
+    parent_bus = bus != NULL ? bus : NuSoundSystem::sMasterBus;
 }

--- a/src/nu2api/nusound/nusound_bus.hpp
+++ b/src/nu2api/nusound/nusound_bus.hpp
@@ -1,9 +1,18 @@
 #pragma once
 
+#include "nu2api/nusound/nulist.hpp"
+
 class NuSoundEffect;
 
 class NuSoundBus {
+  public:
+    NuSoundBus *previous;
+    NuSoundBus *next;
+    float output_mix[8];
+
+  private:
     NuSoundBus *parent_bus;
+    NuList<NuSoundEffect *> effects;
     char name[128];
 
   public:
@@ -13,7 +22,7 @@ class NuSoundBus {
 
     const char *GetName();
 
-    void AddEffect(NuSoundEffect *);
+    bool AddEffect(NuSoundEffect *);
     void RemoveEffect(NuSoundEffect *);
     void ApplyFinalMix(float *);
     void GetOutputMix(float *);

--- a/src/nu2api/nusound/nusound_clock.cpp
+++ b/src/nu2api/nusound/nusound_clock.cpp
@@ -1,22 +1,56 @@
 #include "nu2api_nusound_types.h"
 
-void NuSoundClock::AddCallback(NuSoundClock::Callback *) {
+void NuSoundClock::AddCallback(NuSoundClock::Callback *callback) {
+    Links *tail_links = GetLinks(tail);
+    Callback *previous = tail_links->prev;
+    tail_links->prev = callback;
+    callback->prev = previous;
+    GetLinks(previous)->next = callback;
+    callback->next = tail;
+    ++callback_count;
 }
 
-void NuSoundClock::GetClockFrequency() const {
+u64 NuSoundClock::GetClockFrequency() const {
+    return frequency;
 }
 
-void NuSoundClock::GetTicks() const {
+u64 NuSoundClock::GetTicks() const {
+    return 0;
 }
 
 void NuSoundClock::HandleCallbacks() {
+    u64 ticks = GetTicks();
+    u64 clock_frequency = GetClockFrequency();
+    u64 elapsed = ticks - last_ticks;
+    for (Callback *callback = GetLinks(head)->next; callback != tail; callback = callback->next) {
+        callback->OnCallback(elapsed, clock_frequency);
+    }
+    last_ticks = ticks;
 }
 
 NuSoundClock::NuSoundClock() {
+    head = reinterpret_cast<Callback *>(reinterpret_cast<char *>(&start) - sizeof(void *));
+    tail = reinterpret_cast<Callback *>(reinterpret_cast<char *>(&end) - sizeof(void *));
+    start.prev = NULL;
+    start.next = tail;
+    end.prev = head;
+    end.next = NULL;
+    callback_count = 0;
+    last_ticks = 0;
 }
 
-void NuSoundClock::RemoveCallback(NuSoundClock::Callback *) {
+void NuSoundClock::RemoveCallback(NuSoundClock::Callback *callback) {
+    if (callback->next != NULL || callback->prev != NULL) {
+        --callback_count;
+        Callback *next = callback->next;
+        Callback *prev = callback->prev;
+        if (prev != NULL) GetLinks(prev)->next = next;
+        if (next != NULL) GetLinks(next)->prev = prev;
+        callback->next = NULL;
+        callback->prev = NULL;
+    }
 }
 
 NuSoundClock::~NuSoundClock() {
+    while (callback_count != 0) RemoveCallback(GetLinks(head)->next);
 }

--- a/src/nu2api/nusound/nusound_decoder.cpp
+++ b/src/nu2api/nusound/nusound_decoder.cpp
@@ -1,3 +1,4 @@
+#include "decomp_assert.h"
 #include "nusound_decoder.hpp"
 
 #include "nu2api/nucore/nucore.hpp"
@@ -23,12 +24,12 @@ i32 NuSoundDecodeThread::sThreadPriority = 2;
 NuSoundDecoder::NuSoundDecoder(char const *name, NuSoundSource *wrapped)
     : NuSoundSource(NULL, SourceType::STREAMING, NuSoundSource::FeedType::STREAMING) {
     (void)name;
-    static_assert(sizeof(void *) != 4 || sizeof(NuSoundBuffer) == 0x40, "decoder ring buffer stride");
-    static_assert(sizeof(void *) != 4 || sizeof(NuSoundDecoder) == 0xe8, "decoder callback base offset");
-    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, buffers) == 0x24, "embedded decoder buffers");
-    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, decoded_bytes) == 0xb8, "decoder byte counter");
-    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, total_decoded_bytes) == 0xc8, "decoder total byte counter");
-    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, decode_mutex) == 0xdc, "decoder completion mutex");
+    DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundBuffer) == 0x40, "decoder ring buffer stride");
+    DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundDecoder) == 0xe8, "decoder callback base offset");
+    DECOMP_ASSERT(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, buffers) == 0x24, "embedded decoder buffers");
+    DECOMP_ASSERT(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, decoded_bytes) == 0xb8, "decoder byte counter");
+    DECOMP_ASSERT(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, total_decoded_bytes) == 0xc8, "decoder total byte counter");
+    DECOMP_ASSERT(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, decode_mutex) == 0xdc, "decoder completion mutex");
     // The decode-sync pair the decode thread raises per completed request
     // (device offsets +0xdc/+0xe0/+0xe4).
     pthread_mutex_init(&this->decode_mutex, NULL);
@@ -245,10 +246,10 @@ void NuSoundDecoder::RequestBuffer(bool loop, NuSoundWeakPtr<NuSoundBufferCallba
 // libTTapp.so 0x31f010: 128 zeroed loader slots behind a 128-signal
 // semaphore, then the worker thread (priority 2, cafe/xbox core 2).
 NuSoundDecodeThread::NuSoundDecodeThread() : semaphore(128) {
-    static_assert(sizeof(void *) != 4 || sizeof(Loader) == 0x1c, "decode queue entry stride");
-    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecodeThread, loaders) == 4, "decode queue offset");
-    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecodeThread, semaphore) == 0xe0c, "decode semaphore offset");
-    static_assert(sizeof(void *) != 4 || sizeof(NuSoundDecodeThread) == 0xe1c, "decode thread allocation size");
+    DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(Loader) == 0x1c, "decode queue entry stride");
+    DECOMP_ASSERT(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecodeThread, loaders) == 4, "decode queue offset");
+    DECOMP_ASSERT(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecodeThread, semaphore) == 0xe0c, "decode semaphore offset");
+    DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundDecodeThread) == 0xe1c, "decode thread allocation size");
     memset(this->loaders, 0, sizeof(this->loaders));
     this->tail_index = 0;
     this->head_index = 0;

--- a/src/nu2api/nusound/nusound_decoder.cpp
+++ b/src/nu2api/nusound/nusound_decoder.cpp
@@ -1,15 +1,20 @@
 #include "nusound_decoder.hpp"
 
 #include "nu2api/nucore/nucore.hpp"
+#include "nu2api/nucore/numemory.h"
 #include "nu2api/nusound/nusound_buffer.hpp"
 #include "nu2api/nusound/nusound_sample.hpp"
 #include "nu2api/nusound/nusound_voice.hpp"
 #include "nu2api/nusound/nusound_system.hpp"
 
 #include <new>
+#include <string.h>
 
 // libTTapp.so NuSoundDecoder::sDecodeThread @0x11e90d0.
 NuSoundDecodeThread *NuSoundDecoder::sDecodeThread = NULL;
+// Original static initializer at 0xde53d passes a maximum of one signal.
+NuThreadSemaphore NuSoundDecodeThread::sShutdownSemaphore(1);
+i32 NuSoundDecodeThread::sThreadPriority = 2;
 
 // libTTapp.so 0x31eed0: the decoder wraps the source, carries two ring
 // buffer objects and starts closed. The source's stream descriptor (the
@@ -18,46 +23,38 @@ NuSoundDecodeThread *NuSoundDecoder::sDecodeThread = NULL;
 NuSoundDecoder::NuSoundDecoder(char const *name, NuSoundSource *wrapped)
     : NuSoundSource(NULL, SourceType::STREAMING, NuSoundSource::FeedType::STREAMING) {
     (void)name;
-    this->source = wrapped;
-    this->buffers[0] = new NuSoundBuffer();
-    this->buffers[1] = new NuSoundBuffer();
-
-    pthread_mutex_init(&this->mutex, NULL);
-    pthread_cond_init(&this->cond, NULL);
-
+    static_assert(sizeof(void *) != 4 || sizeof(NuSoundBuffer) == 0x40, "decoder ring buffer stride");
+    static_assert(sizeof(void *) != 4 || sizeof(NuSoundDecoder) == 0xe8, "decoder callback base offset");
+    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, buffers) == 0x24, "embedded decoder buffers");
+    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, decoded_bytes) == 0xb8, "decoder byte counter");
+    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, total_decoded_bytes) == 0xc8, "decoder total byte counter");
+    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecoder, decode_mutex) == 0xdc, "decoder completion mutex");
     // The decode-sync pair the decode thread raises per completed request
     // (device offsets +0xdc/+0xe0/+0xe4).
     pthread_mutex_init(&this->decode_mutex, NULL);
     pthread_cond_init(&this->decode_cond, NULL);
-    this->decode_done = false;
-
-    this->consumed_pos = 0;
+    this->source = wrapped;
     this->ring_count = 0;
+    this->consumed_pos = 0;
     this->decode_pos = 0;
-    this->buffers_started = 0;
-    this->buffer_size = 0x2000;
-    this->stream_open = false;
     this->field_0xd4 = 0;
-    this->locked_flag = false;
-    this->loop_flag = false;
+    this->buffer_size = 0x2000;
+    this->field_0xe5 = false;
+    this->decode_done = false;
     this->field_0xc0 = 0;
     this->field_0xc4 = 0;
-    this->field_0xc8 = 0;
-    this->field_0xcc = 0;
     this->total_decoded_bytes = 0;
     this->decoded_bytes = 0;
+    this->stream_open = false;
 
     this->SetStreamDesc(wrapped->GetStreamDesc());
+    this->field_0x1c = 1;
 }
 
 // libTTapp.so 0x31ede0 / 0x31ee70.
 NuSoundDecoder::~NuSoundDecoder() {
-    pthread_mutex_destroy(&this->mutex);
-    pthread_cond_destroy(&this->cond);
     pthread_mutex_destroy(&this->decode_mutex);
     pthread_cond_destroy(&this->decode_cond);
-    delete this->buffers[0];
-    delete this->buffers[1];
 }
 
 __attribute__((weak)) void NuSoundDecoder::Reset() {
@@ -69,24 +66,21 @@ __attribute__((weak)) void NuSoundDecoder::Reset() {
 // been decoded (the remaining chunks decode on demand through the decode
 // thread as the voice consumes the ring).
 bool NuSoundDecoder::OpenStream(bool loop) {
-    u64 total = 0;
     u64 decoded = 0;
     this->source->OpenStream(loop);
 
     NuSoundStreamDesc *desc = this->source->GetStreamDesc();
+    u64 total = desc->GetDecodedLengthBytes();
     this->ring_count = 0;
-    this->decode_pos = 0;
     this->consumed_pos = 0;
+    this->decode_pos = 0;
 
-    if (desc != NULL) {
-        total = desc->GetDecodedLengthBytes();
-    }
-
-    for (u32 i = 0; decoded < total; i++) {
-        NuSoundBuffer &buffer = *this->buffers[i];
+    NuSoundBuffer *ring_buffers = this->buffers;
+    for (i32 i = 0; decoded < total && i < 2; i++) {
+        NuSoundBuffer &buffer = ring_buffers[i];
 
         if (buffer.Allocate(this->buffer_size, NuSoundSystem::MemoryDiscipline::DECODER) != 1) {
-            this->source->CloseStream();
+            this->CloseStream();
             return false;
         }
 
@@ -96,9 +90,6 @@ bool NuSoundDecoder::OpenStream(bool loop) {
         this->decode_pos++;
         this->buffers_started++;
 
-        if (i >= 1) {
-            break;
-        }
     }
 
     this->stream_open = true;
@@ -107,24 +98,33 @@ bool NuSoundDecoder::OpenStream(bool loop) {
 
 // libTTapp.so 0x31e9c0.
 bool NuSoundDecoder::IsStreamOpen() const {
-    return this->stream_open;
+    return this->source->IsStreamOpen() && this->stream_open;
 }
 
 // libTTapp.so 0x31ebb0.
 void NuSoundDecoder::CloseStream() {
+    this->closing = true;
+    while ((i32)this->field_0xd4 > 0) {
+        pthread_mutex_lock(&this->decode_mutex);
+        while (!this->decode_done) {
+            pthread_cond_wait(&this->decode_cond, &this->decode_mutex);
+        }
+        this->decode_done = this->field_0xe5;
+        pthread_mutex_unlock(&this->decode_mutex);
+    }
+    for (i32 i = 0; i < (i32)this->ring_count; ++i) {
+        this->buffers[i].Free();
+    }
+    this->source->CloseStream();
     this->stream_open = false;
-    this->ring_count = 0;
-    this->decode_pos = 0;
-    this->consumed_pos = 0;
 }
 
 // libTTapp.so 0x31f0e0: allocate the singleton decode thread.
 void NuSoundDecoder::Initialise() {
     // 0xe1c is the device-side object size; the host NuThreadSemaphore and
     // weakptr types differ in size, so size the block from the real object.
-    NuSoundDecodeThread *thread = (NuSoundDecodeThread *)NuSoundSystem::_AllocMemory(
-        NuSoundSystem::MemoryDiscipline::SCRATCH, (u32)sizeof(NuSoundDecodeThread), 4,
-        "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/android/nusound_decoder.cpp:69");
+    NuSoundDecodeThread *thread = (NuSoundDecodeThread *)NuMemoryGet()->GetThreadMem()->_BlockAlloc(
+        (u32)sizeof(NuSoundDecodeThread), 4, 1, "", 7);
 
     if (thread != NULL) {
         new (thread) NuSoundDecodeThread();
@@ -135,10 +135,19 @@ void NuSoundDecoder::Initialise() {
 
 // libTTapp.so 0x31fe00.
 void NuSoundDecoder::Shutdown() {
+    if (sDecodeThread != NULL) {
+        sDecodeThread->Shutdown();
+        NuSoundDecodeThread *thread = sDecodeThread;
+        if (thread != NULL) {
+            thread->~NuSoundDecodeThread();
+            NuMemoryGet()->GetThreadMem()->BlockFree(thread, 0);
+        }
+        sDecodeThread = NULL;
+    }
 }
 
 bool NuSoundDecoder::IsLocked() const {
-    return this->locked_flag;
+    return this->source->IsLocked();
 }
 
 // libTTapp.so 0x31eb50: the decoder lock is what keeps the ring buffers'
@@ -147,35 +156,31 @@ bool NuSoundDecoder::IsLocked() const {
 // stays locked at count >= 1 and SubmitBuffer always hands the device a
 // live address while the voice exists.
 void NuSoundDecoder::Lock() {
-    pthread_mutex_lock(&this->mutex);
-    this->locked_flag = true;
-
-    for (u32 i = 0; i < this->ring_count; i++) {
-        this->buffers[i]->Lock();
+    for (i32 i = 0; i < (i32)this->ring_count; i++) {
+        this->buffers[i].Lock();
     }
 }
 
 // libTTapp.so 0x31eaf0.
 void NuSoundDecoder::Unlock() {
-    for (u32 i = 0; i < this->ring_count; i++) {
-        this->buffers[i]->Unlock();
+    for (i32 i = 0; i < (i32)this->ring_count; i++) {
+        this->buffers[i].Unlock();
     }
-
-    pthread_mutex_unlock(&this->mutex);
-    this->locked_flag = false;
 }
 
 // libTTapp.so 0x31eab0 / 0x31ea40: voice bookkeeping on the wrapped source.
 void NuSoundDecoder::VoiceReference() {
-    if (this->source != NULL) {
-        this->source->VoiceReference();
-    }
+    NuSoundSource::VoiceReference();
+    this->source->VoiceReference();
 }
 
 void NuSoundDecoder::VoiceRelease() {
-    if (this->source != NULL) {
-        this->source->VoiceRelease();
-    }
+    this->Reset();
+    this->consumed_pos = 0;
+    this->decode_pos = 0;
+    this->buffers_started = 0;
+    NuSoundSource::VoiceRelease();
+    this->source->VoiceRelease();
 }
 
 // libTTapp.so 0x31ea10: min(ring buffers, sNumInitialBuffersByType[type]).
@@ -204,24 +209,20 @@ u32 NuSoundDecoder::GetMaxBufferSize() {
 // thread (RequestDecode) and returns immediately; the thread decodes the
 // buffer and performs the same SubmitBuffer hand-off on its own stack.
 void NuSoundDecoder::RequestBuffer(bool loop, NuSoundWeakPtr<NuSoundBufferCallback> callback) {
-    if (this->decode_pos > this->consumed_pos && this->ring_count > 0) {
-        NuSoundBuffer &ready = *this->buffers[this->consumed_pos % this->ring_count];
+    if (this->decode_pos > this->consumed_pos) {
+        NuSoundBuffer &ready = this->buffers[this->consumed_pos % this->ring_count];
         NuSoundBuffer::Context &context = ready.GetCurrentContext();
 
-        if ((context.read_size | context.size2) != 0) {
+        if (context.size2 != 0) {
+            pthread_mutex_lock(&NuSoundSample::sCriticalSection);
             NuSoundBufferCallback *cb = (NuSoundBufferCallback *)callback.obj;
             if (cb != NULL) {
-                pthread_mutex_lock(&NuSoundSample::sCriticalSection);
                 cb->SubmitBuffer(&ready);
-                pthread_mutex_unlock(&NuSoundSample::sCriticalSection);
             }
+            pthread_mutex_unlock(&NuSoundSample::sCriticalSection);
         }
 
         this->consumed_pos++;
-        return;
-    }
-
-    if (this->source == NULL || !this->stream_open) {
         return;
     }
 
@@ -229,14 +230,11 @@ void NuSoundDecoder::RequestBuffer(bool loop, NuSoundWeakPtr<NuSoundBufferCallba
     // decode thread and return; the thread performs the decode and the
     // SubmitBuffer hand-off. The ring slot was already allocated by the
     // OpenStream prefill, and the consume cursor advances on the caller side.
-    if (NuSoundDecoder::sDecodeThread != NULL && this->ring_count > 0) {
-        NuSoundBuffer &buffer = *this->buffers[this->decode_pos % this->ring_count];
-        NuSoundWeakPtr<NuSoundBufferCallback> request;
-        request.Set((NuSoundBufferCallback *)callback.obj);
-        NuSoundDecoder::sDecodeThread->RequestDecode(*this, buffer, request, (loop & 1) != 0);
-        this->decode_pos++;
+    {
+        NuSoundBuffer &buffer = this->buffers[this->decode_pos % this->ring_count];
+        NuSoundDecoder::sDecodeThread->RequestDecode(*this, buffer, callback, loop);
     }
-
+    this->decode_pos++;
     this->consumed_pos++;
 }
 
@@ -246,15 +244,19 @@ void NuSoundDecoder::RequestBuffer(bool loop, NuSoundWeakPtr<NuSoundBufferCallba
 
 // libTTapp.so 0x31f010: 128 zeroed loader slots behind a 128-signal
 // semaphore, then the worker thread (priority 2, cafe/xbox core 2).
-NuSoundDecodeThread::NuSoundDecodeThread() : semaphore(128), loaders(), thread(NULL), tail_index(0), head_index(0) {
-    NuSoundDecodeThread *self = this;
-    (void)self;
-    this->thread = NuCore::m_threadManager->CreateThread(NuSoundDecodeThread::ThreadFunc, this, 2, "NuSoundDecode", 0,
-                                                         NUTHREADCAFECORE_UNKNOWN_1, NUTHREADXBOX360CORE_UNKNOWN_1);
+NuSoundDecodeThread::NuSoundDecodeThread() : semaphore(128) {
+    static_assert(sizeof(void *) != 4 || sizeof(Loader) == 0x1c, "decode queue entry stride");
+    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecodeThread, loaders) == 4, "decode queue offset");
+    static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundDecodeThread, semaphore) == 0xe0c, "decode semaphore offset");
+    static_assert(sizeof(void *) != 4 || sizeof(NuSoundDecodeThread) == 0xe1c, "decode thread allocation size");
+    memset(this->loaders, 0, sizeof(this->loaders));
+    this->tail_index = 0;
+    this->head_index = 0;
+    this->thread = NuCore::m_threadManager->CreateThread(NuSoundDecodeThread::ThreadFunc, this, sThreadPriority, "NuSoundDecode", 0,
+                                                         NUTHREADCAFECORE_UNKNOWN_2, NUTHREADXBOX360CORE_UNKNOWN_2);
 }
 
 NuSoundDecodeThread::~NuSoundDecodeThread() {
-    this->Shutdown();
 }
 
 // libTTapp.so 0x31f670: bump the decoder's pending-request count, park
@@ -263,14 +265,12 @@ NuSoundDecodeThread::~NuSoundDecodeThread() {
 // the callback's weak list so the worker can re-validate the callback.
 void NuSoundDecodeThread::RequestDecode(NuSoundDecoder &decoder, NuSoundBuffer &buffer,
                                         NuSoundWeakPtr<NuSoundBufferCallback> callback, bool loop) {
-    decoder.field_0xd4++;
+    __sync_fetch_and_add(&decoder.field_0xd4, 1);
 
+    Loader request = {&decoder, &buffer, callback, loop};
     Loader &entry = this->loaders[this->tail_index % 128];
-    entry.decoder = &decoder;
-    entry.buffer = &buffer;
-    entry.callback.Set((NuSoundBufferCallback *)callback.obj);
-    entry.loop = loop;
-    this->tail_index++;
+    new (&entry) Loader(request);
+    __sync_fetch_and_add(&this->tail_index, 1);
 
     this->semaphore.Signal();
 }
@@ -285,46 +285,43 @@ void NuSoundDecodeThread::ThreadFunc(void *self_) {
         self->semaphore.Wait();
 
         Loader &entry = self->loaders[self->head_index % 128];
-        self->head_index++;
-
         NuSoundDecoder *decoder = entry.decoder;
         NuSoundBuffer *buffer = entry.buffer;
-        NuSoundBufferCallback *callback = (NuSoundBufferCallback *)entry.callback.obj;
+        NuSoundWeakPtr<NuSoundBufferCallback> callback;
+        callback.Set((NuSoundBufferCallback *)entry.callback.obj);
         bool loop = entry.loop;
+        entry.~Loader();
+        __sync_fetch_and_add(&self->head_index, 1);
 
-        // libTTapp.so 0x31f4d3: a closed decoder drops the request
-        // (pending count--) without decoding.
-        if (decoder == NULL || !decoder->IsStreamOpen()) {
-            if (decoder != NULL) {
-                decoder->field_0xd4--;
-            }
-            continue;
+        if (decoder == NULL) {
+            sShutdownSemaphore.Signal();
+            return;
         }
 
-        // The worker takes the buffer's data lock for the decode and keeps
-        // it held after the SubmitBuffer hand-off (libTTapp.so 0x31f190 has
-        // no Unlock on this path; the ring slot stays allocated so the next
-        // RequestBuffer reuses the same pool block).
-        buffer->Lock();
-        decoder->Decode(*decoder, *buffer, loop);
-        decoder->buffers_started++;
-
-        if (callback != NULL) {
+        // 0x31f4df: closing requests skip Decode but still signal completion.
+        if (!decoder->closing) {
+            decoder->Decode(*decoder->GetEncodedSource(), *buffer, loop);
+            decoder->buffers_started++;
             pthread_mutex_lock(&NuSoundSample::sCriticalSection);
-            callback->SubmitBuffer(buffer);
+            if (callback.obj != NULL) {
+                ((NuSoundBufferCallback *)callback.obj)->SubmitBuffer(buffer);
+            }
             pthread_mutex_unlock(&NuSoundSample::sCriticalSection);
         }
 
         // libTTapp.so 0x31f1c8: the request is complete; drop the pending
         // count (a locked atomic sub on device) and raise the decode-done
         // flag through the decoder's decode-sync pair (mutex +0xdc,
-        // cond +0xe0, done flag +0xe4). This never touches the decoder's
-        // lifetime lock mutex, which the owning voice holds.
-        decoder->field_0xd4--;
+        // cond +0xe0, done flag +0xe4).
+        __sync_fetch_and_sub(&decoder->field_0xd4, 1);
         pthread_mutex_lock(&decoder->decode_mutex);
         if (decoder->decode_done == false) {
             decoder->decode_done = true;
-            pthread_cond_signal(&decoder->decode_cond);
+            if (decoder->field_0xe5) {
+                pthread_cond_broadcast(&decoder->decode_cond);
+            } else {
+                pthread_cond_signal(&decoder->decode_cond);
+            }
         }
         pthread_mutex_unlock(&decoder->decode_mutex);
     }
@@ -332,4 +329,17 @@ void NuSoundDecodeThread::ThreadFunc(void *self_) {
 
 // libTTapp.so 0x31fc90.
 void NuSoundDecodeThread::Shutdown() {
+    NuSoundWeakPtrListNode::sPtrListLock.Lock();
+    NuSoundWeakPtrListNode::sPtrListLock.Unlock();
+    Loader &entry = this->loaders[this->tail_index % 128];
+    new (&entry) Loader;
+    entry.decoder = NULL;
+    entry.buffer = NULL;
+    entry.callback.Set(NULL);
+    entry.loop = false;
+    __sync_fetch_and_add(&this->tail_index, 1);
+    this->semaphore.Signal();
+    sShutdownSemaphore.Wait();
+    NuSoundWeakPtrListNode::sPtrListLock.Lock();
+    NuSoundWeakPtrListNode::sPtrListLock.Unlock();
 }

--- a/src/nu2api/nusound/nusound_decoder.hpp
+++ b/src/nu2api/nusound/nusound_decoder.hpp
@@ -3,6 +3,7 @@
 #include "nu2api/nucore/android/NuThread_android.h"
 #include "nu2api/nucore/nuthread.h"
 #include "nu2api/nusound/nusound_source.hpp"
+#include "nu2api/nusound/nusound_buffer.hpp"
 #include "nu2api/nusound/nusound_weakptr.hpp"
 
 #include <pthread.h>
@@ -22,6 +23,8 @@ class NuSoundDecoder : public NuSoundSource {
   public:
     NuSoundDecoder(char const *name, NuSoundSource *source);
     virtual ~NuSoundDecoder();
+    const char *GetName() const override { return source != NULL ? source->GetName() : "NuSoundDecoder"; }
+    NuSoundSource *GetEncodedSource() override { return source; }
 
     void CloseStream();
     static void Initialise();
@@ -37,7 +40,6 @@ class NuSoundDecoder : public NuSoundSource {
     u32 GetMaxBufferSize() override;
     unsigned int GetNumRingBuffers() const;
     void RequestBuffer(bool loop, NuSoundWeakPtr<NuSoundBufferCallback> callback) override;
-    void Reset();
 
     // libTTapp.so @0x11e90d0: the singleton decode thread created by Initialise.
     static NuSoundDecodeThread *sDecodeThread;
@@ -48,37 +50,28 @@ class NuSoundDecoder : public NuSoundSource {
     // to two ring buffers upfront in OpenStream; further chunks are decoded
     // through the decode thread as the voice consumes them.
     virtual u64 Decode(NuSoundSource &source, NuSoundBuffer &buffer, bool loop) = 0;
+    virtual void Reset(); // original vtable slot +0x40, after Decode
 
   protected:
     NuSoundSource *source;     // wrapped source
-    NuSoundBuffer *buffers[2]; // the two ring buffer objects
-    u32 buffer_size;           // bytes per ring buffer
-    u32 ring_count;            // buffers filled so far
-    u32 decode_pos;            // next buffer index to decode
-    u32 consumed_pos;          // next buffer index to hand out
+    NuSoundBuffer buffers[2];  // +0x24, +0x64: embedded ring buffers
+    i32 buffer_size;           // bytes per ring buffer
+    i32 ring_count;            // buffers filled so far
+    i32 decode_pos;            // next buffer index to decode
+    i32 consumed_pos;          // next buffer index to hand out
     u32 buffers_started;
     u64 decoded_bytes; // bytes decoded since stream start
     u32 field_0xc0;
     u32 field_0xc4;
-    u32 field_0xc8;
-    u32 field_0xcc;
     u64 total_decoded_bytes;
+    u32 field_0xd0;
     u32 field_0xd4;
+    bool stream_open;             // +0xd8
+    bool closing;                 // +0xd9
     pthread_mutex_t decode_mutex; // +0xdc: decode-completion sync pair
     pthread_cond_t decode_cond;   // +0xe0
     bool decode_done;             // +0xe4
-    bool stream_open;
-    pthread_mutex_t mutex;
-    pthread_cond_t cond;
-    bool locked_flag;
-    bool loop_flag;
-
-    // Still-unidentified target fields. They put NuSoundDecoderOGG's
-    // NuSoundBufferCallback base at +0xe8 in the original (the three _ZThn232
-    // thunks encode that adjustment). Host pthread objects are larger, so host
-    // code must use C++ base conversions rather than copying this target
-    // offset.
-    u8 field_0x7c_to_0xe8[0x6c];
+    bool field_0xe5;
 };
 
 // libTTapp.so: the async decode worker. RequestDecode parks a 0x1c-byte
@@ -104,10 +97,14 @@ class NuSoundDecodeThread {
     static void ThreadFunc(void *self_);
     void Shutdown();
     void RequestDecode(NuSoundDecoder &, NuSoundBuffer &, NuSoundWeakPtr<NuSoundBufferCallback>, bool);
+    static NuThreadSemaphore sShutdownSemaphore;
+    static i32 sThreadPriority;
 
+    NuThread *thread;            // +0x000
+    union {
+        Loader loaders[128];     // +0x004; lifetime spans enqueue to dequeue
+    };
+    i32 tail_index; // +0xe04, producer (RequestDecode) write index
+    i32 head_index; // +0xe08, consumer (ThreadFunc) read index
     NuThreadSemaphore semaphore; // +0xe0c
-    Loader loaders[128];         // +0x004
-    NuThread *thread;
-    u32 tail_index; // +0xe04, producer (RequestDecode) write index
-    u32 head_index; // +0xe08, consumer (ThreadFunc) read index
 };

--- a/src/nu2api/nusound/nusound_decoder_ogg.cpp
+++ b/src/nu2api/nusound/nusound_decoder_ogg.cpp
@@ -2,6 +2,7 @@
 
 #include "nu2api/nucore/nucore.hpp"
 #include "nu2api/nucore/numemory.h"
+#include "nu2api/nuandroid/ios_graphics.h"
 #include "nu2api/nusound/nusound_buffer.hpp"
 #include "nu2api/nusound/nusound_system.hpp"
 
@@ -11,27 +12,13 @@
 
 // libTTapp.so 0x32e630: the OGG decoder extends the base decoder with the
 // streaming reader subobject and a 0x2b000-byte ring buffer size.
-NuSoundDecoderOGG::NuSoundDecoderOGG(char const *name, NuSoundSource *wrapped) : NuSoundDecoder(name, wrapped) {
-    this->field_0xec = 0;
-    this->field_0xf0 = &this->field_0xf0;
-    this->field_0xf4 = static_cast<NuSoundBufferCallback *>(this);
-    this->field_0xf8 = 0;
-    this->field_0xfc = static_cast<NuSoundBufferCallback *>(this);
-    this->field_0x100 = &this->field_0xf0;
-    this->field_0x104 = 0;
-    this->field_0x108 = 0;
-
-    new (&this->read_callbacks) OGGReadCallbacksDecoder();
-
-    this->ring_read_pos = 0;
+NuSoundDecoderOGG::NuSoundDecoderOGG(char const *name, NuSoundSource *wrapped)
+    : NuSoundDecoder(name, wrapped), field_0x108(0) {
     this->ring_write_pos = 0;
-    for (u32 i = 0; i < 4; i++) {
-        this->encoded_buffers[i] = NULL;
-    }
+    this->ring_read_pos = 0;
+    this->read_callbacks.SetDecoder(this);
     this->locked_buffer = NULL;
     this->ogg_loop = false;
-
-    this->read_callbacks.SetDecoder(this);
 
     this->buffer_size = 0x2b000;
 }
@@ -51,7 +38,6 @@ void NuSoundDecoderOGG::SubmitBuffer(NuSoundBuffer *buffer) {
 
 // libTTapp.so 0x32e5f0 / 0x32e620.
 NuSoundDecoderOGG::OGGReadCallbacksDecoder::OGGReadCallbacksDecoder() {
-    this->decoder = NULL;
     this->position = 0;
 }
 
@@ -77,7 +63,8 @@ int NuSoundDecoderOGG::OGGReadCallbacksDecoder::GetPosition() const {
 // runs dry and looping the stream at EOF when requested.
 int NuSoundDecoderOGG::OGGReadCallbacksDecoder::Read(void *dest, unsigned int size) {
     memset(dest, 0, size);
-    if (this->decoder == NULL || size == 0) {
+    this->decoder->GetEncodedSource();
+    if (size == 0) {
         return 0;
     }
 
@@ -90,25 +77,28 @@ int NuSoundDecoderOGG::OGGReadCallbacksDecoder::Read(void *dest, unsigned int si
         buffer->Lock();
         NuSoundBuffer::Context &context = buffer->GetCurrentContext();
 
-        u64 boundary = context.size3 != 0 ? context.size3 : context.read_size;
-        u32 available = boundary > this->position ? (u32)(boundary - this->position) : 0;
+        u32 available = (u32)context.read_size - this->position;
+        u32 boundary = context.size3 != 0 ? (u32)context.size3 - this->position : available;
         u32 take = remaining < available ? remaining : available;
-        if (take != 0) {
-            memmove(out, (u8 *)buffer->GetAddress() + this->position, take);
-            this->position += take;
-            out += take;
-            remaining -= take;
-            copied += take;
-        }
+        if (take > boundary) take = boundary;
+        memmove(out, (u8 *)buffer->GetAddress() + this->position, take);
+        this->position += take;
+        out += take;
+        remaining -= take;
+        copied += take;
 
-        bool at_end = (context.flags & 2) != 0;
         buffer->Unlock();
 
-        if (remaining == 0 || (at_end && !this->decoder->ogg_loop)) {
-            break;
+        if (remaining == 0 || ((context.flags & 2) != 0 && !this->decoder->ogg_loop)) {
+            return (int)copied;
         }
 
-        if (available == take) {
+        if (context.size3 != 0 && context.size3 < context.read_size) {
+            context.size3 = 0;
+            return (int)copied;
+        }
+
+        {
             // Decode() keeps the current encoded buffer locked while
             // vorbisfile reads it.  At a buffer boundary the original drops
             // that persistent lock before moving to the next ring entry.
@@ -123,46 +113,42 @@ int NuSoundDecoderOGG::OGGReadCallbacksDecoder::Read(void *dest, unsigned int si
                 this->position = 0;
                 return (int)copied;
             }
-            this->decoder->locked_buffer = this->decoder->encoded_buffers[this->decoder->ring_read_pos % 4];
+            NuSoundBuffer *next_buffer = this->decoder->encoded_buffers[this->decoder->ring_read_pos % 4];
             __sync_fetch_and_add(&this->decoder->ring_read_pos, 1);
+            this->decoder->locked_buffer = next_buffer;
 
-            NuSoundWeakPtr<NuSoundBufferCallback> callback;
-            callback.Set(this->decoder);
-            this->decoder->source->RequestBuffer(this->decoder->ogg_loop, callback);
+            {
+                this->decoder->source->RequestBuffer(
+                    this->decoder->ogg_loop, NuSoundWeakPtr<NuSoundBufferCallback>(this->decoder));
+            }
 
             this->decoder->locked_buffer->Lock();
             this->position = 0;
         }
     }
 
-    return (int)copied;
+    memset(out, 0, remaining);
+    return (int)remaining;
 }
 
 // libTTapp.so 0x32e730: decode the next chunk of the stream into the given
 // buffer. Returns the number of decoded bytes written (the buffer context's
-// read_size). Encoded buffers arrive through the four-entry ring at +0x11c;
+// size2 at context offset +8). Encoded buffers arrive through the four-entry ring at +0x11c;
 // the callback reader at +0x10c exposes that ring to vorbisfile.
 u64 NuSoundDecoderOGG::Decode(NuSoundSource &source, NuSoundBuffer &buffer, bool loop) {
     this->ogg_loop = loop;
 
     if (this->locked_buffer == NULL) {
-        u32 initial = source.GetNumInitialBuffers();
-        for (u32 i = 0; i < initial; i++) {
-            NuSoundWeakPtr<NuSoundBufferCallback> callback;
-            callback.Set(this);
-            source.RequestBuffer(loop, callback);
+        for (i32 i = 0; i < (i32)source.GetNumInitialBuffers(); i++) {
+            source.RequestBuffer(loop, NuSoundWeakPtr<NuSoundBufferCallback>(this));
         }
-        if (this->ring_read_pos != this->ring_write_pos) {
-            this->locked_buffer = this->encoded_buffers[this->ring_read_pos % 4];
-            this->ring_read_pos++;
-        }
+        NuSoundBuffer *initial_buffer = this->encoded_buffers[this->ring_read_pos % 4];
+        __sync_fetch_and_add(&this->ring_read_pos, 1);
+        this->locked_buffer = initial_buffer;
     }
 
-    NuSoundStreamDesc *desc = source.GetStreamDesc();
-    if (this->locked_buffer == NULL || desc == NULL) {
-        return 0;
-    }
     NuSoundBuffer::Context &context = buffer.GetCurrentContext();
+    NuSoundStreamDesc *desc = source.GetStreamDesc();
 
     if (this->locked_buffer != NULL) {
         this->locked_buffer->Lock();
@@ -171,39 +157,40 @@ u64 NuSoundDecoderOGG::Decode(NuSoundSource &source, NuSoundBuffer &buffer, bool
     buffer.Lock();
 
     context.flags &= ~0x3u;
-    context.read_size = 0;
     context.size2 = 0;
 
+    desc->GetNumChannels();
     memset(buffer.GetAddress(), 0, buffer.GetBufferSize());
 
     char *dest = (char *)buffer.GetAddress();
-    u32 buffer_bytes = (u32)buffer.GetBufferSize();
+    i32 buffer_bytes = (i32)buffer.GetBufferSize();
 
     if (this->decoded_bytes == 0) {
         context.flags |= 1;
     }
 
-    u32 block_size = desc->GetBlockSize();
-    u32 rounded = buffer_bytes - (buffer_bytes % block_size);
+    i32 block_size = (i32)desc->GetBlockSize();
+    i32 rounded = (buffer_bytes / block_size) * block_size;
 
     u64 total = desc->GetDecodedLengthBytes();
 
-    u32 chunk = rounded;
+    i32 chunk = rounded;
     if (loop == false) {
-        u64 remaining = total - this->decoded_bytes;
-        if (remaining < (u64)chunk) {
-            chunk = (u32)remaining;
+        i32 remaining = (i32)((u32)total - (u32)this->decoded_bytes);
+        if (remaining < chunk) {
+            chunk = remaining;
         }
     }
 
     u32 got = this->DecodeOggChunk(dest, chunk);
 
     this->total_decoded_bytes += got;
-    this->decoded_bytes += chunk;
-    context.read_size += got;
+    u64 decoded_end = this->decoded_bytes + (i64)chunk;
+    this->decoded_bytes = decoded_end;
+    context.size2 += got;
 
     total = desc->GetDecodedLengthBytes();
-    if (this->decoded_bytes == total) {
+    if (decoded_end == total) {
         context.flags |= 2;
         this->decoded_bytes = 0;
     }
@@ -214,7 +201,7 @@ u64 NuSoundDecoderOGG::Decode(NuSoundSource &source, NuSoundBuffer &buffer, bool
 
     buffer.Unlock();
 
-    return context.read_size;
+    return context.size2;
 }
 
 // libTTapp.so 0x32e310: ov_read() the encoded stream until the destination
@@ -228,22 +215,21 @@ u32 NuSoundDecoderOGG::DecodeOggChunk(char *dest, unsigned int size) {
     u32 bits_per_sample = desc->GetBitsPerChannel();
 
     NuSoundHeaderOGG *header = (NuSoundHeaderOGG *)desc;
-    OggVorbis_File *ogg = header != NULL ? &header->ogg_file : NULL;
-    void *saved_datasource = ogg != NULL ? ogg->datasource : NULL;
-    if (ogg != NULL) {
-        ogg->datasource = &this->read_callbacks;
-    }
+    OggVorbis_File *ogg = &header->ogg_file;
+    void *saved_datasource = ogg->datasource;
+    ogg->datasource = &this->read_callbacks;
     u32 decoded = 0;
 
     u32 block_size = desc->GetBlockSize();
-    u32 bytes_per_sample = (bits_per_sample + 7) / 8;
+    i32 bytes_per_sample = (i32)bits_per_sample / 8;
+    int bitstream = 0;
 
-    if (size != 0 && block_size < size && ogg != NULL) {
+    if (size != 0 && block_size < size) {
         char *cursor = dest;
         char *end = dest + size;
 
-        while (cursor < end) {
-            int bitstream = 0;
+        while (cursor < end && block_size < (u32)(end - cursor) && ogg->ready_state != 0) {
+            NuIOS_IsLowEndDevice();
             int ret = ov_read(ogg, cursor, (int)(end - cursor), 0, bytes_per_sample, 1, &bitstream);
 
             if (ret <= 0) {
@@ -254,6 +240,7 @@ u32 NuSoundDecoderOGG::DecodeOggChunk(char *dest, unsigned int size) {
                 }
                 if (this->ogg_loop) {
                     // Stream finished and the voice wants a loop: restart it.
+                    NuIOS_IsLowEndDevice();
                     ov_raw_seek(ogg, 0);
                     continue;
                 }
@@ -268,15 +255,15 @@ u32 NuSoundDecoderOGG::DecodeOggChunk(char *dest, unsigned int size) {
     // Channel permutation passes (Vorbis orders multichannel material
     // differently from WAVE): 3-channel streams rotate the first samples of
     // each frame, 6-channel streams apply the 5.1 reordering.
-    u32 channels = desc->GetNumChannels();
-    if (channels == 3) {
-        for (u32 i = 0; i < decoded / bytes_per_sample; i++) {
+    ogg->datasource = saved_datasource;
+    if (desc->GetNumChannels() == 3) {
+        for (u32 i = 0; i < decoded / ((i32)desc->GetBitsPerChannel() / 8); i += desc->GetNumChannels()) {
             u16 tmp = *(u16 *)&dest[2 + i * 2];
             *(u16 *)&dest[2 + i * 2] = *(u16 *)&dest[4 + i * 2];
             *(u16 *)&dest[4 + i * 2] = tmp;
         }
-    } else if (channels == 6) {
-        for (u32 i = 0; i < decoded / bytes_per_sample; i++) {
+    } else if (desc->GetNumChannels() == 6) {
+        for (u32 i = 0; i < decoded / ((i32)desc->GetBitsPerChannel() / 8); i += desc->GetNumChannels()) {
             u16 tmp = *(u16 *)&dest[2 + i * 2];
             *(u16 *)&dest[2 + i * 2] = *(u16 *)&dest[4 + i * 2];
             *(u16 *)&dest[4 + i * 2] = tmp;
@@ -291,8 +278,5 @@ u32 NuSoundDecoderOGG::DecodeOggChunk(char *dest, unsigned int size) {
         }
     }
 
-    if (ogg != NULL) {
-        ogg->datasource = saved_datasource;
-    }
     return decoded;
 }

--- a/src/nu2api/nusound/nusound_decoder_ogg.hpp
+++ b/src/nu2api/nusound/nusound_decoder_ogg.hpp
@@ -14,7 +14,7 @@
 class NuSoundDecoderOGG : public NuSoundDecoder, public NuSoundBufferCallback {
   public:
     // Streaming datasource the decoder reads the encoded stream through.
-    class OGGReadCallbacksDecoder {
+    class OGGReadCallbacksDecoder : public NuSoundLoaderOGG::OGGFileCallbacks {
       public:
         OGGReadCallbacksDecoder();
 
@@ -32,25 +32,17 @@ class NuSoundDecoderOGG : public NuSoundDecoder, public NuSoundBufferCallback {
     NuSoundDecoderOGG(char const *name, NuSoundSource *source);
     ~NuSoundDecoderOGG();
 
-    void Reset();
+    void Reset() override;
     void SubmitBuffer(NuSoundBuffer *buffer) override;
     u64 Decode(NuSoundSource &source, NuSoundBuffer &buffer, bool loop) override;
 
     u32 DecodeOggChunk(char *dest, unsigned int size);
 
-    u32 field_0xec;
-    void *field_0xf0;
-    void *field_0xf4;
-    u32 field_0xf8;
-    void *field_0xfc;
-    void *field_0x100;
-    u32 field_0x104;
     u32 field_0x108;
     OGGReadCallbacksDecoder read_callbacks;
-    u32 field_0x118;
     NuSoundBuffer *encoded_buffers[4];
-    u32 ring_read_pos;            // 0x12c
-    u32 ring_write_pos;           // 0x130
+    i32 ring_read_pos;            // 0x12c
+    i32 ring_write_pos;           // 0x130
     NuSoundBuffer *locked_buffer; // 0x134
     bool ogg_loop;                // 0x138
 };

--- a/src/nu2api/nusound/nusound_effect.cpp
+++ b/src/nu2api/nusound/nusound_effect.cpp
@@ -1,6 +1,50 @@
 #include "nu2api_nusound_types.h"
 
+static_assert(sizeof(void *) != 4 || offsetof(NuSoundEffect, reference_head) == 0x38,
+              "effect reference-list head must retain its Android offset");
+
 NuSoundEffect::~NuSoundEffect() {
+    ReferenceNode *node = reference_head->next;
+    while (node != reference_tail) {
+        --reference_count;
+        ReferenceNode *previous = node->prev;
+        ReferenceNode *next = node->next;
+        if (previous != NULL) previous->next = next;
+        if (next != NULL) next->prev = previous;
+
+        ManagedReference &ref = node->reference;
+        if (ref.object != NULL) {
+            if (ref.next == &ref) {
+                ref.object->references = NULL;
+            } else {
+                ManagedReference *next_reference = ref.next;
+                ManagedReference *previous_reference = ref.previous;
+                next_reference->previous = previous_reference;
+                previous_reference->next = next_reference;
+                if (ref.object->references == &ref) ref.object->references = next_reference;
+            }
+            ref.object = NULL;
+            ref.next = NULL;
+            ref.previous = NULL;
+        }
+        NuMemoryGet()->GetThreadMem()->BlockFree(node, 0);
+        node = reference_head->next;
+    }
+
+    ManagedReference *head = references;
+    if (head != NULL) {
+        while (head->next != head) {
+            ManagedReference *ref = head->next;
+            ref->object = NULL;
+            head->next = ref->next;
+            ref->previous = NULL;
+            ref->next = NULL;
+        }
+        head->next = NULL;
+        head->object = NULL;
+        head->previous = NULL;
+        references = NULL;
+    }
 }
 
 bool NuSoundEffect::Initialise() {

--- a/src/nu2api/nusound/nusound_effect_doppler.cpp
+++ b/src/nu2api/nusound/nusound_effect_doppler.cpp
@@ -1,12 +1,43 @@
 #include "nu2api_nusound_types.h"
+#include "nusound_voice.hpp"
+#include "nu2api/numath/nuvec.h"
 
 NuSoundEffectDoppler::NuSoundEffectDoppler() {
+    unknown_08[0] = 0;
+    unknown_08[1] = 0;
+    unknown_08[2] = 1;
+    unknown_08[3] = 8;
+    attenuation = 1.0f;
+    pitch_scale = 1.0f;
+    system_owned = false;
+    enabled = true;
+    speed_of_sound = 343.0f;
+    velocity_scale = 1.0f;
+    listeners = NULL;
 }
 
-void NuSoundEffectDoppler::ProcessVoice(NuSoundVoice *, float) {
+void NuSoundEffectDoppler::ProcessVoice(NuSoundVoice *voice, float) {
+    if (!enabled || listeners == NULL || voice->GetPosition() == NULL) return;
+    NuSoundListener *listener = NuSoundSystem::GetNearestRealListener(*listeners, *voice->GetPosition());
+    if (listener == NULL || listener->GetFocusPosition() == NULL || voice->GetPosition() == NULL) return;
+    const VuVec *source_velocity = voice->GetVelocity();
+    const VuVec *listener_velocity = listener->GetVelocity();
+    const VuVec *source_position = voice->GetPosition();
+    const VuVec *listener_position = listener->GetFocusPosition();
+    NUVEC direction;
+    direction.x = listener_position->x - source_position->x;
+    direction.y = listener_position->y - source_position->y;
+    direction.z = listener_position->z - source_position->z;
+    NuVecNorm(&direction, &direction);
+    float listener_speed = (listener_velocity->x * direction.x + listener_velocity->y * direction.y) + listener_velocity->z * direction.z;
+    float source_speed = (direction.x * source_velocity->x + direction.y * source_velocity->y) + direction.z * source_velocity->z;
+    pitch_scale = (speed_of_sound - listener_speed * velocity_scale) / (speed_of_sound - source_speed * velocity_scale);
 }
 
-void NuSoundEffectDoppler::SetParameters(float, float, NuEList<NuSoundListener, DefaultElist> const *) {
+void NuSoundEffectDoppler::SetParameters(float speed, float scale, NuEList<NuSoundListener, DefaultElist> const *list) {
+    speed_of_sound = speed;
+    velocity_scale = scale;
+    listeners = list;
 }
 
 NuSoundEffectDoppler::~NuSoundEffectDoppler() {

--- a/src/nu2api/nusound/nusound_effect_fader.cpp
+++ b/src/nu2api/nusound/nusound_effect_fader.cpp
@@ -1,33 +1,124 @@
 #include "nu2api_nusound_types.h"
+#include "nusound_android.hpp"
 
-void NuSoundEffectFader::AttachBus(NuSoundBus *) {
+static_assert(sizeof(void *) != 4 || offsetof(NuSoundEffectFader, curve) == 0x44,
+              "fader curve must retain its Android offset");
+
+bool NuSoundEffectFader::AttachBus(NuSoundBus *) {
+    return true;
 }
 
-void NuSoundEffectFader::AttachVoice(NuSoundVoice *) {
+bool NuSoundEffectFader::AttachVoice(NuSoundVoice *) {
+    return true;
 }
 
 void NuSoundEffectFader::Disable() {
+    enabled = false;
 }
 
 void NuSoundEffectFader::Enable() {
+    unknown_08[2] = unknown_58 < 1.0f;
+    enabled = true;
 }
 
 NuSoundEffectFader::NuSoundEffectFader() {
+    unknown_08[0] = 0;
+    unknown_08[1] = 0;
+    unknown_08[2] = 0;
+    unknown_08[3] = 2;
+    system_owned = false;
+    attenuation = 1.0f;
+    enabled = true;
+    pitch_scale = 1.0f;
+    curve.mode = 0;
+    curve.data = NULL;
+    unknown_4c = 1.0f;
+    unknown_50 = 1.0f;
+    unknown_54 = 0;
+    unknown_58 = 1.0f;
+    unknown_5c = 0;
+    unknown_60 = 0;
+    unknown_64 = 0;
+    unknown_68 = false;
 }
 
-void NuSoundEffectFader::Process(float) {
+void NuSoundEffectFader::Process(float frametime) {
+    if (!enabled || !(unknown_58 < 1.0f)) return;
+    unknown_08[2] = 1;
+    if (unknown_54 == 0.0f) {
+        unknown_58 = 1.0f;
+        attenuation = unknown_50;
+        return;
+    }
+    f32 step = frametime == 0.0f ? 0.0f : frametime / unknown_54;
+    f32 progress = unknown_58 + step;
+    if (progress < 1.0f && progress < 0.0f) progress = 0.0f;
+    else if (!(progress < 1.0f)) progress = 1.0f;
+    unknown_58 = progress;
+    f32 destination_weight = 0.0f;
+    f32 source_weight = 1.0f;
+    if (curve.mode == 0) {
+        destination_weight = progress;
+        source_weight = 1.0f - progress;
+    } else if (curve.mode == 1) {
+        destination_weight = NuSound.CalculateCrossfadeHeight(
+            *static_cast<NuSoundSystem::CurveData *>(curve.data), progress);
+        source_weight = 1.0f - destination_weight;
+        progress = unknown_58;
+    }
+    attenuation = destination_weight * unknown_50 + source_weight * unknown_4c;
+    if (progress == 1.0f) {
+        unknown_08[2] = 0;
+        unknown_68 = true;
+    }
 }
 
 void NuSoundEffectFader::ProcessBus(NuSoundBus *, float) {
 }
 
-void NuSoundEffectFader::ProcessVoice(NuSoundVoice *, float) {
+void NuSoundEffectFader::ProcessVoice(NuSoundVoice *voice, float) {
+    if (!unknown_68) return;
+    switch (unknown_60) {
+    case 1:
+        voice->Stop(true);
+        break;
+    case 2:
+        voice->Pause();
+        break;
+    case 3:
+        if (unknown_64 != NULL) unknown_64->OnFinish();
+        break;
+    }
+    unknown_68 = false;
 }
 
-void NuSoundEffectFader::SetCurveParams(NuSoundEffectFader::Curve const &) {
+void NuSoundEffectFader::SetCurveParams(NuSoundEffectFader::Curve const &value) {
+    curve = value;
 }
 
-void NuSoundEffectFader::SetParameters(float, float, NuSoundEffectFader::FinishState) {
+void NuSoundEffectFader::SetParameters(float target, float duration, NuSoundEffectFader::FinishState state) {
+    if (target != unknown_50 || duration != unknown_54) {
+        f32 current = attenuation;
+        unknown_4c = current;
+        unknown_5c = !(target > current);
+        f32 progress = 0.0f;
+        if (!(duration > 0.0f)) {
+            attenuation = target;
+            unknown_08[2] = 0;
+            progress = 1.0f;
+            current = target;
+        }
+        if (target == current) {
+            unknown_58 = 1.0f;
+            unknown_08[2] = 0;
+            unknown_68 = true;
+        } else {
+            unknown_58 = progress;
+        }
+        unknown_50 = target;
+        unknown_54 = duration;
+    }
+    unknown_60 = static_cast<u32>(state);
 }
 
 NuSoundEffectFader::~NuSoundEffectFader() {

--- a/src/nu2api/nusound/nusound_effect_pitchramp.cpp
+++ b/src/nu2api/nusound/nusound_effect_pitchramp.cpp
@@ -1,18 +1,64 @@
 #include "nu2api_nusound_types.h"
+#include "nusound_voice.hpp"
 
-void NuSoundEffectPitchRamp::AttachVoice(NuSoundVoice *) {
+bool NuSoundEffectPitchRamp::AttachVoice(NuSoundVoice *) {
+    return true;
 }
 
 NuSoundEffectPitchRamp::NuSoundEffectPitchRamp() {
+    unknown_08[0] = 0;
+    unknown_08[1] = 0;
+    unknown_08[2] = 0;
+    unknown_08[3] = 3;
+    attenuation = 1.0f;
+    pitch_scale = 1.0f;
+    system_owned = false;
+    enabled = true;
+    field_44 = 1.0f;
+    field_48 = 0.0f;
+    field_4c = false;
+    field_50 = 0;
 }
 
-void NuSoundEffectPitchRamp::Process(float) {
+void NuSoundEffectPitchRamp::Process(float frametime) {
+    if (!enabled || pitch_scale == field_44) return;
+    unknown_08[2] = 1;
+    field_4c = false;
+    if (field_48 == 0.0f) {
+        pitch_scale = field_44;
+        return;
+    }
+    float step = frametime == 0.0f ? 0.0f : frametime / field_48;
+    if (field_44 > pitch_scale) {
+        pitch_scale += step;
+        if (pitch_scale > field_44) {
+            unknown_08[2] = 0;
+            field_4c = true;
+            pitch_scale = field_44;
+        }
+    } else {
+        pitch_scale -= step;
+        if (field_44 > pitch_scale) {
+            unknown_08[2] = 0;
+            field_4c = true;
+            pitch_scale = field_44;
+        }
+    }
 }
 
-void NuSoundEffectPitchRamp::ProcessVoice(NuSoundVoice *, float) {
+void NuSoundEffectPitchRamp::ProcessVoice(NuSoundVoice *voice, float) {
+    if (field_4c) {
+        if (field_50 == 1) voice->Stop(true);
+        field_4c = false;
+    }
 }
 
-void NuSoundEffectPitchRamp::SetParameters(float, float, NuSoundEffectPitchRamp::FinishState) {
+void NuSoundEffectPitchRamp::SetParameters(float target, float divisor, NuSoundEffectPitchRamp::FinishState state) {
+    field_50 = static_cast<u32>(state);
+    field_44 = target;
+    field_48 = divisor;
+    if (0.01f > target) field_44 = 0.01f;
+    if (divisor == 0.0f) pitch_scale = target;
 }
 
 NuSoundEffectPitchRamp::~NuSoundEffectPitchRamp() {

--- a/src/nu2api/nusound/nusound_handle.cpp
+++ b/src/nu2api/nusound/nusound_handle.cpp
@@ -85,10 +85,10 @@ void NuSoundHandle::RemoveEffect(NuSoundEffect *) {
 }
 
 void NuSoundHandle::ResetFrameCount() {
-    NuListNodeBase *node = effects.head->next;
-    NuListNodeBase *end = effects.tail;
+    NuListNodeBase *node = callbacks.head->next;
+    NuListNodeBase *end = callbacks.tail;
     for (; node != end; node = node->next) {
-        static_cast<NuListNode<NuSoundEffect *> *>(node)->value->Initialise();
+        static_cast<NuListNode<Callback *> *>(node)->value->OnResetFrameCount(this);
     }
 }
 

--- a/src/nu2api/nusound/nusound_listener.cpp
+++ b/src/nu2api/nusound/nusound_listener.cpp
@@ -1,70 +1,131 @@
 #include "nu2api_nusound_types.h"
+#include "nu2api/numath/nuvec.h"
+#include <float.h>
 
 void NuSoundListener::Disable() {
+    enabled = false;
 }
 
 void NuSoundListener::DisableFocusPosition() {
+    focus_enabled = false;
 }
 
 void NuSoundListener::Enable() {
+    enabled = true;
 }
 
 void NuSoundListener::EnableFocusPosition() {
+    focus_enabled = true;
 }
 
-void NuSoundListener::Get2DScreenPosition() const {
+const VuVec * NuSoundListener::Get2DScreenPosition() const {
+    return screen_position;
 }
 
-void NuSoundListener::GetAttenuationDistance(VuVec const &) const {
+f32 NuSoundListener::GetAttenuationDistance(VuVec const &position) const {
+    const VuVec *origin = GetAttenuationPosition(position);
+    return NuVecDist((NUVEC *)origin, (NUVEC *)&position, NULL);
 }
 
-void NuSoundListener::GetAttenuationPosition(VuVec const &) const {
+const VuVec *NuSoundListener::GetAttenuationPosition(VuVec const &position) const {
+    if (focus_position != NULL && focus_enabled) {
+        f32 focus_distance = NuVecDist((NUVEC *)focus_position, (NUVEC *)&position, NULL);
+        if (!(focus_distance > GetHeadDistance(position))) return focus_position;
+    }
+    return reinterpret_cast<const VuVec *>(reinterpret_cast<const char *>(head_matrix) + 0x30);
 }
 
-void NuSoundListener::GetFocusPosition() const {
+const VuVec *NuSoundListener::GetFocusPosition() const {
+    if (focus_position != NULL && focus_enabled) return focus_position;
+    if (head_matrix != NULL) {
+        return reinterpret_cast<const VuVec *>(reinterpret_cast<const char *>(head_matrix) + 0x30);
+    }
+    return NULL;
 }
 
-void NuSoundListener::GetHeadDistance(VuVec const &) const {
+f32 NuSoundListener::GetHeadDistance(VuVec const &position) const {
+    if (head_matrix == NULL) return FLT_MAX;
+    const char *translation = reinterpret_cast<const char *>(head_matrix) + 0x30;
+    return NuVecDist((NUVEC *)translation, (NUVEC *)&position, NULL);
 }
 
-void NuSoundListener::GetHeadMatrix() const {
+const VuMtx * NuSoundListener::GetHeadMatrix() const {
+    return head_matrix;
 }
 
-void NuSoundListener::GetOutputDevices() const {
+i32 NuSoundListener::GetOutputDevices() const {
+    return output_devices;
 }
 
-void NuSoundListener::GetSensitivity() const {
+f32 NuSoundListener::GetSensitivity() const {
+    return sensitivity;
 }
 
-void NuSoundListener::GetVelocity() const {
+const VuVec * NuSoundListener::GetVelocity() const {
+    return &velocity;
 }
 
-void NuSoundListener::IsEnabled() const {
+bool NuSoundListener::IsEnabled() const {
+    return enabled;
 }
 
-void NuSoundListener::IsFocusPositionEnabled() const {
+bool NuSoundListener::IsFocusPositionEnabled() const {
+    return focus_enabled;
 }
 
 NuSoundListener::NuSoundListener() {
+    sensitivity = 1.0f;
+    next = NULL;
+    prev = NULL;
+    references = NULL;
+    head_matrix = NULL;
+    focus_position = NULL;
+    enabled = false;
+    focus_enabled = true;
+    output_devices = 1;
 }
 
-void NuSoundListener::Set2DScreenPosition(VuVec const *) {
+void NuSoundListener::Set2DScreenPosition(VuVec const *value) {
+    screen_position = value;
 }
 
-void NuSoundListener::SetFocusPosition(VuVec const *) {
+void NuSoundListener::SetFocusPosition(VuVec const *value) {
+    focus_position = value;
 }
 
-void NuSoundListener::SetHeadMatrix(VuMtx const *) {
+void NuSoundListener::SetHeadMatrix(VuMtx const *value) {
+    head_matrix = value;
 }
 
-void NuSoundListener::SetOutputDevices(i32) {
+void NuSoundListener::SetOutputDevices(i32 value) {
+    output_devices = value;
 }
 
-void NuSoundListener::SetSensitivity(float) {
+void NuSoundListener::SetSensitivity(float value) {
+    if (value >= 0.0f) sensitivity = value;
 }
 
-void NuSoundListener::SetVelocity(VuVec const &) {
+void NuSoundListener::SetVelocity(VuVec const &value) {
+    velocity.x = value.x;
+    velocity.y = value.y;
+    velocity.z = value.z;
+    velocity.w = value.w;
 }
 
 NuSoundListener::~NuSoundListener() {
+    NuSoundEffect::ManagedReference *head = references;
+    if (head != NULL) {
+        while (head->next != head) {
+            NuSoundEffect::ManagedReference *ref = head->next;
+            NuSoundEffect::ManagedReference *next = ref->next;
+            ref->object = NULL;
+            head->next = next;
+            ref->previous = NULL;
+            ref->next = NULL;
+        }
+        head->object = NULL;
+        head->previous = NULL;
+        head->next = NULL;
+        references = NULL;
+    }
 }

--- a/src/nu2api/nusound/nusound_loader.cpp
+++ b/src/nu2api/nusound/nusound_loader.cpp
@@ -17,15 +17,30 @@ NuSoundLoader::NuSoundLoader() {
 NuSoundLoader::~NuSoundLoader() {
 }
 
-i32 NuSoundLoader::CloseStream() {
-    return 0;
+void NuSoundLoader::CloseStream() {
+    Close();
 }
 
 u64 NuSoundLoader::Deinterleave(char *data, i32 length, char **dest, i32 count, NuSoundSystem::ChannelConfig config) {
-    return 0;
+    i32 frames = length / (count * (i32)config);
+    u64 copied = 0;
+    for (i32 frame = 0; frame < frames; ++frame) {
+        for (i32 channel = 0; channel < (i32)config; ++channel) {
+            for (i32 byte = 0; byte < count; ++byte) {
+                *dest[channel] = *data++;
+                ++dest[channel];
+                ++copied;
+            }
+        }
+    }
+    return copied;
 }
 
-void NuSoundLoader::GetChannelAddress(NuSoundBuffer *, NuSoundStreamDesc *, NuSoundSystem::AudioChannel) {
+void *NuSoundLoader::GetChannelAddress(NuSoundBuffer *buffer, NuSoundStreamDesc *desc,
+                                     NuSoundSystem::AudioChannel channel) {
+    i32 channels = desc->GetNumChannels();
+    u32 channel_size = buffer->GetBufferSize() / (u64)(i64)channels;
+    return static_cast<char *>(buffer->GetAddress()) + channel_size * (u32)channel;
 }
 
 void NuSoundLoader::ReleaseHeader(NuSoundStreamDesc *desc) {
@@ -56,15 +71,22 @@ i32 NuSoundLoader::Load(NuSoundStreamDesc *desc, NuSoundBuffer *buffer) {
     }
 
     bool decode_on_open = desc->DecodeStreamOnOpen();
-    char *path = const_cast<char *>(this->path);
-    bool use_decoded_length = NuStrIStr(path, "coin") != NULL || NuStrIStr(path, "counter") != NULL ||
-                              NuStrIStr(path, "fs_") != NULL || NuStrIStr(path, "saber") != NULL || decode_on_open;
+    bool use_decoded_length = NuStrIStr(const_cast<char *>(this->path), "coin") != NULL ||
+                              NuStrIStr(const_cast<char *>(this->path), "counter") != NULL ||
+                              NuStrIStr(const_cast<char *>(this->path), "fs_") != NULL ||
+                              NuStrIStr(const_cast<char *>(this->path), "saber") != NULL || decode_on_open;
     u64 length = use_decoded_length ? desc->GetDecodedLengthBytes() : desc->GetEncodedLengthBytes();
 
     result = buffer->Allocate(length, NuSoundSystem::MemoryDiscipline::SAMPLE);
     if (result != 1) {
         if (this->oom != NULL) {
-            (*this->oom)();
+            bool retry = result == -2
+                ? this->oom->OnAllocationFailureMinusTwo((u32)length)
+                : this->oom->OnAllocationFailure((u32)length);
+            if (!retry) {
+                Close();
+                return 5;
+            }
         }
         result = buffer->Allocate(length, NuSoundSystem::MemoryDiscipline::SAMPLE);
         if (result != 1) {
@@ -79,7 +101,8 @@ i32 NuSoundLoader::Load(NuSoundStreamDesc *desc, NuSoundBuffer *buffer) {
     SeekRawData(0);
     u64 read = ReadData(buffer->GetAddress(), length);
 
-    NuSoundBuffer::Context context;
+    NuSoundBuffer::Context context = {};
+    context.flags = 1;
     context.read_size = read;
     context.size2 = read;
     context.size3 = 0;
@@ -88,11 +111,12 @@ i32 NuSoundLoader::Load(NuSoundStreamDesc *desc, NuSoundBuffer *buffer) {
     buffer->SetCurrentContext(context);
     buffer->Unlock();
 
-    Close();
     if (read == 0) {
+        Close();
         buffer->Free();
         return 4;
     }
+    Close();
     return 1;
 }
 
@@ -117,57 +141,44 @@ i32 NuSoundLoader::OpenForStreaming(const char *path, f64 length, NuSoundStreamD
     return 1;
 }
 
-void NuSoundLoader::FillStreamBuffer(NuSoundBuffer *buffer, bool param3) {
-    NuSoundBuffer::Context context;
+NuSoundBuffer::Context NuSoundLoader::FillStreamBuffer(NuSoundBuffer *buffer, bool param3) {
+    NuSoundBuffer::Context context = {};
+    context.flags = 1;
+    memset(&context, 0, sizeof(context));
 
     if (this->file == 0) {
-        return;
+        return context;
     }
 
     buffer->Lock();
     u8 *data = (u8 *)buffer->GetAddress();
     u64 buffer_size = buffer->GetBufferSize();
 
-    u64 uVar3iVar2 = context.size2;
-
-    u64 read_size, size;
-
-    do {
-        do {
-            if (buffer_size <= uVar3iVar2) {
-            LAB_0033fce8:
-                buffer->SetCurrentContext(context);
-                buffer->Unlock();
-                return;
-            }
-            read_size = buffer_size - uVar3iVar2;
-            size = ReadData(data, read_size);
-
-            context.read_size += size;
-
-            data += size;
-
-            context.size2 += size;
-            uVar3iVar2 = context.size2;
-
-        } while (read_size == size);
+    for (;;) {
+        if (buffer_size <= context.size2) {
+        filled:
+            buffer->SetCurrentContext(context);
+            buffer->Unlock();
+            return context;
+        }
+        u64 read_size = buffer_size - context.size2;
+        u64 size = ReadData(data, read_size);
+        context.read_size += size;
+        context.size2 += size;
+        data += size;
+        if (read_size == size) continue;
 
         SeekRawData(0);
 
         context.size3 = context.read_size;
 
-        u32 uVar5 = buffer->GetBufferSize();
-
-        u32 uVar6 = this->desc->GetEncodedLengthBytes();
-
-        if ((uVar6 <= uVar5) || (!param3)) {
+        u64 capacity = buffer->GetBufferSize();
+        u64 encoded_length = this->desc->GetEncodedLengthBytes();
+        if ((capacity >= encoded_length) || (!param3)) {
             context.flags |= 2;
-            goto LAB_0033fce8;
+            goto filled;
         }
-
-        uVar3iVar2 = context.size2;
-
-    } while (true);
+    }
 }
 
 bool NuSoundLoader::SeekRawData(u64 position) {

--- a/src/nu2api/nusound/nusound_loader.hpp
+++ b/src/nu2api/nusound/nusound_loader.hpp
@@ -14,8 +14,8 @@ class NuSoundLoadTrigger {
   public:
     pthread_mutex_t mutex;
     pthread_cond_t cond;
-    volatile bool a;
-    volatile bool b;
+    bool a;
+    bool b;
 
     NuSoundLoadTrigger() {
         pthread_mutex_init(&mutex, NULL);
@@ -41,9 +41,9 @@ class NuSoundLoader {
   public:
     NuSoundLoader();
 
-    i32 CloseStream();
-    u64 Deinterleave(char *data, int length, char **dest, int count, NuSoundSystem::ChannelConfig config);
-    void GetChannelAddress(NuSoundBuffer *, NuSoundStreamDesc *, NuSoundSystem::AudioChannel);
+    void CloseStream();
+    static u64 Deinterleave(char *data, int length, char **dest, int count, NuSoundSystem::ChannelConfig config);
+    static void *GetChannelAddress(NuSoundBuffer *, NuSoundStreamDesc *, NuSoundSystem::AudioChannel);
     // libTTapp calls this after clearing its loader pointer.  The routine never
     // reads `this`; exposing that original static-style semantic to sanitizer
     // builds avoids manufacturing a non-null object that the target did not use.
@@ -57,7 +57,7 @@ class NuSoundLoader {
     virtual NuSoundStreamDesc *CreateHeader() = 0;
 
     virtual i32 OpenForStreaming(const char *path, f64 param2, NuSoundStreamDesc *desc, bool param4);
-    virtual void FillStreamBuffer(NuSoundBuffer *buffer, bool param2);
+    virtual NuSoundBuffer::Context FillStreamBuffer(NuSoundBuffer *buffer, bool param2);
 
     virtual bool SeekRawData(u64 position);
     virtual bool SeekPCMSample(u64 index) = 0;
@@ -100,17 +100,11 @@ class NuSoundHeaderWAV : public NuSoundStreamDesc {
     DataFormat GetDecodedDataFormat() const override {
         return DataFormat::ZERO;
     }
-    DataFormat GetEncodedDataFormat() const override {
-        return DataFormat::ZERO;
-    }
     u64 GetEncodedLengthBytes() const override {
         return this->encoded_length_bytes;
     }
-    u64 GetDecodedLengthBytes() const override {
-        return this->encoded_length_bytes;
-    }
     u64 GetLengthSamples() const override {
-        return GetEncodedLengthBytes() / ((GetBitsPerChannel() + 7) / 8);
+        return GetEncodedLengthBytes() / (static_cast<i32>(GetBitsPerChannel()) / 8);
     }
     f32 GetLengthSeconds() const override {
         return (f32)GetLengthSamples() / (f32)GetSampleRate();
@@ -118,29 +112,17 @@ class NuSoundHeaderWAV : public NuSoundStreamDesc {
     u64 GetDataOffset() const override {
         return this->data_position;
     }
-    u16 GetNumChannels() const override {
+    u32 GetNumChannels() const override {
         return this->num_channels;
     }
     u32 GetSampleRate() const override {
         return this->sample_rate;
     }
-    u16 GetBitsPerChannel() const override {
+    u32 GetBitsPerChannel() const override {
         return this->bits_per_channel;
     }
-    u16 GetBlockSize() const override {
+    u32 GetBlockSize() const override {
         return this->block_size;
-    }
-    u16 GetInterleaveSize() const override {
-        return 0;
-    }
-    u16 GetFormatID() const override {
-        return this->format_id;
-    }
-    u16 GetExtendedDataSize() const override {
-        return this->extended_data_size;
-    }
-    void *GetExtendedData() const override {
-        return (void *)&this->extended_data;
     }
 };
 

--- a/src/nu2api/nusound/nusound_loader_ogg.cpp
+++ b/src/nu2api/nusound/nusound_loader_ogg.cpp
@@ -9,10 +9,12 @@
 
 namespace {
     struct OGGCallbacksVTable {
+        void (*set_file)(void *, NUFILE);
         i32 (*read)(void *, void *, u32);
         void (*seek)(void *, i32, u32);
         void (*close)(void *);
         i32 (*get_position)(const void *);
+        NUFILE (*get_file)(const void *);
     };
 } // namespace
 
@@ -98,9 +100,9 @@ i32 NuSoundLoaderOGG::OpenFileForStreaming(const char *path, bool flag) {
 }
 
 void NuSoundLoaderOGG::Close() {
-    if (this->desc != NULL) {
+    NuSoundHeaderOGG *header = (NuSoundHeaderOGG *)this->desc;
+    if (header != NULL) {
         NuIOS_IsLowEndDevice();
-        NuSoundHeaderOGG *header = (NuSoundHeaderOGG *)this->desc;
         ov_clear(&header->ogg_file);
     }
     if (this->file != 0) {
@@ -120,26 +122,18 @@ i32 NuSoundLoaderOGG::ReadHeader(NuSoundStreamDesc *desc) {
     NuSoundHeaderOGG *header = (NuSoundHeaderOGG *)desc;
     OggVorbis_File *ogg_file = &header->ogg_file;
 
+    ov_callbacks callbacks = {
+        OggCallbackRead, OggCallbackSeek, NULL, OggCallbackTell
+    };
     file_callbacks.SetFile(file);
 
-    u32 channels = ov_open_callbacks( //
-        &file_callbacks,              //
-        ogg_file,                     //
-        NULL,                         //
-        0,                            //
-        (ov_callbacks){
-            .read_func = OggCallbackRead,
-            .seek_func = OggCallbackSeek,
-            .close_func = OggCallbackClose,
-            .tell_func = OggCallbackTell,
-        } //
-    );
+    i32 result = ov_open_callbacks(&file_callbacks, ogg_file, NULL, 0, callbacks);
 
-    if (channels >= 0) {
+    if (result >= 0) {
         vorbis_info *info = ov_info(ogg_file, 0);
         if (info != NULL) {
-            channels = info->channels;
-            u16 rate = info->rate;
+            i32 channels = info->channels;
+            i32 rate = info->rate;
             header->sample_rate = rate;
             header->bits_per_channel = 16;
             header->format_id = -2;
@@ -149,31 +143,19 @@ i32 NuSoundLoaderOGG::ReadHeader(NuSoundStreamDesc *desc) {
             header->extended_data_size = 0x16;
             *(u16 *)&header->extended_data[0] = 0x10;
             if (channels > 0) {
-                u32 channel_mask = 0;
+                u32 channel_mask = *(u32 *)&header->extended_data[2];
                 for (u32 channel = 0; channel < (u32)channels; channel++) {
                     channel_mask |= 1 << channel;
                 }
                 *(u32 *)&header->extended_data[2] = channel_mask;
             }
 
-            // header->extended_data[0] = 0x10;
-            // if (channels > 0) {
-            //     u32 uVar2 = *(u32 *)(header->extended_data + 1);
-            //     rate = 0;
-            //     do {
-            //         bVar3 = (byte)rate;
-            //         rate = rate + 1;
-            //         uVar2 = uVar2 | 1 << (bVar3 & 0x1f);
-            //     } while (rate != channels);
-            //     *(u32 *)((header->parent).extended_data + 1) = uVar2;
-            // }
-
             header->encoded_length_bytes = NuFileOpenSize(file);
 
-            u32 total = ov_pcm_total(ogg_file, -1);
+            i32 total = ov_pcm_total(ogg_file, -1);
             header->decoded_length_bytes = header->block_size * total;
 
-            u32 pcm_total = ov_pcm_total(ogg_file, -1);
+            i64 pcm_total = ov_pcm_total(ogg_file, -1);
             header->length_samples = pcm_total;
 
             double time_total = ov_time_total(ogg_file, -1);
@@ -217,7 +199,7 @@ u64 NuSoundHeaderOGG::GetDataOffset() const {
     return 0;
 }
 
-u16 NuSoundHeaderOGG::GetNumChannels() const {
+u32 NuSoundHeaderOGG::GetNumChannels() const {
     return num_channels;
 }
 
@@ -225,11 +207,11 @@ u32 NuSoundHeaderOGG::GetSampleRate() const {
     return sample_rate;
 }
 
-u16 NuSoundHeaderOGG::GetBitsPerChannel() const {
+u32 NuSoundHeaderOGG::GetBitsPerChannel() const {
     return bits_per_channel;
 }
 
-u16 NuSoundHeaderOGG::GetBlockSize() const {
+u32 NuSoundHeaderOGG::GetBlockSize() const {
     return block_size;
 }
 

--- a/src/nu2api/nusound/nusound_loader_ogg.hpp
+++ b/src/nu2api/nusound/nusound_loader_ogg.hpp
@@ -28,10 +28,10 @@ class NuSoundHeaderOGG : public NuSoundStreamDesc {
     u64 GetLengthSamples() const;
     f32 GetLengthSeconds() const;
     u64 GetDataOffset() const;
-    u16 GetNumChannels() const;
+    u32 GetNumChannels() const;
     u32 GetSampleRate() const;
-    u16 GetBitsPerChannel() const;
-    u16 GetBlockSize() const;
+    u32 GetBitsPerChannel() const;
+    u32 GetBlockSize() const;
     DataFormat GetEncodedDataFormat() const;
     u64 GetDecodedLengthBytes() const;
     u16 GetInterleaveSize() const;
@@ -47,12 +47,12 @@ class NuSoundLoaderOGG : public NuSoundLoader {
         NUFILE file;
 
       public:
+        virtual void SetFile(NUFILE file);
         virtual i32 Read(void *dest, u32 size);
         virtual void Seek(i32 origin, u32 offset);
         virtual void Close();
-        void SetFile(NUFILE file);
-        NUFILE GetFile() const;
         virtual i32 GetPosition() const;
+        virtual NUFILE GetFile() const;
     };
 
     NuSoundLoaderOGG();

--- a/src/nu2api/nusound/nusound_memorymanager.cpp
+++ b/src/nu2api/nusound/nusound_memorymanager.cpp
@@ -175,13 +175,61 @@ NuSoundMemoryManager::NuSoundMemoryManager() {
 }
 
 NuSoundMemoryManager::~NuSoundMemoryManager() {
+    Release();
+    pthread_mutex_destroy(&mutex);
+    name = NULL;
+    name_length = 0;
+    name_length2 = 0;
 }
 
-// libTTapp.so 0x3221e0: relocate trailing blocks to satisfy an alloc. Not
-// transcribed yet; returns no block so Alloc fails cleanly.
+// libTTapp.so 0x3221e0: compact free space, stopping when a requested size fits.
 NuSoundMemoryBuffer *NuSoundMemoryManager::Defragment(u32 size) {
-    (void)size;
-    return NULL;
+    pthread_mutex_lock(&mutex);
+    NuSoundMemoryBuffer::BeginCriticalSection();
+    NuSoundMemoryBuffer *result = NULL;
+    if (free_count != 0) {
+        NuSoundMemoryBuffer *buffer = free_list_head;
+        while (buffer != NULL) {
+            NuSoundMemoryBuffer *next = buffer->GetNext();
+            if (next == NULL) break;
+            if (buffer->IsAlloced()) {
+                buffer = next;
+                continue;
+            }
+            if (!next->IsAlloced()) {
+                buffer = MergeFreeBuffer(buffer);
+                if (size != 0 && buffer->GetSize() >= size) {
+                    result = buffer;
+                    break;
+                }
+                continue;
+            }
+            NuSoundMemoryBuffer *remainder = NULL;
+            NuSoundMemoryBuffer *merged = NULL;
+            NuSoundMemoryBuffer *moved = MoveLargestTrailingBufferIntoBuffer(buffer, &remainder, &merged);
+            if (size != 0 && merged != NULL && merged->GetSize() >= size) {
+                result = merged;
+                break;
+            }
+            if (moved != buffer) {
+                buffer = moved;
+                continue;
+            }
+            u32 previous_size = buffer->GetSize();
+            do {
+                buffer = SwapOrMergeAdjacentBuffers(buffer);
+            } while (buffer != NULL && buffer->GetSize() <= previous_size);
+            if (buffer == NULL) break;
+            if (size != 0 && buffer->GetSize() >= size) {
+                result = buffer;
+                break;
+            }
+        }
+        if (result == NULL || size == 0) free_count = 0;
+    }
+    NuSoundMemoryBuffer::EndCriticalSection();
+    pthread_mutex_unlock(&mutex);
+    return result;
 }
 
 // libTTapp.so 0x3223c0
@@ -204,10 +252,9 @@ NuSoundMemoryBuffer *NuSoundMemoryManager::Alloc(u32 size) {
     if (alloc_size <= this->GetFree()) {
         for (NuSoundMemoryBuffer *buf = this->free_list_head; buf != NULL;) {
             if (!buf->IsAlloced()) {
-                u32 buf_size = buf->GetSize();
-                if (buf_size >= alloc_size) {
-                    if (best == NULL || best->GetSize() > buf_size) {
-                        if (buf_size == alloc_size) {
+                if (buf->GetSize() >= alloc_size) {
+                    if (best == NULL || best->GetSize() > buf->GetSize()) {
+                        if (buf->GetSize() == alloc_size) {
                             best = buf;
                             break;
                         }
@@ -218,12 +265,12 @@ NuSoundMemoryBuffer *NuSoundMemoryManager::Alloc(u32 size) {
             buf = buf->GetNext();
         }
 
-        if (best == NULL && (this->flags & 2) != 0) {
+        if ((this->flags & 2) != 0 && best == NULL) {
             best = this->Defragment(alloc_size);
         }
 
         if (best != NULL) {
-            if (best->GetSize() != alloc_size) {
+            if (best->GetSize() > alloc_size) {
                 best = this->SplitFreeBuffer(best, alloc_size, NULL);
             }
             best->SetAlloced(true);
@@ -273,7 +320,7 @@ void NuSoundMemoryManager::Free(NuSoundMemoryBuffer *buffer) {
     pthread_mutex_lock(&this->mutex);
 
     buffer->SetAlloced(false);
-    this->free_bytes = this->free_bytes + buffer->GetSize();
+    this->free_bytes += buffer->GetSize();
     this->MergeFreeBuffer(buffer);
     this->free_count = this->free_count + 1;
 
@@ -368,11 +415,11 @@ bool NuSoundMemoryManager::Release() {
     return true;
 }
 
-// libTTapp.so 0x322550 (AllocAddress). Debug-only; not transcribed yet. It
-// takes a raw pool offset, so returning nothing keeps every caller's flow
-// intact without inventing behavior.
-void NuSoundMemoryManager::AllocAddress(u32 address) {
-    (void)address;
+// libTTapp.so 0x322550: allocate a block and expose its data address.
+void *NuSoundMemoryManager::AllocAddress(u32 size) {
+    NuSoundMemoryBuffer *buffer = Alloc(size);
+    if (buffer != NULL) return buffer->GetAddress();
+    return NULL;
 }
 
 // libTTapp.so 0x3225a0 (CheckList). Debug-only list validator; not
@@ -380,36 +427,65 @@ void NuSoundMemoryManager::AllocAddress(u32 address) {
 void NuSoundMemoryManager::CheckList() {
 }
 
-// libTTapp.so 0x321f40 (CountAdjacentFreeBuffers). Debug-only; not
-// transcribed yet.
-void NuSoundMemoryManager::CountAdjacentFreeBuffers(NuSoundMemoryBuffer *buffer) {
-    (void)buffer;
+// libTTapp.so 0x321f40: count free neighbors for buffer relocation.
+u32 NuSoundMemoryManager::CountAdjacentFreeBuffers(NuSoundMemoryBuffer *buffer) {
+    u32 count = 0;
+    if (buffer->GetPrev() != NULL && !buffer->GetPrev()->IsAlloced()) count = 1;
+    if (buffer->GetNext() != NULL && !buffer->GetNext()->IsAlloced()) ++count;
+    return count;
 }
 
-// libTTapp.so 0x322750 (EnableDebug). Debug-only flag setter; not transcribed
-// yet.
+// libTTapp.so 0x322750: debug flag, preserving the other configuration bits.
 void NuSoundMemoryManager::EnableDebug(bool enable) {
-    (void)enable;
+    flags = (flags & 0xfe) | static_cast<u8>(enable);
 }
 
-// libTTapp.so 0x322790 (EnableDefragOnFree). Debug-only flag setter; not
-// transcribed yet.
+// libTTapp.so 0x322790: defragment-on-free configuration bit.
 void NuSoundMemoryManager::EnableDefragOnFree(bool enable) {
-    (void)enable;
+    flags = (flags & 0xfb) | (static_cast<u8>(enable) << 2);
 }
 
-// libTTapp.so 0x3219e0 (FreeAddress). Debug-only; not transcribed yet.
+// libTTapp.so 0x3219e0: release the first block with the requested address.
 void NuSoundMemoryManager::FreeAddress(void *address) {
-    (void)address;
+    pthread_mutex_lock(&mutex);
+    for (NuSoundMemoryBuffer *buffer = free_list_head; buffer != NULL; buffer = buffer->GetNext()) {
+        if (buffer->GetAddress() == address) {
+            Free(buffer);
+            break;
+        }
+    }
+    pthread_mutex_unlock(&mutex);
 }
 
-// libTTapp.so 0x321fe0 (MoveLargestTrailingBufferIntoBuffer). Defrag
-// helper; not transcribed yet.
-void NuSoundMemoryManager::MoveLargestTrailingBufferIntoBuffer(NuSoundMemoryBuffer *buffer, NuSoundMemoryBuffer **out_a,
+// libTTapp.so 0x321fe0: select a trailing allocation to fill a free block.
+NuSoundMemoryBuffer *NuSoundMemoryManager::MoveLargestTrailingBufferIntoBuffer(NuSoundMemoryBuffer *buffer, NuSoundMemoryBuffer **out_a,
                                                                NuSoundMemoryBuffer **out_b) {
-    (void)buffer;
-    (void)out_a;
-    (void)out_b;
+    if (buffer->IsAlloced() || buffer->IsLocked()) return buffer;
+    NuSoundMemoryBuffer *last = buffer;
+    while (last != NULL && last->GetNext() != NULL) last = last->GetNext();
+    NuSoundMemoryBuffer *best = NULL;
+    u32 best_neighbors = 0;
+    for (NuSoundMemoryBuffer *candidate = last; candidate != NULL && candidate != buffer; candidate = candidate->GetPrev()) {
+        if (!candidate->IsAlloced() || candidate->IsLocked() || buffer->GetSize() < candidate->GetSize()) continue;
+        if (best == NULL) {
+            best = candidate;
+        } else if (best->GetSize() == candidate->GetSize()) {
+            u32 neighbors = CountAdjacentFreeBuffers(candidate);
+            if (neighbors > best_neighbors) {
+                best_neighbors = neighbors;
+                best = candidate;
+            }
+        } else if (best->GetSize() < candidate->GetSize()) {
+            best_neighbors = CountAdjacentFreeBuffers(candidate);
+            best = candidate;
+        }
+    }
+    if (best == NULL) return buffer;
+    if (buffer->GetSize() > best->GetSize()) buffer = SplitFreeBuffer(buffer, best->GetSize(), out_a);
+    if (!SwapSimilarBuffers(best, buffer)) return buffer;
+    NuSoundMemoryBuffer *merged = MergeFreeBuffer(buffer);
+    if (out_b != NULL) *out_b = merged;
+    return best->GetNext();
 }
 
 // libTTapp.so 0x322640 (OutputList). Debug dump over the free list; not
@@ -429,15 +505,86 @@ void NuSoundMemoryManager::RenderMap(f32 x, f32 y, f32 scale) {
     (void)scale;
 }
 
-// libTTapp.so 0x321d10 (SwapOrMergeAdjacentBuffers). Defrag helper; not
-// transcribed yet.
-void NuSoundMemoryManager::SwapOrMergeAdjacentBuffers(NuSoundMemoryBuffer *buffer) {
-    (void)buffer;
+// libTTapp.so 0x321d10: slide an adjacent allocation into the free space.
+NuSoundMemoryBuffer *NuSoundMemoryManager::SwapOrMergeAdjacentBuffers(NuSoundMemoryBuffer *buffer) {
+    if (buffer->IsAlloced() || buffer->IsLocked()) return buffer;
+    NuSoundMemoryBuffer *next = buffer->GetNext();
+    if (next == NULL || next->IsLocked()) return NULL;
+    if (next->IsAlloced()) {
+        buffer->Lock("SwapOrMergeAdjacentBuffers buffer");
+        next->Lock("SwapOrMergeAdjacentBuffers next");
+        u32 free_size = buffer->GetSize();
+        u32 bytes = next->GetSize();
+        char *source = static_cast<char *>(next->GetAddress());
+        char *destination = static_cast<char *>(buffer->GetAddress());
+        buffer->SetAddress(destination + bytes);
+        next->SetAddress(destination);
+        if (free_size >= bytes) {
+            memmove(destination, source, bytes);
+        } else {
+            while (bytes != 0) {
+                i32 chunk = static_cast<i32>(bytes) <= static_cast<i32>(free_size) ? static_cast<i32>(bytes) : static_cast<i32>(free_size);
+                memmove(destination, source, chunk);
+                destination += chunk;
+                source += chunk;
+                bytes -= chunk;
+            }
+        }
+        next->Unlock();
+        buffer->Unlock();
+        NuSoundMemoryBuffer *previous = buffer->GetPrev();
+        NuSoundMemoryBuffer *following = next->GetNext();
+        if (previous != NULL) previous->SetNext(next);
+        next->SetPrev(previous);
+        next->SetNext(buffer);
+        buffer->SetPrev(next);
+        buffer->SetNext(following);
+        if (following != NULL) following->SetPrev(buffer);
+    }
+    return CheckAndMergeFreeBufferNext(buffer);
 }
 
-// libTTapp.so 0x321a60 (SwapSimilarBuffers). Defrag helper; not transcribed
-// yet.
-void NuSoundMemoryManager::SwapSimilarBuffers(NuSoundMemoryBuffer *a, NuSoundMemoryBuffer *b) {
-    (void)a;
-    (void)b;
+// libTTapp.so 0x321a60: relocate an unlocked allocation into an equal-sized free block.
+bool NuSoundMemoryManager::SwapSimilarBuffers(NuSoundMemoryBuffer *a, NuSoundMemoryBuffer *b) {
+    if (!a->IsAlloced() || a->IsLocked() || b->IsAlloced() || b->IsLocked()) return false;
+    u32 bytes = a->GetSize();
+    if (bytes != b->GetSize()) return false;
+    a->Lock("SwapSimilarBuffers src");
+    b->Lock("SwapSimilarBuffers dest");
+    void *source = a->GetAddress();
+    void *destination = b->GetAddress();
+    memmove(destination, source, bytes);
+    a->SetAddress(destination);
+    b->SetAddress(source);
+    b->Unlock();
+    a->Unlock();
+    NuSoundMemoryBuffer *b_prev = b->GetPrev();
+    NuSoundMemoryBuffer *b_next = b->GetNext();
+    NuSoundMemoryBuffer *a_prev = a->GetPrev();
+    NuSoundMemoryBuffer *a_next = a->GetNext();
+    if (b_next == a) {
+        if (b_prev != NULL) b_prev->SetNext(a);
+        a->SetPrev(b_prev);
+        a->SetNext(b);
+        b->SetPrev(a);
+        b->SetNext(a_next);
+        if (a_next != NULL) a_next->SetPrev(b);
+    } else if (a_next == b) {
+        if (a_prev != NULL) a_prev->SetNext(b);
+        b->SetPrev(a_prev);
+        b->SetNext(a);
+        a->SetPrev(b);
+        a->SetNext(b_next);
+        if (b_next != NULL) b_next->SetPrev(a);
+    } else {
+        if (b_prev != NULL) b_prev->SetNext(a);
+        a->SetPrev(b_prev);
+        a->SetNext(b_next);
+        if (b_next != NULL) b_next->SetPrev(a);
+        if (a_prev != NULL) a_prev->SetNext(b);
+        b->SetPrev(a_prev);
+        b->SetNext(a_next);
+        if (a_next != NULL) a_next->SetPrev(b);
+    }
+    return true;
 }

--- a/src/nu2api/nusound/nusound_memorymanager.hpp
+++ b/src/nu2api/nusound/nusound_memorymanager.hpp
@@ -6,6 +6,7 @@
 #include <pthread.h>
 
 class NuSoundMemoryBuffer {
+    friend class NuSoundMemoryManager;
     void *address;
     u32 size : 30;
     bool alloced : 1;
@@ -82,19 +83,19 @@ class NuSoundMemoryManager {
     u32 GetUsed(); // 0x322590: GetSize() minus the free counter
 
     // Debug/diagnostic helpers (device addresses in nusound_memorymanager.cpp).
-    void AllocAddress(u32 address);
+    void *AllocAddress(u32 size);
     void CheckList();
-    void CountAdjacentFreeBuffers(NuSoundMemoryBuffer *buffer);
+    u32 CountAdjacentFreeBuffers(NuSoundMemoryBuffer *buffer);
     void EnableDebug(bool enable);
     void EnableDefragOnFree(bool enable);
     void FreeAddress(void *address);
-    void MoveLargestTrailingBufferIntoBuffer(NuSoundMemoryBuffer *buffer, NuSoundMemoryBuffer **out_a,
+    NuSoundMemoryBuffer *MoveLargestTrailingBufferIntoBuffer(NuSoundMemoryBuffer *buffer, NuSoundMemoryBuffer **out_a,
                                              NuSoundMemoryBuffer **out_b);
     void OutputList();
     void OutputMap();
     void RenderMap(f32 x, f32 y, f32 scale);
-    void SwapOrMergeAdjacentBuffers(NuSoundMemoryBuffer *buffer);
-    void SwapSimilarBuffers(NuSoundMemoryBuffer *a, NuSoundMemoryBuffer *b);
+    NuSoundMemoryBuffer *SwapOrMergeAdjacentBuffers(NuSoundMemoryBuffer *buffer);
+    bool SwapSimilarBuffers(NuSoundMemoryBuffer *a, NuSoundMemoryBuffer *b);
 
   private:
     NuSoundMemoryBuffer *CheckAndMergeFreeBufferNext(NuSoundMemoryBuffer *buffer);

--- a/src/nu2api/nusound/nusound_mixer.cpp
+++ b/src/nu2api/nusound/nusound_mixer.cpp
@@ -1,13 +1,44 @@
 #include "nu2api_nusound_types.h"
 
-void NuSoundMixer::GetOutputIndex(i32, i32) {
+#include <string.h>
+
+u8 NuSoundMixer::sDownmixerChannelMaps[4][8] = {
+    {1, 1, 1, 1, 1, 1, 1, 1},
+    {1, 1, 1, 1, 0, 0, 0, 0},
+    {1, 1, 0, 0, 0, 0, 0, 0},
+    {0, 0, 1, 0, 0, 0, 0, 0}
+};
+
+i32 NuSoundMixer::GetOutputIndex(i32 output, i32 index) {
+    if (output_layout != 0) {
+        return output_config * output + index;
+    }
+    return input_config * index + output;
 }
 
-void NuSoundMixer::Mix(float *, float *) {
+void NuSoundMixer::Mix(float *in, float *out) {
+    f32 *input_matrix = routing_table->GetMatrix(input_config, static_cast<NuSoundSystem::ChannelConfig>(8))->matrix;
+    f32 *output_matrix = routing_table->GetMatrix(static_cast<NuSoundSystem::ChannelConfig>(8), output_config)->matrix;
+    const u8 *channel_map = sDownmixerChannelMaps[static_cast<u32>(downmix_type)];
+    memset(out, 0, input_config * output_config * sizeof(f32));
+    for (i32 input = 0; input < (i32)input_config; ++input) {
+        if ((i32)output_config < (i32)input_config && channel_map[input] == 0) continue;
+        for (i32 output = 0; output < (i32)output_config; ++output) {
+            f32 gain = 0.0f;
+            for (i32 channel = 0; channel < 8; ++channel) {
+                gain += input_matrix[channel * input_config + input] * in[channel]
+                      * output_matrix[output * 8 + channel];
+            }
+            i32 index = GetOutputIndex(input, output);
+            out[index] = !(gain < 1.0f) ? 1.0f : (gain < 0.0f ? 0.0f : gain);
+        }
+    }
 }
 
-NuSoundMixer::NuSoundMixer(NuSoundSystem::ChannelConfig, NuSoundSystem::ChannelConfig, NuSoundMixer::OutputLayout,
-                           NuSoundSystem::DownmixType, NuSoundRoutingTable *) {
+NuSoundMixer::NuSoundMixer(NuSoundSystem::ChannelConfig input, NuSoundSystem::ChannelConfig output,
+                           NuSoundMixer::OutputLayout layout, NuSoundSystem::DownmixType downmix,
+                           NuSoundRoutingTable *table)
+    : input_config(input), output_config(output), output_layout(layout), downmix_type(downmix), routing_table(table) {
 }
 
 NuSoundMixer::~NuSoundMixer() {

--- a/src/nu2api/nusound/nusound_plain.cpp
+++ b/src/nu2api/nusound/nusound_plain.cpp
@@ -22,8 +22,6 @@ extern "C" {
     }
     void NuSound3AddStreamEx(void) {
     }
-    void NuSound3AmplitudeTodB(void) {
-    }
     void NuSound3BeginWaitUpdate(void) {
     }
     void NuSound3CancelCheckStereo(void) {
@@ -35,8 +33,6 @@ extern "C" {
     void NuSound3ClearLoopHold(void) {
     }
     void NuSound3Close(void) {
-    }
-    void NuSound3CountVoices(void) {
     }
     void NuSound3DisplayVoiceInfo(void) {
     }
@@ -54,33 +50,25 @@ extern "C" {
     }
     void NuSound3FindFree(void) {
     }
-    void NuSound3FindOldestVoice(void) {
-    }
-    void NuSound3FindQuietestVoice(void) {
-    }
     void NuSound3FlushBG(void) {
     }
     void NuSound3FlushFG(void) {
     }
     void NuSound3FlushLoops(void) {
     }
-    void NuSound3GetListener(void) {
-    }
     void NuSound3GetSize(void) {
     }
     void NuSound3GetStreamInfo(void) {
     }
-    void NuSound3GetStreamPlaybackTime(void) {
-    }
     void NuSound3HoldOffMusic(void) {
     }
-    void NuSound3InitEx(void) {
+    i32 NuSound3InitEx(void) {
+        NuSound3Init(0);
+        return 1;
     }
     void NuSound3InitLoopInfo(void) {
     }
     void NuSound3InitThreadSafeHackyMess(void) {
-    }
-    void NuSound3IsSampleLoaded(void) {
     }
     void NuSound3KillAllAudio(void) {
     }
@@ -88,26 +76,14 @@ extern "C" {
     }
     void NuSound3KillAllAudioWaitEx(void) {
     }
-    void NuSound3Listener(void) {
-    }
     void NuSound3LoadAllSpotFX(void) {
     }
     i32 NuSound3LoadingSfx(void) {
         return 0;
     }
-    void NuSound3Play(void) {
-    }
-    void NuSound3Play3d(void) {
-    }
-    void NuSound3Play3dLoopSfx(void) {
-    }
-    void NuSound3Play3dPri(void) {
-    }
     void NuSound3PlayChan(void) {
     }
     void NuSound3PlayInterleavedStereo(void) {
-    }
-    void NuSound3PlayPri(void) {
     }
     void NuSound3PlayStream(void) {
     }
@@ -149,15 +125,15 @@ extern "C" {
     }
     void NuSound3SetStreamPitch(void) {
     }
-    void NuSound3SetStreamVolume(void) {
+    i32 NuSound3SetStreamVolume(i32 index, i32 volume) {
+        NuSound3SetStereoStreamVolume(index, volume);
+        return 1;
     }
     void NuSound3StopRumble(void) {
     }
     void NuSound3StopSFX(void) {
     }
     void NuSound3StopStream(void) {
-    }
-    void NuSound3StopVoice(void) {
     }
     void NuSound3StreamClose(void) {
     }

--- a/src/nu2api/nusound/nusound_routing.cpp
+++ b/src/nu2api/nusound/nusound_routing.cpp
@@ -1,22 +1,95 @@
 #include "nu2api_nusound_types.h"
+#include <string.h>
 
-void NuSoundRoutingTable::GetConfig(i32) {
+extern "C" const f32 RoutingTableMonoToMono[1] = {1.0f};
+extern "C" const f32 RoutingTableMonoToStereo[2] = {0.7079457640647888f, 0.7079457640647888f};
+extern "C" const f32 RoutingTableMonoToQuad[4] = {0.699999988079071f, 0.699999988079071f, 0.5f, 0.5f};
+extern "C" const f32 RoutingTableMonoTo51[6] = {0.5f, 0.5f, 0.699999988079071f, 0.30000001192092896f, 0.5f, 0.5f};
+extern "C" const f32 RoutingTableMonoTo71[8] = {0.5f, 0.5f, 0.699999988079071f, 0.30000001192092896f, 0.5f, 0.5f, 0.30000001192092896f, 0.30000001192092896f};
+extern "C" const f32 RoutingTableStereoToMono[2] = {0.7079457640647888f, 0.7079457640647888f};
+extern "C" const f32 RoutingTableStereoToStereo[4] = {1.0f, 0.0f, 0.0f, 1.0f};
+extern "C" const f32 RoutingTableStereoToQuad[8] = {1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+extern "C" const f32 RoutingTableStereoTo51[12] = {0.5f, 0.0f, 0.0f, 0.5f, 0.699999988079071f, 0.699999988079071f, 0.30000001192092896f, 0.30000001192092896f, 0.5f, 0.0f, 0.0f, 0.5f};
+extern "C" const f32 RoutingTableStereoTo71[16] = {1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.699999988079071f, 0.0f, 0.0f, 0.699999988079071f, 0.30000001192092896f, 0.0f, 0.0f, 0.30000001192092896f};
+extern "C" const f32 RoutingTableLRCToMono[3] = {0.5011900067329407f, 0.5011900067329407f, 0.5011900067329407f};
+extern "C" const f32 RoutingTableLRCToStereo[6] = {1.0f, 0.0f, 0.6800000071525574f, 0.0f, 1.0f, 0.6800000071525574f};
+extern "C" const f32 RoutingTableLRCToQuad[12] = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+extern "C" const f32 RoutingTableLRCTo51[18] = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+extern "C" const f32 RoutingTableLRCTo71[24] = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+extern "C" const f32 RoutingTable51ToMono[6] = {0.5011900067329407f, 0.5011900067329407f, 0.5011900067329407f, 0.5011900067329407f, 0.5011900067329407f, 0.5011900067329407f};
+extern "C" const f32 RoutingTable51ToStereo[12] = {1.0f, 0.0f, 0.6800000071525574f, 0.20000000298023224f, 0.20000000298023224f, 0.0f, 0.0f, 1.0f, 0.6800000071525574f, 0.20000000298023224f, 0.0f, 0.20000000298023224f};
+extern "C" const f32 RoutingTable51ToQuad[24] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+extern "C" const f32 RoutingTable51To51[36] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+extern "C" const f32 RoutingTable51To71[48] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.30000001192092896f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.30000001192092896f};
+extern "C" const f32 RoutingTable71ToMono[8] = {0.5011900067329407f, 0.5011900067329407f, 0.5011900067329407f, 0.5011900067329407f, 0.5011900067329407f, 0.5011900067329407f, 0.0f, 0.0f};
+extern "C" const f32 RoutingTable71ToStereo[16] = {1.0f, 0.0f, 0.6800000071525574f, 0.30000001192092896f, 0.30000001192092896f, 0.0f, 0.30000001192092896f, 0.0f, 0.0f, 1.0f, 0.6800000071525574f, 0.30000001192092896f, 0.0f, 0.30000001192092896f, 0.0f, 0.30000001192092896f};
+extern "C" const f32 RoutingTable71ToQuad[32] = {1.0f, 0.0f, 0.5f, 0.30000001192092896f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.5f, 0.30000001192092896f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.6000000238418579f, 0.0f, 0.4000000059604645f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.6000000238418579f, 0.0f, 0.4000000059604645f};
+extern "C" const f32 RoutingTable71To51[48] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.6000000238418579f, 0.0f, 0.4000000059604645f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.6000000238418579f, 0.0f, 0.4000000059604645f};
+extern "C" const f32 RoutingTable71To71[64] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+
+NuSoundSystem::ChannelConfig NuSoundRoutingTable::GetConfig(i32 index) {
+    switch (index) {
+    case 1: return static_cast<NuSoundSystem::ChannelConfig>(2);
+    case 2: return static_cast<NuSoundSystem::ChannelConfig>(3);
+    case 3: return static_cast<NuSoundSystem::ChannelConfig>(4);
+    case 4: return static_cast<NuSoundSystem::ChannelConfig>(6);
+    case 5: return static_cast<NuSoundSystem::ChannelConfig>(8);
+    default: return static_cast<NuSoundSystem::ChannelConfig>(1);
+    }
 }
 
-void NuSoundRoutingTable::GetIndex(NuSoundSystem::ChannelConfig) {
+i32 NuSoundRoutingTable::GetIndex(NuSoundSystem::ChannelConfig config) {
+    switch (config) {
+    case 2: return 1;
+    case 3: return 2;
+    case 4: return 3;
+    case 6: return 4;
+    case 8: return 5;
+    default: return 0;
+    }
 }
 
-void NuSoundRoutingTable::GetMatrix(NuSoundSystem::ChannelConfig, NuSoundSystem::ChannelConfig) const {
+NuSoundMixMatrix *NuSoundRoutingTable::GetMatrix(NuSoundSystem::ChannelConfig from, NuSoundSystem::ChannelConfig to) const {
+    return matrices[GetIndex(from)][GetIndex(to)];
 }
 
-void NuSoundRoutingTable::GetName() const {
+const char *NuSoundRoutingTable::GetName() const {
+    return name_data;
 }
 
-NuSoundRoutingTable::NuSoundRoutingTable(char const *) {
+NuSoundRoutingTable::NuSoundRoutingTable(char const *name) {
+    unknown_04 = 0;
+    name_data = name_storage;
+    unknown_00 = 0;
+    name_capacity = 32;
+    name_length = 1;
+    name_storage[0] = 0;
+    u16 length = strlen(name) + 1;
+    memcpy(name_data, name, length);
+    name_length = length;
+    memset(matrices, 0, sizeof(matrices));
 }
 
-NuSoundRoutingTable::NuSoundRoutingTable(char const *, NuSoundRoutingTable const *) {
+NuSoundRoutingTable::NuSoundRoutingTable(char const *name, NuSoundRoutingTable const *parent) {
+    unknown_04 = 0;
+    name_data = name_storage;
+    unknown_00 = 0;
+    name_capacity = 32;
+    name_length = 1;
+    name_storage[0] = 0;
+    u16 length = strlen(name) + 1;
+    memcpy(name_data, name, length);
+    name_length = length;
+    memset(matrices, 0, sizeof(matrices));
+    for (i32 input = 0; input < 6; ++input) {
+        for (i32 output = 0; output < 6; ++output) {
+            NuSoundSystem::ChannelConfig from = GetConfig(input);
+            NuSoundSystem::ChannelConfig to = GetConfig(output);
+            SetMatrix(from, to, parent->GetMatrix(from, to));
+        }
+    }
 }
 
-void NuSoundRoutingTable::SetMatrix(NuSoundSystem::ChannelConfig, NuSoundSystem::ChannelConfig, NuSoundMixMatrix *) {
+void NuSoundRoutingTable::SetMatrix(NuSoundSystem::ChannelConfig from, NuSoundSystem::ChannelConfig to, NuSoundMixMatrix *matrix) {
+    matrices[GetIndex(from)][GetIndex(to)] = matrix;
 }

--- a/src/nu2api/nusound/nusound_sample.cpp
+++ b/src/nu2api/nusound/nusound_sample.cpp
@@ -7,8 +7,8 @@ pthread_mutex_t NuSoundSample::sCriticalSection = PTHREAD_MUTEX_INITIALIZER;
 
 NuSoundSample::NuSoundSample(const char *path, FeedType feed_type)
     : NuSoundSource(path, SourceType::ZERO, feed_type), buffer{} {
-    this->field2_0x24 = 0;
-    this->field1_0x20 = 0;
+    this->list_next = NULL;
+    this->list_previous = NULL;
     this->file_type = NuSoundSystem::DetermineFileType(path);
     this->load_state = LoadState::NOT_LOADED;
     this->last_error = ErrorState::NONE;
@@ -103,6 +103,12 @@ void NuSoundSample::SetLoadState(LoadState state) {
 }
 
 NuSoundSample::~NuSoundSample() {
+    if (stream_desc != NULL) {
+        NuSoundSystem::FreeMemory(NuSoundSystem::MemoryDiscipline::SCRATCH,
+                                  reinterpret_cast<usize>(stream_desc), 0);
+        SetStreamDesc(NULL);
+    }
+    if (buffer.IsAllocated()) Unload();
 }
 
 void NuSoundSample::SetLastErrorState(ErrorState state) {
@@ -132,9 +138,10 @@ i32 NuSoundSample::Unload() {
         this->buffer.Free();
     }
 
-    if (this->stream_desc != NULL) {
-        this->stream_desc->~NuSoundStreamDesc();
-        NuSoundSystem::FreeMemory(NuSoundSystem::MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(this->stream_desc),
+    NuSoundStreamDesc *desc = this->stream_desc;
+    if (desc != NULL) {
+        desc->~NuSoundStreamDesc();
+        NuSoundSystem::FreeMemory(NuSoundSystem::MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(desc),
                                   0);
         SetStreamDesc(NULL);
     }

--- a/src/nu2api/nusound/nusound_sample.hpp
+++ b/src/nu2api/nusound/nusound_sample.hpp
@@ -23,9 +23,11 @@ class NuSoundSample : public NuSoundSource {
         UNSUPPORTED = 3,
     };
 
+  public:
+    NuSoundSample *list_previous;
+    NuSoundSample *list_next;
+
   protected:
-    i32 field1_0x20;
-    i32 field2_0x24;
     NuSoundBuffer buffer;
     NuSoundSystem::FileType file_type;
 
@@ -69,9 +71,8 @@ class NuSoundSample : public NuSoundSource {
     // NuSoundSource overrides (the original dispatched through the source
     // vtable; Play() calls RequestBuffer to obtain its initial buffers).
     bool IsStreamOpen() const override;
-    u32 GetMaxBufferSize() override {
-        return 0;
-    }
+    bool OpenStream(bool) override { return true; }
+    void CloseStream() override {}
     void RequestBuffer(bool loop, NuSoundWeakPtr<NuSoundBufferCallback> callback) override;
 
     ~NuSoundSample();

--- a/src/nu2api/nusound/nusound_source.hpp
+++ b/src/nu2api/nusound/nusound_source.hpp
@@ -33,7 +33,8 @@ class NuSoundSource {
     NuSoundSource(const char *file, SourceType source_type, FeedType feed_type);
     virtual ~NuSoundSource();
 
-    const char *GetName() const;
+    virtual const char *GetName() const;
+    virtual NuSoundSource *GetEncodedSource() { return this; }
 
     void SetStreamDesc(NuSoundStreamDesc *desc);
     NuSoundStreamDesc *GetStreamDesc() const {
@@ -43,20 +44,15 @@ class NuSoundSource {
     // Source virtuals the voice layer dispatches through (the original went
     // through the source vtable; NuSoundSample / NuSoundStreamingSample and
     // NuSoundDecoder override them).
-    virtual bool OpenStream(bool loop) {
-        (void)loop;
-        return true;
-    }
-    virtual void CloseStream() {
-    }
+    virtual bool OpenStream(bool loop) = 0;
+    virtual void CloseStream() = 0;
     virtual bool IsStreamOpen() const = 0;
-    virtual u32 GetMaxBufferSize() = 0;
-    virtual u32 GetNumInitialBuffers() const;
     virtual void RequestBuffer(bool loop, NuSoundWeakPtr<NuSoundBufferCallback> callback) = 0;
-    virtual void Lock() {
-    }
-    virtual void Unlock() {
-    }
+    virtual u32 GetMaxBufferSize() { return 0; }
+    virtual void Lock() = 0;
+    virtual void Unlock() = 0;
+    virtual bool IsLocked() const = 0;
+    virtual u32 GetNumInitialBuffers() const;
     virtual void VoiceReference();
     virtual void VoiceRelease();
 

--- a/src/nu2api/nusound/nusound_streamdesc.hpp
+++ b/src/nu2api/nusound/nusound_streamdesc.hpp
@@ -22,17 +22,29 @@ class NuSoundStreamDesc {
     virtual u64 GetLengthSamples() const = 0;
     virtual f32 GetLengthSeconds() const = 0;
     virtual u64 GetDataOffset() const = 0;
-    virtual u16 GetNumChannels() const = 0;
+    virtual u32 GetNumChannels() const = 0;
     virtual u32 GetSampleRate() const = 0;
-    virtual u16 GetBitsPerChannel() const = 0;
-    virtual u16 GetBlockSize() const = 0;
-    virtual DataFormat GetEncodedDataFormat() const = 0;
-    virtual u64 GetDecodedLengthBytes() const = 0;
+    virtual u32 GetBitsPerChannel() const = 0;
+    virtual u32 GetBlockSize() const = 0;
+    virtual DataFormat GetEncodedDataFormat() const {
+        return GetDecodedDataFormat();
+    }
+    virtual u64 GetDecodedLengthBytes() const {
+        return GetEncodedLengthBytes();
+    }
     virtual i32 DecodeStreamOnOpen() const;
     virtual i32 GetLoopStart() const;
     virtual i32 GetLoopEnd() const;
-    virtual u16 GetInterleaveSize() const = 0;
-    virtual u16 GetFormatID() const = 0;
-    virtual u16 GetExtendedDataSize() const = 0;
-    virtual void *GetExtendedData() const = 0;
+    virtual u16 GetInterleaveSize() const {
+        return 0;
+    }
+    virtual u16 GetFormatID() const {
+        return 1;
+    }
+    virtual u16 GetExtendedDataSize() const {
+        return 0;
+    }
+    virtual void *GetExtendedData() const {
+        return nullptr;
+    }
 };

--- a/src/nu2api/nusound/nusound_streamer.cpp
+++ b/src/nu2api/nusound/nusound_streamer.cpp
@@ -8,6 +8,7 @@
 #include "nu2api/nusound/nusound_loader.hpp"
 
 #include <new>
+#include <string.h>
 
 NuList<NuSoundStreamer *> NuSoundStreamer::sStreamers;
 i32 NuSoundStreamer::sThreadPriority = 2;
@@ -21,6 +22,8 @@ NUTHREAD_CORE NuSoundStreamer::sThreadCoreId = {.value = 0};
 NuSoundStreamer::NuSoundStreamer()
     : queue1_semaphore(32), queue2_semaphore(32), semaphore(32), queue1_length(0), queue1_index(0), queue2_length(0),
       queue2_index(0), running(true) {
+    memset(queue1, 0, sizeof(queue1));
+    memset(queue2, 0, sizeof(queue2));
     thread =
         NuCore::m_threadManager->CreateThread(ThreadFunc, this, sThreadPriority, "NuSoundStreamThread",
                                               sThreadStackSize, sThreadCoreId.cafe_core, sThreadCoreId.xbox360_core);
@@ -34,6 +37,14 @@ NuSoundStreamer::NuSoundStreamer()
 }
 
 NuSoundStreamer::~NuSoundStreamer() {
+    running = false;
+    for (NuListNodeBase *node = sStreamers.Head(); node != sStreamers.Tail();) {
+        NuListNodeBase *next = node->GetNext();
+        if (static_cast<NuListNode<NuSoundStreamer *> *>(node)->value == this) {
+            sStreamers.Remove(node);
+        }
+        node = next;
+    }
 }
 
 void NuSoundStreamer::RequestCue(NuSoundStreamingSample *streaming_sample, bool loop, f32 start_offset,
@@ -42,6 +53,7 @@ void NuSoundStreamer::RequestCue(NuSoundStreamingSample *streaming_sample, bool 
     streaming_sample->streamer = this;
 
     QueueElement *element = &this->queue1[this->queue1_length % 32];
+    new (element) QueueElement;
     element->message = QueueElement::Message::OPEN_SAMPLE;
     element->sample = streaming_sample;
     element->loop = loop;
@@ -66,27 +78,17 @@ void NuSoundStreamer::RequestFill(NuSoundStreamingSample *sample, NuSoundBuffer 
                                   NuSoundWeakPtr<NuSoundBufferCallback> callback) {
     // Fill requests go to the priority queue so the streamer always services
     // them before any pending control request.
-    QueueElement *element = &this->queue2[this->queue2_length % 32];
-    element->message = QueueElement::Message::FILL_STREAM_BUFFER;
-    element->sample = sample;
-    element->loop = loop;
-    element->start_offset = 0.0f;
-    element->buffer = buffer;
+    QueueElement request;
+    request.message = QueueElement::Message::FILL_STREAM_BUFFER;
+    request.sample = sample;
+    request.loop = loop;
+    request.start_offset = 0.0f;
+    request.buffer = buffer;
+    request.weak_ptr = callback;
+    request.weak_flag = false;
 
-    NuSoundWeakPtrListNode::sPtrListLock.Lock();
-    NuSoundWeakPtr<NuSoundBufferCallback> local;
-    local.obj = callback.obj;
-    if (element->weak_ptr.obj != local.obj) {
-        if (element->weak_ptr.obj != NULL) {
-            element->weak_ptr.obj->Unlink(&element->weak_ptr);
-        }
-        if (local.obj != NULL) {
-            local.obj->Link(&element->weak_ptr);
-        }
-        element->weak_ptr.obj = local.obj;
-    }
-    NuSoundWeakPtrListNode::sPtrListLock.Unlock();
-    element->weak_flag = false;
+    QueueElement *element = &this->queue2[this->queue2_length % 32];
+    new (element) QueueElement(request);
 
     __sync_fetch_and_add(&this->queue2_length, 1);
 
@@ -97,6 +99,7 @@ void NuSoundStreamer::RequestClose(NuSoundStreamingSample *sample) {
     sample->AddedToThreadQueue();
 
     QueueElement *element = &this->queue1[this->queue1_length % 32];
+    new (element) QueueElement;
     element->message = QueueElement::Message::CLOSE_SAMPLE;
     element->sample = sample;
     element->loop = false;
@@ -121,6 +124,7 @@ void NuSoundStreamer::RequestReCue(NuSoundStreamingSample *sample, bool loop, f3
     sample->AddedToThreadQueue();
 
     QueueElement *element = &this->queue1[this->queue1_length % 32];
+    new (element) QueueElement;
     element->message = QueueElement::Message::RECUE_SAMPLE;
     element->sample = sample;
     element->loop = loop;
@@ -143,17 +147,28 @@ void NuSoundStreamer::RequestReCue(NuSoundStreamingSample *sample, bool loop, f3
 
 void NuSoundStreamer::ShutdownThread() {
     QueueElement *element = &this->queue1[this->queue1_length % 32];
+    new (element) QueueElement;
     element->message = QueueElement::Message::SHUTDOWN;
     element->sample = NULL;
     element->loop = false;
     element->start_offset = 0.0f;
     element->buffer = NULL;
-    element->weak_ptr.obj = NULL;
+    NuSoundWeakPtrListNode::sPtrListLock.Lock();
+    if (element->weak_ptr.obj != NULL) {
+        element->weak_ptr.obj->Unlink(&element->weak_ptr);
+        element->weak_ptr.obj = NULL;
+    }
+    NuSoundWeakPtrListNode::sPtrListLock.Unlock();
     element->weak_flag = false;
 
     __sync_fetch_and_add(&this->queue1_length, 1);
 
     this->semaphore.Signal();
+    while (running) {
+        NuThreadSleep(1);
+    }
+    NuSoundWeakPtrListNode::sPtrListLock.Lock();
+    NuSoundWeakPtrListNode::sPtrListLock.Unlock();
 }
 
 void NuSoundStreamer::ShutdownAll() {
@@ -173,6 +188,7 @@ void NuSoundStreamer::ThreadFunc(void *self) {
     do {
         streamer->semaphore.Wait();
 
+        QueueElement element;
         QueueElement *slot;
         bool is_fill;
         if (streamer->queue2_index == streamer->queue2_length) {
@@ -183,18 +199,17 @@ void NuSoundStreamer::ThreadFunc(void *self) {
             is_fill = true;
         }
 
-        // Take a copy of the element; the queue slot releases its weak
-        // reference as soon as the element is taken.
-        QueueElement element;
-        element.message = slot->message;
-        element.sample = slot->sample;
-        element.loop = slot->loop;
-        element.start_offset = slot->start_offset;
-        element.buffer = slot->buffer;
-        element.weak_ptr.obj = slot->weak_ptr.obj;
-        element.weak_flag = slot->weak_flag;
-        slot->weak_ptr.obj = NULL;
-        slot->weak_flag = false;
+        // Release the queue slot before assigning the request to the worker.
+        {
+            QueueElement dequeued(*slot);
+            slot->~QueueElement();
+            if (is_fill) {
+                __sync_fetch_and_add(&streamer->queue2_index, 1);
+            } else {
+                __sync_fetch_and_add(&streamer->queue1_index, 1);
+            }
+            element = dequeued;
+        }
 
         LOG_INFO("NuSoundStreamer::ThreadFunc: processing element %p (message=%d, sample=%p, loop=%d, "
                  "start_offset=%f, buffer=%p, weak_ptr.obj=%p)",
@@ -237,18 +252,6 @@ void NuSoundStreamer::ThreadFunc(void *self) {
                 break;
         }
 
-        if (element.weak_ptr.obj != NULL) {
-            NuSoundWeakPtrListNode::sPtrListLock.Lock();
-            element.weak_ptr.obj->Unlink(&element.weak_ptr);
-            element.weak_ptr.obj = NULL;
-            NuSoundWeakPtrListNode::sPtrListLock.Unlock();
-        }
-
-        if (is_fill) {
-            __sync_fetch_and_add(&streamer->queue2_index, 1);
-        } else {
-            __sync_fetch_and_add(&streamer->queue1_index, 1);
-        }
     } while (streamer->running != false);
 }
 
@@ -267,14 +270,20 @@ NuSoundStreamingSample::NuSoundStreamingSample(const char *file)
 }
 
 NuSoundStreamingSample::~NuSoundStreamingSample() {
+    if (file_loader != NULL) {
+        NuSoundSystem::ReleaseFileLoader(file_loader);
+        file_loader = NULL;
+    }
 }
 
 i32 NuSoundStreamingSample::Open(f32 start_offset, bool loop, bool weak_flag) {
-    if (GetResourceCount() == 0 || GetLoadState() == LoadState::STREAM_READY) {
+    LoadState load_state = GetLoadState();
+    if (GetResourceCount() == 0 || load_state == LoadState::STREAM_READY) {
         return 0;
     }
 
     NuSoundStreamDesc *desc = NULL;
+    i32 open_result;
 
     if (this->sound_buffer1 == NULL) {
         u32 stream_buffer_size = NuSoundSystem::GetStreamBufferSize();
@@ -310,42 +319,54 @@ i32 NuSoundStreamingSample::Open(f32 start_offset, bool loop, bool weak_flag) {
 
     this->SetStreamDesc(desc);
 
-    if (this->file_loader->OpenForStreaming(this->name, start_offset, desc, weak_flag) != 1) {
+    open_result = this->file_loader->OpenForStreaming(this->name, start_offset, desc, weak_flag);
+    if (open_result != 1) {
+    open_error:
+        ErrorState error = ErrorState::FILE_NOT_FOUND;
+        switch (open_result) {
+            case 3:
+            case 4: error = ErrorState::OUT_OF_MEMORY; break;
+            case 5: error = ErrorState::UNSUPPORTED; break;
+        }
         NuSoundSystem::ReleaseFileLoader(this->file_loader);
         this->file_loader = NULL;
-        NuSoundSystem::FreeMemory(NuSoundSystem::MemoryDiscipline::SAMPLE, (usize)desc, 0);
+        NuSoundSystem::FreeMemory(NuSoundSystem::MemoryDiscipline::SCRATCH, (usize)desc, 0);
         this->SetStreamDesc(NULL);
         this->SetLoadState(LoadState::NOT_LOADED);
-        this->SetLastErrorState(ErrorState::NONE);
-        return 1;
+        this->SetLastErrorState(error);
+        return (i32)error;
     }
 
     {
-        NuSoundBuffer::Context context;
+        NuSoundBuffer::Context context = {};
+        context.flags = 1;
         context.flags |= 1; // streaming
 
-        this->file_loader->FillStreamBuffer(this->sound_buffer1, loop);
-        context = this->sound_buffer1->GetCurrentContext();
+        context = this->file_loader->FillStreamBuffer(this->sound_buffer1, loop);
 
         if (context.size2 != 0) {
             this->some_count++;
+        } else if (this->some_count == 0) {
+            this->file_loader->CloseStream();
+            this->sound_buffer1->SetCurrentContext(context);
+            context.flags &= ~1;
+            open_result = 4;
+            goto open_error;
         }
         this->sound_buffer1->SetCurrentContext(context);
+        context.flags &= ~1;
         u32 first_flags = context.flags;
 
         if ((first_flags & 2) == 0) {
-            this->file_loader->FillStreamBuffer(this->sound_buffer2, loop);
-            context = this->sound_buffer2->GetCurrentContext();
+            context = this->file_loader->FillStreamBuffer(this->sound_buffer2, loop);
 
             if (context.size2 != 0) {
                 this->some_count++;
             } else if (this->some_count == 0) {
-                // Nothing decoded at all: the stream is unusable.
                 this->file_loader->CloseStream();
                 this->sound_buffer2->SetCurrentContext(context);
-                this->SetLoadState(LoadState::NOT_LOADED);
-                this->SetLastErrorState(ErrorState::NONE);
-                return 4;
+                open_result = 4;
+                goto open_error;
             }
             this->sound_buffer2->SetCurrentContext(context);
         }
@@ -435,38 +456,41 @@ i32 NuSoundStreamingSample::ReCue(f32 start_offset, bool loop) {
 
     this->file_loader->SeekTime(start_offset);
 
-    NuSoundBuffer::Context context;
+    NuSoundBuffer::Context context = {};
+    context.flags = 1;
     context.flags |= 1;
 
     this->sound_buffer1->Lock();
-    this->file_loader->FillStreamBuffer(this->sound_buffer1, loop);
-    context = this->sound_buffer1->GetCurrentContext();
+    context = this->file_loader->FillStreamBuffer(this->sound_buffer1, loop);
 
     if (context.size2 != 0) {
         this->some_count++;
+    } else if ((context.flags & 2) == 0) {
+        goto refill_error;
     }
     this->sound_buffer1->SetCurrentContext(context);
-    u32 first_flags = context.flags;
+    context.flags &= ~1;
     this->sound_buffer1->Unlock();
 
-    if ((first_flags & 2) == 0) {
+    if ((context.flags & 2) == 0) {
         this->sound_buffer2->Lock();
-        this->file_loader->FillStreamBuffer(this->sound_buffer2, loop);
-        context = this->sound_buffer2->GetCurrentContext();
+        context = this->file_loader->FillStreamBuffer(this->sound_buffer2, loop);
 
         if (context.size2 != 0) {
             this->some_count++;
-        } else {
-            // Ran out of data while re-filling the second buffer.
-            this->file_loader->CloseStream();
-            this->sound_buffer2->Unlock();
-            return 2;
+        } else if ((context.flags & 2) == 0) {
+            goto refill_error;
         }
         this->sound_buffer2->SetCurrentContext(context);
+        context.flags &= ~1;
         this->sound_buffer2->Unlock();
     }
 
     return 0;
+
+refill_error:
+    this->file_loader->CloseStream();
+    return 2;
 }
 
 bool NuSoundStreamingSample::IsLocked() const {
@@ -503,10 +527,7 @@ void NuSoundStreamingSample::RequestBuffer(bool loop, NuSoundWeakPtr<NuSoundBuff
         // thread; the voice gets it once the fill completes.
         NuSoundBuffer *buffer = (&this->sound_buffer1)[this->some_count % 2];
 
-        NuSoundWeakPtr<NuSoundBufferCallback> local;
-        local.obj = callback.obj;
-
-        this->streamer->RequestFill(this, buffer, loop, local);
+        this->streamer->RequestFill(this, buffer, loop, callback);
         this->some_count++;
     }
 

--- a/src/nu2api/nusound/nusound_streamer.hpp
+++ b/src/nu2api/nusound/nusound_streamer.hpp
@@ -46,6 +46,9 @@ class NuSoundStreamingSample : public NuSoundSample {
     i32 ReCue(f32 start_offset, bool loop);
 
     bool IsLocked() const override;
+    bool IsStreamOpen() const override {
+        return GetLoadState() == LoadState::STREAM_READY;
+    }
     void Lock();
     void Unlock();
 
@@ -73,16 +76,9 @@ class NuSoundStreamer {
         NuSoundWeakPtr<NuSoundBufferCallback> weak_ptr;
         bool weak_flag;
 
-        QueueElement() = default;
+        QueueElement() : sample(NULL), loop(false), start_offset(0.0f), buffer(NULL), weak_flag(false) {}
 
-        ~QueueElement() {
-            NuSoundWeakPtrListNode::sPtrListLock.Lock();
-            if (this->weak_ptr.obj != NULL) {
-                this->weak_ptr.obj->Unlink(&this->weak_ptr);
-                this->weak_ptr.obj = NULL;
-            }
-            NuSoundWeakPtrListNode::sPtrListLock.Unlock();
-        }
+        ~QueueElement() = default;
     };
 
   public:
@@ -96,12 +92,12 @@ class NuSoundStreamer {
     NuThread *thread;
     bool running;
 
-    QueueElement queue1[32]; // control queue (open / close / recue / shutdown)
+    union { QueueElement queue1[32]; }; // control queue storage
     i32 queue1_length;
     i32 queue1_index;
     NuThreadSemaphore queue1_semaphore;
 
-    QueueElement queue2[32]; // fill queue — always drained first
+    union { QueueElement queue2[32]; }; // fill queue storage
     i32 queue2_length;
     i32 queue2_index;
     NuThreadSemaphore queue2_semaphore;

--- a/src/nu2api/nusound/nusound_system.cpp
+++ b/src/nu2api/nusound/nusound_system.cpp
@@ -1,8 +1,10 @@
 #include "nu2api/nusound/nusound_system.hpp"
+#include "nu2api/nusound/nusound_android.hpp"
 
 #include "nu2api/nucore/nustring.h"
 #include "nu2api/nufile/nufile.h"
 #include "nu2api/numath/nuvec.h"
+#include "nu2api/numath/nufloat.h"
 #include "nu2api/nusound/nusound_bus.hpp"
 #include "nu2api/nusound/nusound_decoder.hpp"
 #include "nu2api/nusound/nusound_decoder_ogg.hpp"
@@ -10,14 +12,59 @@
 #include "nu2api/nusound/nusound_voice.hpp"
 
 #include "decomp.h"
+#include "globals.h"
+#include "nu2api/nucore/numemory.h"
 
 #include <cstdio>
 #include <cstring>
 #include <new>
 
+static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectAttenuation) == 0x48, "attenuation effect ABI");
+static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectPitch) == 0x44, "pitch effect ABI");
+static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectRandomVolume) == 0x44, "random volume effect ABI");
+static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectRandomPitch) == 0x44, "random pitch effect ABI");
+static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectRepeat) == 0x54, "repeat effect ABI");
+static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectDoppler) == 0x50, "Doppler effect ABI");
+static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectFader) == 0x6c, "fader effect ABI");
+static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectPitchRamp) == 0x54, "pitch ramp effect ABI");
+
+// Sentinels contain only the intrusive links, with the same adjusted object
+// pointers used by the original NuEList<NuSoundVoice>.
+static NuSoundSystem::VoiceLinks *VoiceLinksFor(NuSoundVoice *voice) {
+    return voice != NULL ? reinterpret_cast<NuSoundSystem::VoiceLinks *>(
+        reinterpret_cast<char *>(voice) + offsetof(NuSoundVoice, field_0x24)) : NULL;
+}
+
+static_assert(sizeof(void *) != 4 || offsetof(NuSoundVoice, field_0x24) == 0x24,
+              "voice intrusive links must retain their Android offset");
+#if defined(__arm__)
+static_assert(offsetof(NuSoundSystem, voice_head) == 0x78, "ARM voice list head offset");
+static_assert(offsetof(NuSoundSystem, effect_head) == 0x94, "ARM effect list head offset");
+#else
+static_assert(sizeof(void *) != 4 || offsetof(NuSoundSystem, voice_head) == 0x74,
+              "voice list head must retain its Android offset");
+static_assert(sizeof(void *) != 4 || offsetof(NuSoundSystem, effect_head) == 0x90,
+              "effect list head must retain its Android offset");
+#endif
+static_assert(sizeof(void *) != 4 || offsetof(NuSoundEffect, system_owned) == 0x24,
+              "effect ownership flag must retain its Android offset");
+
 NuSoundBus *NuSoundSystem::sMasterBus = NULL;
+
+template <typename T> void NuSoundMemory::PushNuListNode(NuList<T> &list, const T &value) {
+    NuMemoryManager *previous = NuMemoryGet()->SetThreadMem(NuSoundSystem::sScratchMemMgr);
+    NuListNode<T> *node = static_cast<NuListNode<T> *>(
+        NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuListNode<T>), 4, 1, "", 0));
+    if (node != NULL) new (node) NuListNode<T>(NULL, NULL, value);
+    list.Append(node);
+    NuMemoryGet()->SetThreadMem(previous);
+    NuSoundSystem::sAllocdMemory[0] += sizeof(NuListNode<T>);
+}
+
+template void NuSoundMemory::PushNuListNode(NuList<NuSoundEffect *> &, NuSoundEffect *const &);
 i32 NuSoundSystem::sAllocdMemory[3] = {0};
 i32 NuSoundSystem::sTotalMemory[3] = {0};
+u32 NuSoundSystem::sGfxMemorySize = 0;
 void *NuSoundSystem::sScratchMemory = NULL;
 void *NuSoundSystem::sSampleMemory = NULL;
 void *NuSoundSystem::sDecoderMemory = NULL;
@@ -33,8 +80,313 @@ i32 NuSoundSystem::sOutputConfig = 0;
 
 NuMemoryManager *NuSoundSystem::sScratchMemMgr = NULL;
 
+extern "C" const f32 RoutingTableMonoToMono[1];
+extern "C" const f32 RoutingTableMonoToStereo[2];
+extern "C" const f32 RoutingTableMonoToQuad[4];
+extern "C" const f32 RoutingTableMonoTo51[6];
+extern "C" const f32 RoutingTableMonoTo71[8];
+extern "C" const f32 RoutingTableStereoToMono[2];
+extern "C" const f32 RoutingTableStereoToStereo[4];
+extern "C" const f32 RoutingTableStereoToQuad[8];
+extern "C" const f32 RoutingTableStereoTo51[12];
+extern "C" const f32 RoutingTableStereoTo71[16];
+extern "C" const f32 RoutingTableLRCToMono[3];
+extern "C" const f32 RoutingTableLRCToStereo[6];
+extern "C" const f32 RoutingTableLRCToQuad[12];
+extern "C" const f32 RoutingTableLRCTo51[18];
+extern "C" const f32 RoutingTableLRCTo71[24];
+extern "C" const f32 RoutingTable51ToMono[6];
+extern "C" const f32 RoutingTable51ToStereo[12];
+extern "C" const f32 RoutingTable51ToQuad[24];
+extern "C" const f32 RoutingTable51To51[36];
+extern "C" const f32 RoutingTable51To71[48];
+extern "C" const f32 RoutingTable71ToMono[8];
+extern "C" const f32 RoutingTable71ToStereo[16];
+extern "C" const f32 RoutingTable71ToQuad[32];
+extern "C" const f32 RoutingTable71To51[48];
+extern "C" const f32 RoutingTable71To71[64];
+
 void NuSoundInitDefaultRoutingTables(void) {
-    LOG_WARN("NuSoundInitDefaultRoutingTables is not implemented");
+    NuSoundRoutingTable *table = static_cast<NuSoundRoutingTable *>(
+        NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundRoutingTable), 4, 1, "", 7));
+    if (table != NULL) new (table) NuSoundRoutingTable("default");
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 1;
+            matrix->out = 1;
+            matrix->matrix = const_cast<f32 *>(RoutingTableMonoToMono);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(1), static_cast<NuSoundSystem::ChannelConfig>(1), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 1;
+            matrix->out = 2;
+            matrix->matrix = const_cast<f32 *>(RoutingTableMonoToStereo);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(1), static_cast<NuSoundSystem::ChannelConfig>(2), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 1;
+            matrix->out = 4;
+            matrix->matrix = const_cast<f32 *>(RoutingTableMonoToQuad);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(1), static_cast<NuSoundSystem::ChannelConfig>(4), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 1;
+            matrix->out = 6;
+            matrix->matrix = const_cast<f32 *>(RoutingTableMonoTo51);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(1), static_cast<NuSoundSystem::ChannelConfig>(6), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 1;
+            matrix->out = 8;
+            matrix->matrix = const_cast<f32 *>(RoutingTableMonoTo71);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(1), static_cast<NuSoundSystem::ChannelConfig>(8), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 2;
+            matrix->out = 1;
+            matrix->matrix = const_cast<f32 *>(RoutingTableStereoToMono);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(2), static_cast<NuSoundSystem::ChannelConfig>(1), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 2;
+            matrix->out = 2;
+            matrix->matrix = const_cast<f32 *>(RoutingTableStereoToStereo);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(2), static_cast<NuSoundSystem::ChannelConfig>(2), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 2;
+            matrix->out = 4;
+            matrix->matrix = const_cast<f32 *>(RoutingTableStereoToQuad);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(2), static_cast<NuSoundSystem::ChannelConfig>(4), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 2;
+            matrix->out = 6;
+            matrix->matrix = const_cast<f32 *>(RoutingTableStereoTo51);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(2), static_cast<NuSoundSystem::ChannelConfig>(6), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 2;
+            matrix->out = 8;
+            matrix->matrix = const_cast<f32 *>(RoutingTableStereoTo71);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(2), static_cast<NuSoundSystem::ChannelConfig>(8), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 3;
+            matrix->out = 1;
+            matrix->matrix = const_cast<f32 *>(RoutingTableLRCToMono);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(3), static_cast<NuSoundSystem::ChannelConfig>(1), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 3;
+            matrix->out = 2;
+            matrix->matrix = const_cast<f32 *>(RoutingTableLRCToStereo);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(3), static_cast<NuSoundSystem::ChannelConfig>(2), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 3;
+            matrix->out = 4;
+            matrix->matrix = const_cast<f32 *>(RoutingTableLRCToQuad);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(3), static_cast<NuSoundSystem::ChannelConfig>(4), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 3;
+            matrix->out = 6;
+            matrix->matrix = const_cast<f32 *>(RoutingTableLRCTo51);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(3), static_cast<NuSoundSystem::ChannelConfig>(6), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 3;
+            matrix->out = 8;
+            matrix->matrix = const_cast<f32 *>(RoutingTableLRCTo71);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(3), static_cast<NuSoundSystem::ChannelConfig>(8), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 6;
+            matrix->out = 1;
+            matrix->matrix = const_cast<f32 *>(RoutingTable51ToMono);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(6), static_cast<NuSoundSystem::ChannelConfig>(1), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 6;
+            matrix->out = 2;
+            matrix->matrix = const_cast<f32 *>(RoutingTable51ToStereo);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(6), static_cast<NuSoundSystem::ChannelConfig>(2), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 6;
+            matrix->out = 4;
+            matrix->matrix = const_cast<f32 *>(RoutingTable51ToQuad);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(6), static_cast<NuSoundSystem::ChannelConfig>(4), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 6;
+            matrix->out = 6;
+            matrix->matrix = const_cast<f32 *>(RoutingTable51To51);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(6), static_cast<NuSoundSystem::ChannelConfig>(6), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 6;
+            matrix->out = 8;
+            matrix->matrix = const_cast<f32 *>(RoutingTable51To71);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(6), static_cast<NuSoundSystem::ChannelConfig>(8), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 8;
+            matrix->out = 1;
+            matrix->matrix = const_cast<f32 *>(RoutingTable71ToMono);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(8), static_cast<NuSoundSystem::ChannelConfig>(1), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 8;
+            matrix->out = 2;
+            matrix->matrix = const_cast<f32 *>(RoutingTable71ToStereo);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(8), static_cast<NuSoundSystem::ChannelConfig>(2), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 8;
+            matrix->out = 4;
+            matrix->matrix = const_cast<f32 *>(RoutingTable71ToQuad);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(8), static_cast<NuSoundSystem::ChannelConfig>(4), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 8;
+            matrix->out = 6;
+            matrix->matrix = const_cast<f32 *>(RoutingTable71To51);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(8), static_cast<NuSoundSystem::ChannelConfig>(6), matrix);
+    }
+    {
+        NuSoundMixMatrix *matrix = static_cast<NuSoundMixMatrix *>(
+            NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuSoundMixMatrix), 4, 1, "", 7));
+        if (matrix != NULL) {
+            matrix->in = 8;
+            matrix->out = 8;
+            matrix->matrix = const_cast<f32 *>(RoutingTable71To71);
+            matrix->flag = 1;
+        }
+        table->SetMatrix(static_cast<NuSoundSystem::ChannelConfig>(8), static_cast<NuSoundSystem::ChannelConfig>(8), matrix);
+    }
+    NuSound.AddRoutingTable(table);
+    NuSoundSystem::SetDefaultRoutingTable(table);
 }
 
 NuSoundSystem::NuSoundSystem() {
@@ -92,14 +444,48 @@ NuSoundSystem::NuSoundSystem() {
     // this->field42_0xd8 = (undefined1 *)&this->field43_0xdc;
     // this->field43_0xdc = (undefined1 *)&this->field41_0xd4;
     // this->field47_0xec = 0;
-    // this->field48_0xf0 = 0;
-    // this->field49_0xf4 = 0;
+    unknown_f0[0] = 0;
+    unknown_f0[1] = 0;
     this->samples = NULL;
-    // this->field50_0xf8 = 0;
+    sample_head = reinterpret_cast<NuSoundSample *>(reinterpret_cast<char *>(&sample_start) - offsetof(NuSoundSample, list_previous));
+    sample_tail = reinterpret_cast<NuSoundSample *>(reinterpret_cast<char *>(&sample_end) - offsetof(NuSoundSample, list_previous));
+    sample_start.previous = NULL;
+    sample_start.next = sample_tail;
+    sample_end.previous = sample_head;
+    sample_end.next = NULL;
+    sample_list_count = 0;
+    sample_load_count = 0;
     this->sample_count = 0x100;
-    this->voice_list_start = NULL;
-    this->voice_list_end = NULL;
+    voice_head = reinterpret_cast<NuSoundVoice *>(
+        reinterpret_cast<char *>(&voice_start) - offsetof(NuSoundVoice, field_0x24));
+    voice_tail = reinterpret_cast<NuSoundVoice *>(
+        reinterpret_cast<char *>(&voice_end) - offsetof(NuSoundVoice, field_0x24));
+    voice_start.prev = NULL;
+    voice_start.next = voice_tail;
+    voice_end.prev = voice_head;
+    voice_end.next = NULL;
     this->voice_count = 0;
+    effect_head = reinterpret_cast<NuEListNode<NuSoundEffect> *>(&effect_start);
+    effect_tail = reinterpret_cast<NuEListNode<NuSoundEffect> *>(&effect_end);
+    effect_start.prev = NULL;
+    effect_start.next = effect_tail;
+    effect_end.prev = effect_head;
+    effect_end.next = NULL;
+    effect_count = 0;
+    bus_head = reinterpret_cast<NuSoundBus *>(&bus_start);
+    bus_tail = reinterpret_cast<NuSoundBus *>(&bus_end);
+    bus_start.previous = NULL;
+    bus_start.next = bus_tail;
+    bus_end.previous = bus_head;
+    bus_end.next = NULL;
+    bus_count = 0;
+    routing_head = reinterpret_cast<NuSoundRoutingTable *>(&routing_start);
+    routing_tail = reinterpret_cast<NuSoundRoutingTable *>(&routing_end);
+    routing_start.prev = NULL;
+    routing_start.next = routing_tail;
+    routing_end.prev = routing_head;
+    routing_end.next = NULL;
+    routing_count = 0;
     // libTTapp.so ctor (0x319552): the update gate field63_0x108 starts at 1.
     this->initialised = true;
     // this->field63_0x108 = 1;
@@ -125,18 +511,20 @@ bool NuSoundSystem::Initialise(i32 size) {
     sScratchMemMgr = NuMemoryGet()->CreateMemoryManager(&g_handler, "NuSoundSystem Memory");
 
     if (sTotalMemory[(i32)MemoryDiscipline::DECODER] != 0) {
-        s_mmDecoder = NU_ALLOC_T(NuSoundMemoryManager, 1, "", 0);
-        if (s_mmDecoder != NULL) {
-            new (s_mmDecoder) NuSoundMemoryManager{};
+        NuSoundMemoryManager *manager = NU_ALLOC_T(NuSoundMemoryManager, 1, "", 0);
+        if (manager != NULL) {
+            new (manager) NuSoundMemoryManager{};
         }
+        s_mmDecoder = manager;
 
         s_mmDecoder->Init("decoder", sDecoderMemory, sTotalMemory[(i32)MemoryDiscipline::DECODER], 4, 0x800);
     }
 
-    s_mmSample = NU_ALLOC_T(NuSoundMemoryManager, 1, "", 0);
-    if (s_mmSample != NULL) {
-        new (s_mmSample) NuSoundMemoryManager{};
+    NuSoundMemoryManager *manager = NU_ALLOC_T(NuSoundMemoryManager, 1, "", 0);
+    if (manager != NULL) {
+        new (manager) NuSoundMemoryManager{};
     }
+    s_mmSample = manager;
 
     s_mmSample->EnableDefragOnAlloc(true);
     s_mmSample->Init("sample", sSampleMemory, sTotalMemory[(i32)MemoryDiscipline::SAMPLE], 4, 0x800);
@@ -242,6 +630,12 @@ NuSoundBus *NuSoundSystem::CreateBus(const char *name, bool is_master) {
 
         if (bus != NULL) {
             new (bus) NuSoundBus(name, is_master);
+            NuSoundBus *previous = bus_tail->previous;
+            bus_tail->previous = bus;
+            bus->previous = previous;
+            previous->next = bus;
+            bus->next = bus_tail;
+            ++bus_count;
 
             // TODO
             // piVar1 = *(i32 **)&this->field_0xb0;
@@ -288,6 +682,15 @@ NuSoundSample *NuSoundSystem::AddSample(const char *name, FileType file_type, Nu
         return NULL;
     }
 
+    NuSoundSample *previous = sample_tail->list_previous;
+    sample_tail->list_previous = sample;
+    sample->list_previous = previous;
+    previous->list_next = sample;
+    sample->list_next = sample_tail;
+    ++sample_list_count;
+    i32 hash = GenerateHash(buf);
+    sample->next = samples[hash];
+    samples[hash] = sample;
     return sample;
 }
 
@@ -314,13 +717,13 @@ i32 NuSoundSystem::GenerateHash(const char *str) {
     char buf[0x100];
     NuStrUpr(buf, str);
 
-    byte hash = 0x5;
+    u32 hash = 0x1505;
 
     for (char *c = buf; *c != '\0'; c++) {
-        hash = (hash * 0x21) + *c;
+        hash = (hash * 0x21) + static_cast<signed char>(*c);
     }
 
-    return hash;
+    return hash & 0xff;
 }
 
 NuSoundSystem::FileType NuSoundSystem::DetermineFileType(const char *path) {
@@ -348,6 +751,7 @@ void NuSoundSystem::ReleaseFileLoader(NuSoundLoader *loader) {
 }
 
 NuSoundSystem::~NuSoundSystem() {
+    s_staticInstance = NULL;
 }
 
 i32 NuSoundStreamDesc::DecodeStreamOnOpen() const {
@@ -362,16 +766,33 @@ i32 NuSoundStreamDesc::GetLoopEnd() const {
     return 0;
 }
 
-void NuSoundSystem::AddListener(NuSoundListener *) {
+bool NuSoundSystem::AddListener(NuSoundListener *listener) {
+    NuSoundListener *previous = listeners.tail->prev;
+    listeners.tail->prev = listener;
+    listener->prev = previous;
+    previous->next = listener;
+    listener->next = listeners.tail;
+    ++listeners.length;
+    return true;
 }
 
-void NuSoundSystem::AddRoutingTable(NuSoundRoutingTable *) {
+void NuSoundSystem::AddRoutingTable(NuSoundRoutingTable *table) {
+    NuSoundRoutingTable *previous = routing_tail->unknown_00;
+    routing_tail->unknown_00 = table;
+    table->unknown_00 = previous;
+    previous->unknown_04 = table;
+    table->unknown_04 = routing_tail;
+    ++routing_count;
 }
 
-void NuSoundSystem::AmplitudeTodB(float) {
+f32 NuSoundSystem::AmplitudeTodB(float amplitude) {
+    if (amplitude <= 0.0f) return -100.0f;
+    if (amplitude >= 1.0f) return 0.0f;
+    return NuLog10(amplitude) * 20.0f;
 }
 
-void NuSoundSystem::CalculateCrossfadeHeight(NuSoundSystem::CurveData const &, float) const {
+f32 NuSoundSystem::CalculateCrossfadeHeight(NuSoundSystem::CurveData const &, float) const {
+    return 0.0f;
 }
 
 void NuSoundSystem::CreateCrossfadeCurve(u32) {
@@ -382,54 +803,184 @@ void NuSoundSystem::CreateCrossfadeCurve(u32) {
 // (encoded format 3) get a decoder; anything else returns NULL and plays
 // through the plain sample path.
 NuSoundDecoder *NuSoundSystem::CreateDecoder(NuSoundSource *source) {
+    // The original uses a growable, 16-bit-length string for the decoder name.
+    char *decoded_name = const_cast<char *>(theEmptyString);
+    u16 length = 1;
+    u16 capacity = 1;
     const char *name = source->GetName();
-
-    char decoded_name[256];
-    u32 name_len = (u32)strlen(name);
-    if (name_len >= sizeof(decoded_name) - 9) {
-        name_len = sizeof(decoded_name) - 9;
-    }
-    memcpy(decoded_name, name, name_len);
-    memcpy(decoded_name + name_len, "_decoder", 9);
-
-    NuSoundStreamDesc *desc = source->GetStreamDesc();
-    if (desc != NULL && desc->GetEncodedDataFormat() == NuSoundStreamDesc::DataFormat::THREE) {
-        NuSoundDecoderOGG *decoder = (NuSoundDecoderOGG *)this->_AllocMemory(
-            NuSoundSystem::MemoryDiscipline::SCRATCH, sizeof(NuSoundDecoderOGG), 4,
-            "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound_system.cpp:436");
-
-        if (decoder != NULL) {
-            new (decoder) NuSoundDecoderOGG(decoded_name, source);
+    if (name != NULL) {
+        length = static_cast<u16>(strlen(name) + 1);
+        if (length > capacity || decoded_name == theEmptyString) {
+            capacity = (length + 3) & 0xfffc;
+            if (decoded_name == theEmptyString) {
+                decoded_name = static_cast<char *>(NU_ALLOC(capacity, 4, 5,
+                    "i:/SagaTouch-Android_9176564/nu2api.saga/../nu2api.2013/numemory/NuMemory.h:328", 0));
+            } else {
+                decoded_name = static_cast<char *>(NuMemoryGet()->GetThreadMem()->_BlockReAlloc(decoded_name, capacity, 4, 5,
+                    "i:/SagaTouch-Android_9176564/nu2api.saga/../nu2api.2013/numemory/NuMemory.h:333", 0));
+            }
         }
-
-        return decoder;
+        memcpy(decoded_name, name, length);
     }
+    u16 appended_length = length + 8;
+    if (appended_length > capacity || decoded_name == theEmptyString) {
+        capacity = (appended_length + 3) & 0xfffc;
+        if (decoded_name == theEmptyString) {
+            decoded_name = static_cast<char *>(NU_ALLOC(capacity, 4, 5,
+                "i:/SagaTouch-Android_9176564/nu2api.saga/../nu2api.2013/numemory/NuMemory.h:328", 0));
+        } else {
+            decoded_name = static_cast<char *>(NuMemoryGet()->GetThreadMem()->_BlockReAlloc(decoded_name, capacity, 4, 5,
+                "i:/SagaTouch-Android_9176564/nu2api.saga/../nu2api.2013/numemory/NuMemory.h:333", 0));
+        }
+    }
+    memcpy(decoded_name + length - 1, "_decoder", 9);
 
-    return NULL;
+    NuSoundDecoderOGG *decoder = NULL;
+    NuSoundStreamDesc *desc = source->GetStreamDesc();
+    if (desc->GetEncodedDataFormat() == NuSoundStreamDesc::DataFormat::THREE) {
+        decoder = static_cast<NuSoundDecoderOGG *>(_AllocMemory(
+            NuSoundSystem::MemoryDiscipline::SCRATCH, sizeof(NuSoundDecoderOGG), 4,
+            "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound_system.cpp:436"));
+        if (decoder != NULL) new (decoder) NuSoundDecoderOGG(decoded_name, source);
+    }
+    if (decoded_name != theEmptyString) NuMemoryGet()->GetThreadMem()->BlockFree(decoded_name, 4);
+    return decoder;
 }
 
-void NuSoundSystem::CreateEffect(NuSoundEffect::EffectType) {
+inline void NuSoundEffectAttenuation::ProcessVoice(NuSoundVoice *voice, f32) {
+    if (reference_count == 0) {
+        attenuation = value;
+        return;
+    }
+    if (static_cast<u32>(voice->GetSurroundMode()) != 2) {
+        for (ReferenceNode *node = reference_head->next; node != reference_tail; node = node->next) {
+            if (node->reference.object != NULL && node->reference.object == voice->positional_references[1].object) {
+                attenuation = value;
+                return;
+            }
+        }
+    }
+    attenuation = 1.0f;
+}
+
+inline void NuSoundEffectRepeat::ProcessVoice(NuSoundVoice *voice, f32 frametime) {
+    if (static_cast<u32>(voice->GetState()) == 1) {
+        if (armed && repeats != 0) {
+            --repeats;
+            armed = false;
+            remaining = delay;
+            voice->DestroyHardwareVoice();
+            voice->CreateHardwareVoice();
+            voice->Play();
+            voice->Pause();
+        }
+    } else if (static_cast<u32>(voice->GetState()) == 2) {
+        if (!armed && repeats != 0) {
+            remaining -= frametime;
+            if (remaining <= 0.0f) voice->Resume();
+        }
+    } else {
+        armed = true;
+    }
+}
+
+NuSoundEffect *NuSoundSystem::CreateEffect(NuSoundEffect::EffectType type) {
+    NuSoundEffect *effect = NULL;
+    switch (static_cast<u32>(type)) {
+    case 0:
+        effect = static_cast<NuSoundEffect *>(_AllocMemory(MemoryDiscipline::SCRATCH, sizeof(NuSoundEffectAttenuation), 4,
+            "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound.cpp:1094"));
+        if (effect != NULL) new (effect) NuSoundEffectAttenuation();
+        break;
+    case 1:
+        effect = static_cast<NuSoundEffect *>(_AllocMemory(MemoryDiscipline::SCRATCH, sizeof(NuSoundEffectPitch), 4,
+            "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound.cpp:1100"));
+        if (effect != NULL) new (effect) NuSoundEffectPitch();
+        break;
+    case 2:
+        effect = static_cast<NuSoundEffect *>(_AllocMemory(MemoryDiscipline::SCRATCH, sizeof(NuSoundEffectFader), 4,
+            "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound.cpp:1106"));
+        if (effect != NULL) new (effect) NuSoundEffectFader();
+        break;
+    case 3:
+        effect = static_cast<NuSoundEffect *>(_AllocMemory(MemoryDiscipline::SCRATCH, sizeof(NuSoundEffectPitchRamp), 4,
+            "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound.cpp:1112"));
+        if (effect != NULL) new (effect) NuSoundEffectPitchRamp();
+        break;
+    case 4:
+        effect = static_cast<NuSoundEffect *>(_AllocMemory(MemoryDiscipline::SCRATCH, sizeof(NuSoundEffectRandomVolume), 4,
+            "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound.cpp:1118"));
+        if (effect != NULL) new (effect) NuSoundEffectRandomVolume();
+        break;
+    case 5:
+        effect = static_cast<NuSoundEffect *>(_AllocMemory(MemoryDiscipline::SCRATCH, sizeof(NuSoundEffectRandomPitch), 4,
+            "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound.cpp:1124"));
+        if (effect != NULL) new (effect) NuSoundEffectRandomPitch();
+        break;
+    case 8:
+        effect = static_cast<NuSoundEffect *>(_AllocMemory(MemoryDiscipline::SCRATCH, sizeof(NuSoundEffectDoppler), 4,
+            "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound.cpp:1130"));
+        if (effect != NULL) new (effect) NuSoundEffectDoppler();
+        break;
+    case 6:
+        effect = static_cast<NuSoundEffect *>(_AllocMemory(MemoryDiscipline::SCRATCH, sizeof(NuSoundEffectRepeat), 4,
+            "i:/SagaTouch-Android_9176564/nu2api.2013/nusound/nusound.cpp:1136"));
+        if (effect != NULL) new (effect) NuSoundEffectRepeat();
+        break;
+    default:
+        return NULL;
+    }
+    if (effect == NULL) return NULL;
+    effect->Initialise();
+    NuMemoryManager *old_manager = NuMemoryGet()->SetThreadMem(sScratchMemMgr);
+    NuEListNode<NuSoundEffect> *node = static_cast<NuEListNode<NuSoundEffect> *>(
+        NuMemoryGet()->GetThreadMem()->_BlockAlloc(sizeof(NuEListNode<NuSoundEffect>), 4, 1, "", 0));
+    if (node != NULL) {
+        node->prev = NULL;
+        node->next = NULL;
+        node->data = effect;
+    }
+    NuEListNode<NuSoundEffect> *previous = effect_tail->prev;
+    effect_tail->prev = node;
+    node->prev = previous;
+    previous->next = node;
+    node->next = effect_tail;
+    ++effect_count;
+    NuMemoryGet()->SetThreadMem(old_manager);
+    sAllocdMemory[0] += sizeof(NuEListNode<NuSoundEffect>);
+    return effect;
 }
 
 void NuSoundSystem::DefragmentSampleMemory() {
+    s_mmSample->Defragment(0);
 }
 
-void NuSoundSystem::DetermineFileType(NUFILETYPE) {
+NuSoundSystem::FileType NuSoundSystem::DetermineFileType(NUFILETYPE type) {
+    char extension[6] = {};
+    NuFileExtGetExt(extension, 6, type);
+    return DetermineFileType(extension);
 }
 
 void NuSoundSystem::Disable() {
+    sNumAvailableOutputDevices = 0;
 }
 
-void NuSoundSystem::FileTypeSupported(NuSoundSystem::FileType) {
+bool NuSoundSystem::FileTypeSupported(NuSoundSystem::FileType type) {
+    static const bool supported[6] = {true, false, false, false, false, true};
+    u32 index = static_cast<u32>(type);
+    return index <= 5 ? supported[index] : false;
 }
 
-void NuSoundSystem::Get() {
+NuSoundSystem *NuSoundSystem::Get() {
+    return s_staticInstance;
 }
 
-void NuSoundSystem::GetAllocdMemory(NuSoundSystem::MemoryDiscipline) {
+u32 NuSoundSystem::GetAllocdMemory(NuSoundSystem::MemoryDiscipline discipline) {
+    return sAllocdMemory[static_cast<i32>(discipline)];
 }
 
-void NuSoundSystem::GetBufferAlignment() {
+u32 NuSoundSystem::GetBufferAlignment() {
+    return 32;
 }
 
 i32 NuSoundSystem::GetClosestSupportedConfig(i32 config) {
@@ -443,63 +994,156 @@ i32 NuSoundSystem::GetClosestSupportedConfig(i32 config) {
 void NuSoundSystem::GetCrossfadeCurve(u32) const {
 }
 
-void NuSoundSystem::GetDefaultFileType(NuSoundSource::FeedType) {
+NuSoundSystem::FileType NuSoundSystem::GetDefaultFileType(NuSoundSource::FeedType feed) {
+    if (feed == NuSoundSource::FeedType::ZERO) return DetermineFileType(static_cast<NUFILETYPE>(6));
+    if (feed == NuSoundSource::FeedType::STREAMING) return DetermineFileType(static_cast<NUFILETYPE>(7));
+    return FileType::INVALID;
 }
 
 NuSoundRoutingTable *NuSoundSystem::GetDefaultRoutingTable() {
     return sDefaultRoutingTable;
 }
 
-void NuSoundSystem::GetGfxMemorySize() {
+u32 NuSoundSystem::GetGfxMemorySize() {
+    if (sGfxMemorySize != 0 && GetScratchMemorySize() < sGfxMemorySize) {
+        return sGfxMemorySize - GetScratchMemorySize();
+    }
+    return 0x600000;
 }
 
-void NuSoundSystem::GetLanguageString(bool) {
+const char *NuSoundSystem::GetLanguageString(bool) {
+    return "Eng";
 }
 
-void NuSoundSystem::GetLargestMemoryFragment(NuSoundSystem::MemoryDiscipline) {
+u32 NuSoundSystem::GetLargestMemoryFragment(NuSoundSystem::MemoryDiscipline discipline) {
+    if (discipline == MemoryDiscipline::SCRATCH) return sScratchMemMgr->CalculateLargestFragmentSize();
+    return 0;
 }
 
-void NuSoundSystem::GetListeners() {
+NuEList<NuSoundListener, DefaultElist> const *NuSoundSystem::GetListeners() {
+    return &listeners;
 }
 
 i32 NuSoundSystem::GetNumAvailableOutputDevices() {
     return sNumAvailableOutputDevices;
 }
 
-void NuSoundSystem::GetOldestVoice(NuSoundSample *, float &) {
+NuSoundVoice *NuSoundSystem::GetOldestVoice(NuSoundSample *sample, float &value) {
+    value = -1.0f;
+    NuSoundVoice *result = NULL;
+    NuSoundVoice *first = VoiceLinksFor(voice_head)->next;
+    VoiceLinks *node = first == NULL ? NULL : VoiceLinksFor(first);
+    VoiceLinks *end = voice_tail == NULL ? NULL : VoiceLinksFor(voice_tail);
+    while (node != end) {
+        NuSoundVoice *voice = reinterpret_cast<NuSoundVoice *>(reinterpret_cast<char *>(node) - offsetof(NuSoundVoice, field_0x24));
+        if (voice->GetState() == NuSoundVoice::PLAYSTATE_PLAYING &&
+            voice->sound_source->GetEncodedSource() == sample->GetEncodedSource()) {
+            float candidate = voice->GetPlaybackPositionSeconds();
+            if (value < 0.0f || candidate > value) {
+                result = voice;
+                value = candidate;
+            }
+        }
+        NuSoundVoice *next = node->next;
+        node = next == NULL ? NULL : VoiceLinksFor(next);
+    }
+    return result;
 }
 
-void NuSoundSystem::GetOutputChannelConfig() {
+i32 NuSoundSystem::GetOutputChannelConfig() {
+    return sOutputConfig;
 }
 
 void NuSoundSystem::GetPeakAllocdMemory(NuSoundSystem::MemoryDiscipline) {
 }
 
-void NuSoundSystem::GetPlatformString() {
+const char *NuSoundSystem::GetPlatformString() {
+    return "ANDROID";
 }
 
-void NuSoundSystem::GetQuietestVoice(NuSoundSample *, float &) {
+NuSoundVoice *NuSoundSystem::GetQuietestVoice(NuSoundSample *sample, float &value) {
+    value = -1.0f;
+    NuSoundVoice *result = NULL;
+    NuSoundVoice *first = VoiceLinksFor(voice_head)->next;
+    VoiceLinks *node = first == NULL ? NULL : VoiceLinksFor(first);
+    VoiceLinks *end = voice_tail == NULL ? NULL : VoiceLinksFor(voice_tail);
+    while (node != end) {
+        NuSoundVoice *voice = reinterpret_cast<NuSoundVoice *>(reinterpret_cast<char *>(node) - offsetof(NuSoundVoice, field_0x24));
+        if (voice->GetState() == NuSoundVoice::PLAYSTATE_PLAYING &&
+            voice->sound_source->GetEncodedSource() == sample->GetEncodedSource()) {
+            float candidate = voice->field67_0xa8 * voice->GetVolume();
+            if (value < 0.0f || candidate < value) {
+                result = voice;
+                value = candidate;
+            }
+        }
+        NuSoundVoice *next = node->next;
+        node = next == NULL ? NULL : VoiceLinksFor(next);
+    }
+    return result;
 }
 
-void NuSoundSystem::GetRoutingTable(char const *) {
+NuSoundRoutingTable *NuSoundSystem::GetRoutingTable(char const *name) {
+    for (NuSoundRoutingTable *table = routing_head->unknown_04;
+         table != routing_tail; table = table->unknown_04) {
+        if (NuStrICmp(table->GetName(), name) == 0) return table;
+    }
+    return NULL;
 }
 
-void NuSoundSystem::GetTotalMemory(NuSoundSystem::MemoryDiscipline) {
+u32 NuSoundSystem::GetTotalMemory(NuSoundSystem::MemoryDiscipline discipline) {
+    return sTotalMemory[static_cast<i32>(discipline)];
 }
 
-void NuSoundSystem::LoadSample(NuSoundSample *, void *, i32, NuSoundOutOfMemCallback *) {
+bool NuSoundSystem::LoadSample(NuSoundSample *sample, void *data, i32 size, NuSoundOutOfMemCallback *callback) {
+    NuSoundSample::LoadState state = sample->GetLoadState();
+    if (state == NuSoundSample::LoadState::NOT_LOADED) {
+        if (sample->Load(data, size, callback) != NuSoundSample::ErrorState::NONE) return false;
+        ++sample_load_count;
+        state = sample->GetLoadState();
+    }
+    return state == NuSoundSample::LoadState::LOADED;
 }
 
 void NuSoundSystem::PauseAllVoices() {
+    NuSoundVoice *first = VoiceLinksFor(voice_head)->next;
+    VoiceLinks *node = first == NULL ? NULL : VoiceLinksFor(first);
+    VoiceLinks *end = voice_tail == NULL ? NULL : VoiceLinksFor(voice_tail);
+    while (node != end) {
+        NuSoundVoice *voice = reinterpret_cast<NuSoundVoice *>(reinterpret_cast<char *>(node) - offsetof(NuSoundVoice, field_0x24));
+        voice->Pause();
+        NuSoundVoice *next = node->next;
+        node = next == NULL ? NULL : VoiceLinksFor(next);
+    }
 }
 
-void NuSoundSystem::PauseVoices(i32) {
+void NuSoundSystem::PauseVoices(i32 mask) {
+    NuSoundVoice *first = VoiceLinksFor(voice_head)->next;
+    VoiceLinks *node = first == NULL ? NULL : VoiceLinksFor(first);
+    VoiceLinks *end = voice_tail == NULL ? NULL : VoiceLinksFor(voice_tail);
+    while (node != end) {
+        NuSoundVoice *voice = reinterpret_cast<NuSoundVoice *>(reinterpret_cast<char *>(node) - offsetof(NuSoundVoice, field_0x24));
+        if ((voice->field131_0x148 & mask) != 0) voice->Pause();
+        NuSoundVoice *next = node->next;
+        node = next == NULL ? NULL : VoiceLinksFor(next);
+    }
 }
 
 void NuSoundSystem::ReAllocMemory(NuSoundSystem::MemoryDiscipline, u32, u32) {
 }
 
-void NuSoundSystem::ReleaseBus(NuSoundBus *) {
+void NuSoundSystem::ReleaseBus(NuSoundBus *bus) {
+    NuSoundBus *next = bus->next;
+    NuSoundBus *previous = bus->previous;
+    if (next != NULL || previous != NULL) {
+        --bus_count;
+        if (previous != NULL) previous->next = next;
+        if (next != NULL) next->previous = previous;
+        bus->next = NULL;
+        bus->previous = NULL;
+    }
+    bus->~NuSoundBus();
+    FreeMemory(MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(bus), 0);
 }
 
 void NuSoundSystem::ReleaseCrossfadeCurve(u32) {
@@ -510,31 +1154,139 @@ void NuSoundSystem::ReleaseDecoder(NuSoundDecoder *decoder) {
     FreeMemory(MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(decoder), 0);
 }
 
-void NuSoundSystem::ReleaseEffect(NuSoundEffect *) {
+void NuSoundSystem::ReleaseEffect(NuSoundEffect *effect) {
+    if (effect == NULL) {
+        return;
+    }
+
+    if (effect_count != 0) {
+        NuEListNode<NuSoundEffect> *last = effect_tail->prev;
+        NuEListNode<NuSoundEffect> *node = effect_head->next;
+        u32 removed = 0;
+        for (;;) {
+            if (node->data == effect) {
+                bool was_last = node == last;
+                NuEListNode<NuSoundEffect> *next = node->next;
+                if (node->prev != NULL) node->prev->next = next;
+                if (next != NULL) next->prev = node->prev;
+                NuMemoryGet()->GetThreadMem()->BlockFree(node, 0);
+                ++removed;
+                if (was_last) break;
+                node = next;
+            }
+            if (node == last) break;
+            // The original advances once more after removing a non-final
+            // node (0x319873..0x319824); retain that iterator behavior.
+            node = node->next;
+        }
+        effect_count -= removed;
+    }
+
+    sAllocdMemory[static_cast<i32>(MemoryDiscipline::SCRATCH)] -= sizeof(NuEListNode<NuSoundEffect>);
+    effect->Shutdown();
+    effect->~NuSoundEffect();
+    FreeMemory(MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(effect), 0);
 }
 
-void NuSoundSystem::ReleaseSample(NuSoundSample *) {
+void NuSoundSystem::ReleaseSample(NuSoundSample *sample) {
+    NuSoundSample *next = sample->list_next;
+    NuSoundSample *previous = sample->list_previous;
+    if (next != NULL || previous != NULL) {
+        --sample_list_count;
+        if (previous != NULL) previous->list_next = next;
+        if (next != NULL) next->list_previous = previous;
+        sample->list_next = NULL;
+        sample->list_previous = NULL;
+    }
+    sample->~NuSoundSample();
+    FreeMemory(MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(sample), 0);
 }
 
-void NuSoundSystem::RemoveListener(NuSoundListener *) {
+void NuSoundSystem::RemoveListener(NuSoundListener *listener) {
+    if (listener->next != NULL || listener->prev != NULL) {
+        --listeners.length;
+        NuSoundListener *next = listener->next;
+        NuSoundListener *previous = listener->prev;
+        if (previous != NULL) previous->next = next;
+        if (next != NULL) next->prev = previous;
+        listener->next = NULL;
+        listener->prev = NULL;
+    }
 }
 
 void NuSoundSystem::ResumeAllVoices() {
+    NuSoundVoice *first = VoiceLinksFor(voice_head)->next;
+    VoiceLinks *node = first == NULL ? NULL : VoiceLinksFor(first);
+    VoiceLinks *end = voice_tail == NULL ? NULL : VoiceLinksFor(voice_tail);
+    while (node != end) {
+        NuSoundVoice *voice = reinterpret_cast<NuSoundVoice *>(reinterpret_cast<char *>(node) - offsetof(NuSoundVoice, field_0x24));
+        voice->Resume();
+        NuSoundVoice *next = node->next;
+        node = next == NULL ? NULL : VoiceLinksFor(next);
+    }
 }
 
-void NuSoundSystem::ResumeVoices(i32) {
+void NuSoundSystem::ResumeVoices(i32 mask) {
+    NuSoundVoice *first = VoiceLinksFor(voice_head)->next;
+    VoiceLinks *node = first == NULL ? NULL : VoiceLinksFor(first);
+    VoiceLinks *end = voice_tail == NULL ? NULL : VoiceLinksFor(voice_tail);
+    while (node != end) {
+        NuSoundVoice *voice = reinterpret_cast<NuSoundVoice *>(reinterpret_cast<char *>(node) - offsetof(NuSoundVoice, field_0x24));
+        if ((voice->field131_0x148 & mask) != 0) voice->Resume();
+        NuSoundVoice *next = node->next;
+        node = next == NULL ? NULL : VoiceLinksFor(next);
+    }
 }
 
-void NuSoundSystem::SetDefaultRoutingTable(NuSoundRoutingTable *) {
+void NuSoundSystem::SetDefaultRoutingTable(NuSoundRoutingTable *table) {
+    sDefaultRoutingTable = table;
 }
 
-void NuSoundSystem::SetGfxMemorySize(u32) {
+void NuSoundSystem::SetGfxMemorySize(u32 size) {
+    sGfxMemorySize = size;
 }
 
 void NuSoundSystem::SetMainThreadID(NuThread *) {
 }
 
 void NuSoundSystem::Shutdown() {
+    NuSoundVoice *voice = voice_head->field_0x28;
+    while (voice != voice_tail) {
+        NuSoundVoice *next = voice->field_0x28;
+        voice->Stop(false);
+        ReleaseVoice(voice);
+        voice = next;
+    }
+    UnloadAllSamples();
+    NuSoundSample *sample = sample_head->list_next;
+    while (sample != sample_tail) {
+        NuSoundSample *next = sample->list_next;
+        sample->~NuSoundSample();
+        FreeMemory(MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(sample), 0);
+        // The reference advances through the saved next node once more.
+        sample = next->list_next;
+    }
+    NuSoundBus *bus = bus_head->next;
+    while (bus != bus_tail) {
+        NuSoundBus *next = bus->next;
+        ReleaseBus(bus);
+        bus = next->next;
+    }
+    FreeMemory(MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(samples), 0);
+    samples = NULL;
+    if (s_mmSample != NULL) {
+        s_mmSample->~NuSoundMemoryManager();
+        NuMemoryGet()->GetThreadMem()->BlockFree(s_mmSample, 0);
+    }
+    if (s_mmDecoder != NULL) {
+        s_mmDecoder->~NuSoundMemoryManager();
+        NuMemoryGet()->GetThreadMem()->BlockFree(s_mmDecoder, 0);
+    }
+    NuMemoryGet()->DestroyMemoryManager(sScratchMemMgr);
+    NuMemoryGet()->GetThreadMem()->BlockFree(sDecoderMemory, 0);
+    NuMemoryGet()->GetThreadMem()->BlockFree(sSampleMemory, 0);
+    NuMemoryGet()->GetThreadMem()->BlockFree(sScratchMemory, 0);
+    ShutdownAudioDevice();
 }
 
 bool NuSoundSystem::SourceRequiresDecoder(NuSoundSource *source) {
@@ -566,9 +1318,16 @@ void NuSoundSystem::StopVoices(i32) {
 }
 
 void NuSoundSystem::UnloadAllSamples() {
+    for (NuSoundSample *sample = sample_head->list_next; sample != sample_tail; sample = sample->list_next) {
+        if (sample->GetLoadState() == NuSoundSample::LoadState::LOADED) UnloadSample(sample);
+    }
 }
 
-void NuSoundSystem::UnloadSample(NuSoundSample *) {
+bool NuSoundSystem::UnloadSample(NuSoundSample *sample) {
+    if (sample == NULL || sample->field_0x18 != 0) return false;
+    if (sample->GetLoadState() == NuSoundSample::LoadState::NOT_LOADED) return false;
+    sample->Unload();
+    return true;
 }
 
 void NuSoundSystem::Update(f32 frametime) {
@@ -581,16 +1340,20 @@ void NuSoundSystem::Update(f32 frametime) {
 
     pthread_mutex_lock(&this->mutex);
 
-    // Pass 1: drive every platform voice's device state.
-    for (NuSoundVoice *voice = this->voice_list_end; voice != NULL; voice = voice->field_0x24) {
-        voice->UpdateHardwareVoice(frametime);
+    // Original first pass: process the system's registered effects.
+    NuEListNode<NuSoundEffect> *effects_end = effect_tail;
+    for (NuEListNode<NuSoundEffect> *node = effect_head->next; node != effects_end; node = node->next) {
+        node->data->Process(frametime);
     }
 
     // Pass 2: update the engine-side mix of every playing voice; stopped
     // auto-delete voices are released.
-    NuSoundVoice *voice = this->voice_list_start;
-    while (voice != NULL) {
-        NuSoundVoice *next = voice->field_0x28;
+    VoiceLinks *node = VoiceLinksFor(voice_head->field_0x28);
+    VoiceLinks *end = VoiceLinksFor(voice_tail);
+    while (node != end) {
+        NuSoundVoice *voice = reinterpret_cast<NuSoundVoice *>(
+            reinterpret_cast<char *>(node) - offsetof(NuSoundVoice, field_0x24));
+        VoiceLinks *next = VoiceLinksFor(node->next);
 
         NuSoundVoice::PlayState state = voice->GetState();
         if (state == NuSoundVoice::PLAYSTATE_PLAYING) {
@@ -601,7 +1364,7 @@ void NuSoundSystem::Update(f32 frametime) {
             this->ReleaseVoice(voice);
         }
 
-        voice = next;
+        node = next;
     }
 
     pthread_mutex_unlock(&this->mutex);
@@ -611,48 +1374,45 @@ void NuSoundSystem::dBToAmplitude(float) {
 }
 
 NuSoundVoice *NuSoundSystem::CreateVoice(NuSoundSource *source, bool loop) {
-    NuSoundVoice *voice;
+    NuSoundVoice *voice = NULL;
 
-    if (this->SourceRequiresDecoder(source)) {
-        // Encoded sources (OGG) play through a decoder that owns a decode
-        // thread; the decoder becomes the voice's source.
-        NuSoundDecoder *decoder = this->CreateDecoder(source);
-        decoder->OpenStream(loop);
-        if (decoder->IsStreamOpen() == false) {
-            this->ReleaseDecoder(decoder);
-            return NULL;
-        }
-        NuSoundStreamDesc *desc = decoder->GetStreamDesc();
-        NuSoundVoiceFactory *factory = this->factory_list.GetFactory(desc->GetDecodedDataFormat());
-        voice = factory->CreateVoice(decoder, loop);
-        if (voice == NULL) {
-            decoder->CloseStream();
-            this->ReleaseDecoder(decoder);
-            return NULL;
+    if (!SourceRequiresDecoder(source)) {
+        if (source->IsStreamOpen()) {
+            NuSoundStreamDesc *desc = source->GetStreamDesc();
+            NuSoundVoiceFactory *factory = factory_list.GetFactory(desc->GetDecodedDataFormat());
+            voice = factory->CreateVoice(source, loop);
         }
     } else {
-        if (source->IsStreamOpen() == false) {
-            return NULL;
-        }
-        NuSoundStreamDesc *desc = source->GetStreamDesc();
-        NuSoundVoiceFactory *factory = this->factory_list.GetFactory(desc->GetDecodedDataFormat());
-        voice = factory->CreateVoice(source, loop);
-        if (voice == NULL) {
-            return NULL;
+        source = CreateDecoder(source);
+        source->OpenStream(loop);
+        if (source->IsStreamOpen()) {
+            NuSoundStreamDesc *desc = source->GetStreamDesc();
+            NuSoundVoiceFactory *factory = factory_list.GetFactory(desc->GetDecodedDataFormat());
+            voice = factory->CreateVoice(source, loop);
+            if (voice == NULL) {
+                source->CloseStream();
+                ReleaseDecoder(static_cast<NuSoundDecoder *>(source));
+            }
+        } else {
+            ReleaseDecoder(static_cast<NuSoundDecoder *>(source));
         }
     }
+
+    if (voice == NULL) return NULL;
 
     // Append the voice to the system's voice list.
     pthread_mutex_lock(&this->mutex);
-    voice->field_0x24 = this->voice_list_end;
-    voice->field_0x28 = NULL;
-    if (this->voice_list_end != NULL) {
-        this->voice_list_end->field_0x28 = voice;
-    } else {
-        this->voice_list_start = voice;
-    }
-    this->voice_list_end = voice;
+    pthread_mutex_lock(&NuSoundWeakPtrListNode::sPtrAccessLock.mutex);
+    VoiceLinks *tail_links = VoiceLinksFor(voice_tail);
+    NuSoundVoice *previous = tail_links->prev;
+    VoiceLinks *previous_links = VoiceLinksFor(previous);
+    tail_links->prev = voice;
+    voice->field_0x24 = previous;
+    previous_links->next = voice;
+    voice->field_0x28 = reinterpret_cast<NuSoundVoice *>(
+        reinterpret_cast<char *>(tail_links) - offsetof(NuSoundVoice, field_0x24));
     this->voice_count++;
+    pthread_mutex_unlock(&NuSoundWeakPtrListNode::sPtrAccessLock.mutex);
     pthread_mutex_unlock(&this->mutex);
 
     return voice;
@@ -662,12 +1422,13 @@ void NuSoundSystem::ReleaseVoice(NuSoundVoice *voice) {
     pthread_mutex_lock(&this->mutex);
 
     // Detach effects (releasing the ones the system owns).
-    for (NuEListNode<NuSoundEffect> *node = voice->effects_start; node != NULL;) {
-        NuSoundEffect *effect = node->data;
-        NuEListNode<NuSoundEffect> *next = node->next;
+    for (NuListNodeBase *node = voice->effects.Head(); node != voice->effects.Tail();) {
+        NuSoundEffect *effect = static_cast<NuListNode<NuSoundEffect *> *>(node)->value;
+        NuListNodeBase *next = node->GetNext();
         voice->RemoveEffect(effect);
-        // effect->field_0x24 marks system-owned effects; release them.
-        this->ReleaseEffect(effect);
+        if (effect->system_owned) {
+            this->ReleaseEffect(effect);
+        }
         node = next;
     }
 
@@ -678,26 +1439,24 @@ void NuSoundSystem::ReleaseVoice(NuSoundVoice *voice) {
     }
 
     // Unlink from the voice list.
-    if (voice->field_0x24 != NULL) {
-        voice->field_0x24->field_0x28 = voice->field_0x28;
-    } else {
-        this->voice_list_start = voice->field_0x28;
-    }
-    if (voice->field_0x28 != NULL) {
-        voice->field_0x28->field_0x24 = voice->field_0x24;
-    } else {
-        this->voice_list_end = voice->field_0x24;
-    }
-    voice->field_0x24 = NULL;
-    voice->field_0x28 = NULL;
-    if (this->voice_count > 0) {
+    pthread_mutex_lock(&NuSoundWeakPtrListNode::sPtrAccessLock.mutex);
+    if (voice->field_0x28 != NULL || voice->field_0x24 != NULL) {
         this->voice_count--;
+        if (voice->field_0x24 != NULL) {
+            VoiceLinksFor(voice->field_0x24)->next = voice->field_0x28;
+        }
+        if (voice->field_0x28 != NULL) {
+            VoiceLinksFor(voice->field_0x28)->prev = voice->field_0x24;
+        }
+        voice->field_0x28 = NULL;
+        voice->field_0x24 = NULL;
     }
 
     // libTTapp.so 0x31b394: run the voice's complete destructor (vtable slot
     // 0, no free), then hand the block back through FreeMemory(SCRATCH).
     voice->~NuSoundVoice();
     NuSoundSystem::FreeMemory(NuSoundSystem::MemoryDiscipline::SCRATCH, (usize)voice, 0);
+    pthread_mutex_unlock(&NuSoundWeakPtrListNode::sPtrAccessLock.mutex);
 
     if (decoder != NULL) {
         decoder->CloseStream();
@@ -711,4 +1470,35 @@ void NuSound3ExitThreads() {
 }
 
 void NuSound_GetAllocdSampleMemory() {
+}
+
+NuSoundListener *NuSoundSystem::GetNearestRealListener(NuEList<NuSoundListener, DefaultElist> const &listeners, VuVec const &position) {
+    NuSoundListener *nearest = NULL;
+    f32 nearest_distance = FLT_MAX;
+    for (NuSoundListener *listener = listeners.head->next; listener != listeners.tail; listener = listener->next) {
+        if (!listener->IsEnabled() || !(listener->GetSensitivity() > 0.0f)) continue;
+        f32 distance = listener->GetHeadDistance(position);
+        distance /= listener->GetSensitivity();
+        if (distance < nearest_distance || nearest == NULL) {
+            nearest_distance = distance;
+            nearest = listener;
+        }
+    }
+    return nearest;
+}
+
+NuSoundListener *NuSoundSystem::GetNearestFocusListener(NuEList<NuSoundListener, DefaultElist> const &listeners, VuVec const &position,
+                                                        float &nearest_distance) {
+    nearest_distance = FLT_MAX;
+    NuSoundListener *nearest = NULL;
+    for (NuSoundListener *listener = listeners.head->next; listener != listeners.tail; listener = listener->next) {
+        if (!listener->IsEnabled() || !(listener->GetSensitivity() > 0.0f)) continue;
+        f32 distance = listener->GetAttenuationDistance(position);
+        distance /= listener->GetSensitivity();
+        if (distance < nearest_distance || nearest == NULL) {
+            nearest_distance = distance;
+            nearest = listener;
+        }
+    }
+    return nearest;
 }

--- a/src/nu2api/nusound/nusound_system.cpp
+++ b/src/nu2api/nusound/nusound_system.cpp
@@ -1,3 +1,4 @@
+#include "decomp_assert.h"
 #include "nu2api/nusound/nusound_system.hpp"
 #include "nu2api/nusound/nusound_android.hpp"
 
@@ -16,17 +17,18 @@
 #include "nu2api/nucore/numemory.h"
 
 #include <cstdio>
+#include <cfloat>
 #include <cstring>
 #include <new>
 
-static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectAttenuation) == 0x48, "attenuation effect ABI");
-static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectPitch) == 0x44, "pitch effect ABI");
-static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectRandomVolume) == 0x44, "random volume effect ABI");
-static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectRandomPitch) == 0x44, "random pitch effect ABI");
-static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectRepeat) == 0x54, "repeat effect ABI");
-static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectDoppler) == 0x50, "Doppler effect ABI");
-static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectFader) == 0x6c, "fader effect ABI");
-static_assert(sizeof(void *) != 4 || sizeof(NuSoundEffectPitchRamp) == 0x54, "pitch ramp effect ABI");
+DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundEffectAttenuation) == 0x48, "attenuation effect ABI");
+DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundEffectPitch) == 0x44, "pitch effect ABI");
+DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundEffectRandomVolume) == 0x44, "random volume effect ABI");
+DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundEffectRandomPitch) == 0x44, "random pitch effect ABI");
+DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundEffectRepeat) == 0x54, "repeat effect ABI");
+DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundEffectDoppler) == 0x50, "Doppler effect ABI");
+DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundEffectFader) == 0x6c, "fader effect ABI");
+DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundEffectPitchRamp) == 0x54, "pitch ramp effect ABI");
 
 // Sentinels contain only the intrusive links, with the same adjusted object
 // pointers used by the original NuEList<NuSoundVoice>.
@@ -35,18 +37,18 @@ static NuSoundSystem::VoiceLinks *VoiceLinksFor(NuSoundVoice *voice) {
         reinterpret_cast<char *>(voice) + offsetof(NuSoundVoice, field_0x24)) : NULL;
 }
 
-static_assert(sizeof(void *) != 4 || offsetof(NuSoundVoice, field_0x24) == 0x24,
+DECOMP_ASSERT(sizeof(void *) != 4 || offsetof(NuSoundVoice, field_0x24) == 0x24,
               "voice intrusive links must retain their Android offset");
 #if defined(__arm__)
-static_assert(offsetof(NuSoundSystem, voice_head) == 0x78, "ARM voice list head offset");
-static_assert(offsetof(NuSoundSystem, effect_head) == 0x94, "ARM effect list head offset");
+DECOMP_ASSERT(offsetof(NuSoundSystem, voice_head) == 0x78, "ARM voice list head offset");
+DECOMP_ASSERT(offsetof(NuSoundSystem, effect_head) == 0x94, "ARM effect list head offset");
 #else
-static_assert(sizeof(void *) != 4 || offsetof(NuSoundSystem, voice_head) == 0x74,
+DECOMP_ASSERT(sizeof(void *) != 4 || offsetof(NuSoundSystem, voice_head) == 0x74,
               "voice list head must retain its Android offset");
-static_assert(sizeof(void *) != 4 || offsetof(NuSoundSystem, effect_head) == 0x90,
+DECOMP_ASSERT(sizeof(void *) != 4 || offsetof(NuSoundSystem, effect_head) == 0x90,
               "effect list head must retain its Android offset");
 #endif
-static_assert(sizeof(void *) != 4 || offsetof(NuSoundEffect, system_owned) == 0x24,
+DECOMP_ASSERT(sizeof(void *) != 4 || offsetof(NuSoundEffect, system_owned) == 0x24,
               "effect ownership flag must retain its Android offset");
 
 NuSoundBus *NuSoundSystem::sMasterBus = NULL;

--- a/src/nu2api/nusound/nusound_system.hpp
+++ b/src/nu2api/nusound/nusound_system.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "decomp_assert.h"
 #include "nu2api/nucore/NuMemoryManager.h"
 #include "nu2api/nucore/common.h"
 #include "nu2api/nucore/nuelist.hpp"
@@ -689,22 +690,24 @@ class NuSoundHandle {
     void operator==(NuSoundHandle const &other);
 }; // namespace NuSoundSystem
 
+// Binary layouts below describe Android. Host/WASM builds use their own ABI,
+// including native mutex sizes and 64-bit member alignment.
 #if defined(__arm__)
 // Original ARM constructors: clock 0x2f2af8, system 0x2ee5f4;
 // InitAudioDevice 0x2fce38 passes this+0x110 to slCreateEngine.
-static_assert(sizeof(NuSoundClock) == 0x30, "ARM sound clock layout");
-static_assert(__builtin_offsetof(NuSoundSystem, factory_list) == 0x5c, "ARM voice factory offset");
-static_assert(__builtin_offsetof(NuSoundSystem, initialised) == 0x10c, "ARM audio update gate offset");
-static_assert(__builtin_offsetof(NuSoundSystem, engine_object) == 0x110, "ARM OpenSL engine handle offset");
+DECOMP_ASSERT(sizeof(NuSoundClock) == 0x30, "ARM sound clock layout");
+DECOMP_ASSERT(__builtin_offsetof(NuSoundSystem, factory_list) == 0x5c, "ARM voice factory offset");
+DECOMP_ASSERT(__builtin_offsetof(NuSoundSystem, initialised) == 0x10c, "ARM audio update gate offset");
+DECOMP_ASSERT(__builtin_offsetof(NuSoundSystem, engine_object) == 0x110, "ARM OpenSL engine handle offset");
 #else
-static_assert(sizeof(void *) != 4 || sizeof(NuSoundClock) == 0x2c, "Android sound clock layout");
-static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, factory_list) == 0x58, "Android voice factory offset");
-static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, initialised) == 0x108, "Android audio update gate offset");
-static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, engine_object) == 0x10c,
+DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundClock) == 0x2c, "Android sound clock layout");
+DECOMP_ASSERT(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, factory_list) == 0x58, "Android voice factory offset");
+DECOMP_ASSERT(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, initialised) == 0x108, "Android audio update gate offset");
+DECOMP_ASSERT(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, engine_object) == 0x10c,
               "Android OpenSL engine handle offset");
 #endif
-static_assert(sizeof(void *) != 4 || sizeof(NuSoundVoiceFactoryList) == 0xc, "Android voice factory list layout");
-static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, clock) == 8, "Android sound clock offset");
+DECOMP_ASSERT(sizeof(void *) != 4 || sizeof(NuSoundVoiceFactoryList) == 0xc, "Android voice factory list layout");
+DECOMP_ASSERT(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, clock) == 8, "Android sound clock offset");
 
 class NuSoundOutOfMemCallback {
   public:

--- a/src/nu2api/nusound/nusound_system.hpp
+++ b/src/nu2api/nusound/nusound_system.hpp
@@ -12,6 +12,7 @@
 #include "nu2api/nufile/nufile.h"
 
 #include "decomp.h"
+#include <string.h>
 
 struct VuMtx;
 
@@ -25,15 +26,65 @@ class NuSoundVoice;
 class NuThread;
 class NuSoundOutOfMemCallback;
 
+class NuSoundMemory {
+  public:
+    template <typename T> static void PushNuListNode(NuList<T> &list, const T &value);
+};
+
 class NuSoundEffect {
   public:
-    struct EffectType {};
+    enum class EffectType : u32 {};
     enum class EffectProcessStage : u32 {
         ZERO = 0,
         ONE = 1,
     };
-    virtual ~NuSoundEffect();
     virtual bool Initialise();
+    virtual void Shutdown() {}
+    virtual void Enable() { enabled = true; }
+    virtual void Disable() { enabled = false; }
+    virtual ~NuSoundEffect();
+    virtual bool AttachVoice(NuSoundVoice *) { return true; }
+    virtual void DetachVoice(NuSoundVoice *) {}
+    virtual void ProcessVoice(NuSoundVoice *, f32) {}
+    virtual bool AttachBus(NuSoundBus *) { return false; }
+    virtual void DetachBus(NuSoundBus *) {}
+    virtual void ProcessBus(NuSoundBus *, f32) {}
+    virtual void Process(f32) {}
+
+    struct ManagedReference;
+    struct ReferenceTarget { void *unknown_00; void *unknown_04; ManagedReference *references; };
+    struct ManagedReference {
+        ReferenceTarget *object;
+        ManagedReference *next;
+        ManagedReference *previous;
+    };
+    ManagedReference *references;
+    u32 unknown_08[4];
+    bool enabled;
+    u8 unknown_19[3];
+    f32 attenuation;
+    f32 pitch_scale;
+    bool system_owned;
+    u8 unknown_25[3];
+    struct ReferenceNode {
+        ReferenceNode *prev;
+        ReferenceNode *next;
+        ManagedReference reference;
+    };
+    struct ReferenceLinks { ReferenceNode *prev; ReferenceNode *next; } reference_start, reference_end;
+    ReferenceNode *reference_head;
+    ReferenceNode *reference_tail;
+    u32 reference_count;
+
+    NuSoundEffect() : references(NULL) {
+        reference_head = reinterpret_cast<ReferenceNode *>(&reference_start);
+        reference_tail = reinterpret_cast<ReferenceNode *>(&reference_end);
+        reference_start.prev = NULL;
+        reference_start.next = reference_tail;
+        reference_end.prev = reference_head;
+        reference_end.next = NULL;
+        reference_count = 0;
+    }
 };
 
 // --- subsystem classes without a dedicated header (definitions live in their
@@ -41,7 +92,24 @@ class NuSoundEffect {
 
 class NuSoundClock {
   public:
-    struct Callback {};
+    struct Callback {
+        virtual void OnCallback(u64 elapsed, u64 frequency) {}
+        Callback *prev;
+        Callback *next;
+    };
+
+  private:
+    struct Links { Callback *prev; Callback *next; } start, end;
+    Callback *head;
+    Callback *tail;
+    u32 callback_count;
+    u64 frequency;
+    u64 last_ticks;
+    static Links *GetLinks(Callback *callback) {
+        return reinterpret_cast<Links *>(reinterpret_cast<char *>(callback) + sizeof(void *));
+    }
+
+  public:
 
     NuSoundClock();
     ~NuSoundClock();
@@ -49,40 +117,74 @@ class NuSoundClock {
     void AddCallback(Callback *callback);
     void RemoveCallback(Callback *callback);
     void HandleCallbacks();
-    void GetClockFrequency() const;
-    void GetTicks() const;
+    u64 GetClockFrequency() const;
+    u64 GetTicks() const;
 };
 
 class NuSoundListener {
   public:
+    NuSoundListener *prev;
+    NuSoundListener *next;
+    NuSoundEffect::ManagedReference *references;
+    const VuMtx *head_matrix;
+    const VuVec *focus_position;
+    const VuVec *screen_position;
+    VuVec velocity;
+    bool enabled;
+    bool focus_enabled;
+    f32 sensitivity;
+    i32 output_devices;
     NuSoundListener();
     ~NuSoundListener();
 
     void Enable();
     void Disable();
-    void IsEnabled() const;
+    bool IsEnabled() const;
     void SetHeadMatrix(const VuMtx *mtx);
-    void GetHeadMatrix() const;
+    const VuMtx * GetHeadMatrix() const;
     void SetFocusPosition(const VuVec *position);
-    void GetFocusPosition() const;
+    const VuVec *GetFocusPosition() const;
     void EnableFocusPosition();
     void DisableFocusPosition();
-    void IsFocusPositionEnabled() const;
+    bool IsFocusPositionEnabled() const;
     void Set2DScreenPosition(const VuVec *position);
-    void Get2DScreenPosition() const;
+    const VuVec * Get2DScreenPosition() const;
     void SetVelocity(const VuVec &velocity);
-    void GetVelocity() const;
+    const VuVec * GetVelocity() const;
     void SetSensitivity(f32 sensitivity);
-    void GetSensitivity() const;
+    f32 GetSensitivity() const;
     void SetOutputDevices(i32 devices);
-    void GetOutputDevices() const;
-    void GetAttenuationPosition(const VuVec &position) const;
-    void GetAttenuationDistance(const VuVec &position) const;
-    void GetHeadDistance(const VuVec &position) const;
+    i32 GetOutputDevices() const;
+    const VuVec *GetAttenuationPosition(const VuVec &position) const;
+    f32 GetAttenuationDistance(const VuVec &position) const;
+    f32 GetHeadDistance(const VuVec &position) const;
 };
 
-class NuSoundEffectDoppler {
+template <> class NuEList<NuSoundListener, DefaultElist> {
   public:
+    struct Links { NuSoundListener *prev; NuSoundListener *next; };
+    Links start;
+    Links end;
+    NuSoundListener *head;
+    NuSoundListener *tail;
+    u32 length;
+
+    NuEList() {
+        head = reinterpret_cast<NuSoundListener *>(&start);
+        tail = reinterpret_cast<NuSoundListener *>(&end);
+        start.prev = NULL;
+        start.next = tail;
+        end.prev = head;
+        end.next = NULL;
+        length = 0;
+    }
+};
+
+class NuSoundEffectDoppler : public NuSoundEffect {
+  public:
+    f32 speed_of_sound;
+    f32 velocity_scale;
+    const NuEList<NuSoundListener, DefaultElist> *listeners;
     NuSoundEffectDoppler();
     virtual ~NuSoundEffectDoppler();
 
@@ -90,16 +192,27 @@ class NuSoundEffectDoppler {
     void SetParameters(f32 a, f32 b, const NuEList<NuSoundListener, DefaultElist> *listeners);
 };
 
-class NuSoundEffectFader {
+class NuSoundEffectFader : public NuSoundEffect {
   public:
-    struct Curve {};
-    struct FinishState {};
+    struct Curve { u32 mode; void *data; };
+    enum class FinishState : u32 {};
+    struct FinishCallback { virtual void OnFinish() = 0; };
+
+    Curve curve;
+    f32 unknown_4c;
+    f32 unknown_50;
+    f32 unknown_54;
+    f32 unknown_58;
+    u32 unknown_5c;
+    u32 unknown_60;
+    FinishCallback *unknown_64;
+    bool unknown_68;
 
     NuSoundEffectFader();
     virtual ~NuSoundEffectFader();
 
-    void AttachBus(NuSoundBus *bus);
-    void AttachVoice(NuSoundVoice *voice);
+    bool AttachBus(NuSoundBus *bus);
+    bool AttachVoice(NuSoundVoice *voice);
     void Enable();
     void Disable();
     void Process(f32 frametime);
@@ -109,25 +222,82 @@ class NuSoundEffectFader {
     void SetParameters(f32 a, f32 b, FinishState state);
 };
 
-class NuSoundEffectPitchRamp {
+class NuSoundEffectPitchRamp : public NuSoundEffect {
   public:
-    struct FinishState {};
+    enum class FinishState : u32 {};
+    f32 field_44;
+    f32 field_48;
+    bool field_4c;
+    u32 field_50;
 
     NuSoundEffectPitchRamp();
     virtual ~NuSoundEffectPitchRamp();
 
-    void AttachVoice(NuSoundVoice *voice);
+    bool AttachVoice(NuSoundVoice *voice) override;
     void Process(f32 frametime);
     void ProcessVoice(NuSoundVoice *voice, f32 frametime);
     void SetParameters(f32 a, f32 b, FinishState state);
+};
+
+class NuSoundEffectAttenuation : public NuSoundEffect {
+  public:
+    f32 value;
+    NuSoundEffectAttenuation() {
+        unknown_08[0] = 0; unknown_08[1] = 0; unknown_08[2] = 1; unknown_08[3] = 0;
+        attenuation = 1.0f; pitch_scale = 1.0f; system_owned = false; enabled = true;
+        value = 1.0f;
+    }
+    ~NuSoundEffectAttenuation() {}
+    bool AttachBus(NuSoundBus *) { return true; }
+    void ProcessVoice(NuSoundVoice *, f32);
+};
+
+class NuSoundEffectPitch : public NuSoundEffect {
+  public:
+    NuSoundEffectPitch() {
+        unknown_08[0] = 2; unknown_08[1] = 0; unknown_08[2] = 1; unknown_08[3] = 1;
+        attenuation = 1.0f; pitch_scale = 1.0f; system_owned = false; enabled = true;
+    }
+    ~NuSoundEffectPitch() {}
+};
+
+class NuSoundEffectRandomVolume : public NuSoundEffect {
+  public:
+    NuSoundEffectRandomVolume() {
+        unknown_08[0] = 2; unknown_08[1] = 0; unknown_08[2] = 1; unknown_08[3] = 4;
+        attenuation = 1.0f; pitch_scale = 1.0f; system_owned = false; enabled = true;
+    }
+    ~NuSoundEffectRandomVolume() {}
+};
+
+class NuSoundEffectRandomPitch : public NuSoundEffect {
+  public:
+    NuSoundEffectRandomPitch() {
+        unknown_08[0] = 2; unknown_08[1] = 0; unknown_08[2] = 1; unknown_08[3] = 5;
+        attenuation = 1.0f; pitch_scale = 1.0f; system_owned = false; enabled = true;
+    }
+    ~NuSoundEffectRandomPitch() {}
+};
+
+class NuSoundEffectRepeat : public NuSoundEffect {
+  public:
+    f32 delay;
+    u32 repeats;
+    bool armed;
+    f32 remaining;
+    NuSoundEffectRepeat() {
+        unknown_08[0] = 1; unknown_08[1] = 0; unknown_08[2] = 1; unknown_08[3] = 6;
+        attenuation = 1.0f; pitch_scale = 1.0f; system_owned = false; enabled = true;
+        repeats = 1; delay = 0.0f; armed = true;
+    }
+    ~NuSoundEffectRepeat() {}
+    void ProcessVoice(NuSoundVoice *, f32);
 };
 
 // Voice factories (nu2api.2013/nusound/nusound.cpp): one factory per decoded
 // data format, indexed by NuSoundStreamDesc::DataFormat.
 class NuSoundVoiceFactory {
   public:
-    virtual ~NuSoundVoiceFactory() {
-    }
     virtual NuSoundVoice *CreateVoice(NuSoundSource *source, bool loop) = 0;
 };
 
@@ -138,12 +308,48 @@ class NuSoundVoiceFactoryAndroid_PCM : public NuSoundVoiceFactory {
 
 class NuSoundVoiceFactoryList {
   public:
-    NuSoundVoiceFactory *factories[16];
+    NuSoundVoiceFactory **factories;
+    u32 capacity;
+    u32 count;
 
   public:
     NuSoundVoiceFactoryList();
+    ~NuSoundVoiceFactoryList() {
+        count = 0;
+        if (factories != NULL) {
+            NuMemoryGet()->GetThreadMem()->BlockFree(factories, 0);
+            capacity = 0;
+            factories = NULL;
+        }
+    }
     void RegisterFactory(NuSoundVoiceFactory *factory, NuSoundStreamDesc::DataFormat format);
     NuSoundVoiceFactory *GetFactory(NuSoundStreamDesc::DataFormat format);
+};
+
+class NuSoundSystemCallbacks : public NuMemoryManager::IEventHandler {
+  public:
+    void *scratch;
+    u32 scratch_size;
+
+    bool AllocatePage(NuMemoryManager *manager, u32 size, u32 unknown) override {
+        if (scratch == NULL) return false;
+        manager->AddPage(scratch, scratch_size, false);
+        scratch = NULL;
+        return true;
+    }
+    bool ReleasePage(NuMemoryManager *manager, void *ptr, u32 unknown) override {
+        return false;
+    }
+    virtual bool OpenDump(NuMemoryManager *manager, const char *filename, u32 &id) {
+        id = NuFileOpen(const_cast<char *>(filename), NUFILE_WRITE);
+        return id != 0;
+    }
+    virtual void CloseDump(NuMemoryManager *manager, u32 id) {
+        NuFileClose(id);
+    }
+    virtual void Dump(NuMemoryManager *manager, u32 id, const char *message) {
+        NuFileWrite(id, const_cast<char *>(message), strlen(message));
+    }
 };
 
 class NuSoundSystem {
@@ -154,13 +360,11 @@ class NuSoundSystem {
         DECODER = 2,
     };
 
-    struct ChannelConfig {
-        u32 channels;
-    };
+    enum ChannelConfig : u32 {};
 
-    struct AudioChannel {};
+    enum class AudioChannel : u32 {};
     struct CurveData {};
-    struct DownmixType {};
+    enum class DownmixType : u32 {};
     enum class FalloffType { LINEAR = 0 };
     enum class SurroundMode { ZERO = 0 };
 
@@ -182,29 +386,52 @@ class NuSoundSystem {
         INVALID = 13,
     };
 
+  public:
+    pthread_mutex_t mutex;
+    NuSoundClock clock;
+    struct SampleLinks { NuSoundSample *previous; NuSoundSample *next; } sample_start, sample_end;
+    NuSoundSample *sample_head;
+    NuSoundSample *sample_tail;
+    u32 sample_list_count;
+
   private:
     NuSoundSample **samples;
     u32 sample_count;
 
   public:
-    pthread_mutex_t mutex;
-
-  public:
+    NuSoundVoiceFactoryList factory_list;
     // Voice bookkeeping: an intrusive doubly-linked list of all live voices
     // (links live in the voices at +0x24/+0x28), the per-format voice factory
     // and the audio clock.
-    NuSoundVoice *voice_list_start;
-    NuSoundVoice *voice_list_end;
+    struct VoiceLinks { NuSoundVoice *prev; NuSoundVoice *next; } voice_start, voice_end;
+    NuSoundVoice *voice_head;
+    NuSoundVoice *voice_tail;
     i32 voice_count;
-    NuSoundVoiceFactoryList factory_list;
-    NuSoundClock clock;
+    struct EffectLinks { NuEListNode<NuSoundEffect> *prev; NuEListNode<NuSoundEffect> *next; } effect_start, effect_end;
+    NuEListNode<NuSoundEffect> *effect_head;
+    NuEListNode<NuSoundEffect> *effect_tail;
+    u32 effect_count;
+    struct BusLinks { NuSoundBus *previous; NuSoundBus *next; } bus_start, bus_end;
+    NuSoundBus *bus_head;
+    NuSoundBus *bus_tail;
+    u32 bus_count;
+    struct RoutingLinks { NuSoundRoutingTable *prev; NuSoundRoutingTable *next; };
+    RoutingLinks routing_start;
+    RoutingLinks routing_end;
+    NuSoundRoutingTable *routing_head;
+    NuSoundRoutingTable *routing_tail;
+    u32 routing_count;
+    NuEList<NuSoundListener, DefaultElist> listeners;
+    u32 unknown_f0[2];
+    u32 sample_load_count;
+    u8 unknown_fc[0xc];
     bool initialised;
 
     // The original class contains additional intrusive lists and bookkeeping
     // between the update gate at +0x108 and the fields reconstructed above.
     // Keep their storage in the target object even before their types are
     // known, so the OpenSL handles retain their observed ABI offsets.
-    u8 unknown_before_device_handles[0xae];
+    u8 unknown_before_device_handles[3];
 
     // OpenSL ES handles at +0x10c/+0x110/+0x114 in the target object.
     void *engine_object; // SL engine object (realize / GetInterface / destroy)
@@ -219,6 +446,7 @@ class NuSoundSystem {
 
     static i32 sAllocdMemory[3];
     static i32 sTotalMemory[3];
+    static u32 sGfxMemorySize;
 
     static void *sScratchMemory;
     static void *sSampleMemory;
@@ -235,39 +463,33 @@ class NuSoundSystem {
         return s_staticInstance;
     }
 
-    static struct : NuMemoryManager::IEventHandler {
-        u32 unknown;
-        void *scratch;
-        u32 scratch_size;
-
-        virtual bool AllocatePage(NuMemoryManager *manager, u32 size, u32 _unknown) {
-            (void)size;
-            (void)_unknown;
-            if (scratch == NULL) {
-                return false;
-            }
-            manager->AddPage(scratch, scratch_size, false);
-            scratch = NULL;
-            return true;
-        }
-        virtual bool ReleasePage(NuMemoryManager *manager, void *ptr, u32 _unknown) {
-            (void)manager;
-            (void)ptr;
-            (void)_unknown;
-            return false;
-        }
-    } g_handler;
+    static NuSoundSystemCallbacks g_handler;
 
     static NuMemoryManager *sScratchMemMgr;
 
     NuSoundSystem();
 
-    virtual NuSoundVoice *CreateVoice(NuSoundSource *source, bool loop);
-    void ReleaseVoice(NuSoundVoice *voice);
-    bool SourceRequiresDecoder(NuSoundSource *source);
+    virtual ~NuSoundSystem();
+    virtual NuSoundEffect *CreateEffect(NuSoundEffect::EffectType);
+    virtual void ReleaseEffect(NuSoundEffect *);
+    virtual NuSoundBus *CreateBus(const char *name, bool is_master);
+    virtual NuSoundBus *GetBus(const char *name);
+    virtual void ReleaseBus(NuSoundBus *);
+    virtual bool IsUserPlayingMusic() { return false; }
+    virtual void PauseUserMusic() {}
+    virtual void ResumeUserMusic() {}
+    virtual bool TitleHasUserMusicControl() { return true; }
+    virtual void OnEnterSystemMenu() {}
+    virtual void OnExitSystemMenu() {}
+    virtual bool InitAudioDevice() = 0;
+    virtual void ShutdownAudioDevice() = 0;
     virtual void UpdateAudioDevice() = 0;
+
+    NuSoundVoice *CreateVoice(NuSoundSource *source, bool loop);
+    void ReleaseVoice(NuSoundVoice *voice);
+    static bool SourceRequiresDecoder(NuSoundSource *source);
     i32 GetNumAvailableOutputDevices();
-    NuSoundRoutingTable *GetDefaultRoutingTable();
+    static NuSoundRoutingTable *GetDefaultRoutingTable();
     void Update(f32 frametime);
 
   public:
@@ -292,7 +514,7 @@ class NuSoundSystem {
 
     NuSoundSample *GetSample(const char *path);
 
-    i32 GenerateHash(const char *str);
+    static i32 GenerateHash(const char *str);
 
     // vtable:
     // create_effect
@@ -308,62 +530,55 @@ class NuSoundSystem {
     // shutdown_audio_device
     // update_audio_device
 
-    virtual ~NuSoundSystem();
-    virtual bool InitAudioDevice() = 0;
-    virtual NuSoundBus *CreateBus(const char *name, bool is_master);
-    virtual NuSoundBus *GetBus(const char *name);
 
-    void AddListener(NuSoundListener *);
+    bool AddListener(NuSoundListener *);
     void AddRoutingTable(NuSoundRoutingTable *);
-    void AmplitudeTodB(float);
-    void CalculateCrossfadeHeight(NuSoundSystem::CurveData const &, float) const;
+    static f32 AmplitudeTodB(float);
+    f32 CalculateCrossfadeHeight(NuSoundSystem::CurveData const &, float) const;
     void CreateCrossfadeCurve(unsigned int);
-    NuSoundDecoder *CreateDecoder(NuSoundSource *source);
-    void CreateEffect(NuSoundEffect::EffectType);
+    static NuSoundDecoder *CreateDecoder(NuSoundSource *source);
     void DefragmentSampleMemory();
-    void DetermineFileType(NUFILETYPE);
+    static FileType DetermineFileType(NUFILETYPE);
     void Disable();
-    void FileTypeSupported(NuSoundSystem::FileType);
-    void Get();
-    void GetAllocdMemory(NuSoundSystem::MemoryDiscipline);
-    void GetBufferAlignment();
+    static bool FileTypeSupported(NuSoundSystem::FileType);
+    static NuSoundSystem *Get();
+    static u32 GetAllocdMemory(NuSoundSystem::MemoryDiscipline);
+    static u32 GetBufferAlignment();
     i32 GetClosestSupportedConfig(i32 config);
     void GetCrossfadeCurve(unsigned int) const;
-    void GetDefaultFileType(NuSoundSource::FeedType);
-    void GetGfxMemorySize();
-    void GetLanguageString(bool);
-    void GetLargestMemoryFragment(NuSoundSystem::MemoryDiscipline);
-    void GetListeners();
-    NuSoundListener *GetNearestRealListener(NuEList<NuSoundListener, DefaultElist> const &, VuVec const &);
-    NuSoundListener *GetNearestFocusListener(NuEList<NuSoundListener, DefaultElist> const &, VuVec const &, float &);
-    void GetOldestVoice(NuSoundSample *, float &);
-    void GetOutputChannelConfig();
+    static FileType GetDefaultFileType(NuSoundSource::FeedType);
+    static u32 GetGfxMemorySize();
+    static const char *GetLanguageString(bool);
+    static u32 GetLargestMemoryFragment(NuSoundSystem::MemoryDiscipline);
+    NuEList<NuSoundListener, DefaultElist> const *GetListeners();
+    static NuSoundListener *GetNearestRealListener(NuEList<NuSoundListener, DefaultElist> const &, VuVec const &);
+    static NuSoundListener *GetNearestFocusListener(NuEList<NuSoundListener, DefaultElist> const &, VuVec const &, float &);
+    NuSoundVoice *GetOldestVoice(NuSoundSample *, float &);
+    static i32 GetOutputChannelConfig();
     void GetPeakAllocdMemory(NuSoundSystem::MemoryDiscipline);
-    void GetPlatformString();
-    void GetQuietestVoice(NuSoundSample *, float &);
-    void GetRoutingTable(char const *);
-    void GetTotalMemory(NuSoundSystem::MemoryDiscipline);
-    void LoadSample(NuSoundSample *, void *, int, NuSoundOutOfMemCallback *);
+    static const char *GetPlatformString();
+    NuSoundVoice *GetQuietestVoice(NuSoundSample *, float &);
+    NuSoundRoutingTable *GetRoutingTable(char const *);
+    static u32 GetTotalMemory(NuSoundSystem::MemoryDiscipline);
+    bool LoadSample(NuSoundSample *, void *, int, NuSoundOutOfMemCallback *);
     void PauseAllVoices();
     void PauseVoices(int);
     void ReAllocMemory(NuSoundSystem::MemoryDiscipline, unsigned int, unsigned int);
-    void ReleaseBus(NuSoundBus *);
     void ReleaseCrossfadeCurve(unsigned int);
     static void ReleaseDecoder(NuSoundDecoder *decoder);
-    void ReleaseEffect(NuSoundEffect *);
     void ReleaseSample(NuSoundSample *);
     void RemoveListener(NuSoundListener *);
     void ResumeAllVoices();
     void ResumeVoices(int);
-    void SetDefaultRoutingTable(NuSoundRoutingTable *);
-    void SetGfxMemorySize(unsigned int);
+    static void SetDefaultRoutingTable(NuSoundRoutingTable *);
+    static void SetGfxMemorySize(unsigned int);
     void SetMainThreadID(NuThread *);
     void Shutdown();
     void StopAllVoices();
     void StopVoices(NuSoundSource const &);
     void StopVoices(int);
     void UnloadAllSamples();
-    void UnloadSample(NuSoundSample *);
+    bool UnloadSample(NuSoundSample *);
     void dBToAmplitude(float);
 };
 // One row of a routing table: an N-in by M-out gain matrix pointing at one of
@@ -372,21 +587,26 @@ struct NuSoundMixMatrix {
     u32 in;
     u32 out;
     f32 *matrix;
-    u32 flag;
+    u8 flag;
 };
 
 class NuSoundMixer {
   public:
-    struct OutputLayout {
-        u32 layout;
-    };
+    enum OutputLayout : u32 {};
 
     NuSoundMixer(NuSoundSystem::ChannelConfig config, NuSoundSystem::ChannelConfig output,
                  NuSoundMixer::OutputLayout layout, NuSoundSystem::DownmixType downmix, NuSoundRoutingTable *table);
     ~NuSoundMixer();
 
     void Mix(f32 *in, f32 *out);
-    void GetOutputIndex(i32 output, i32 index);
+    i32 GetOutputIndex(i32 output, i32 index);
+
+    NuSoundSystem::ChannelConfig input_config;
+    NuSoundSystem::ChannelConfig output_config;
+    OutputLayout output_layout;
+    NuSoundSystem::DownmixType downmix_type;
+    NuSoundRoutingTable *routing_table;
+    static u8 sDownmixerChannelMaps[4][8];
 };
 class NuSoundRoutingTable {
   public:
@@ -395,16 +615,35 @@ class NuSoundRoutingTable {
     ~NuSoundRoutingTable();
 
     void SetMatrix(NuSoundSystem::ChannelConfig from, NuSoundSystem::ChannelConfig to, NuSoundMixMatrix *matrix);
-    void GetMatrix(NuSoundSystem::ChannelConfig from, NuSoundSystem::ChannelConfig to) const;
-    void GetConfig(i32 config);
-    void GetIndex(NuSoundSystem::ChannelConfig config);
-    void GetName() const;
+    NuSoundMixMatrix *GetMatrix(NuSoundSystem::ChannelConfig from, NuSoundSystem::ChannelConfig to) const;
+    static NuSoundSystem::ChannelConfig GetConfig(i32 config);
+    static i32 GetIndex(NuSoundSystem::ChannelConfig config);
+    const char *GetName() const;
+    NuSoundRoutingTable *unknown_00;
+    NuSoundRoutingTable *unknown_04;
+    u16 name_capacity;
+    u16 name_length;
+    char *name_data;
+    char name_storage[32];
+    NuSoundMixMatrix *matrices[6][6];
 };
 class NuSoundHandle {
-    void *field_00;
-    i32 field_04;
+  public:
+    // Callback slots recovered from handle destruction, voice invalidation,
+    // and ResetFrameCount; this list does not contain sound effects.
+    class Callback {
+      public:
+        virtual void OnDestroy(NuSoundHandle *) = 0;
+        virtual void OnInvalidateVoice(NuSoundHandle *) = 0;
+        virtual void OnResetFrameCount(NuSoundHandle *) = 0;
+    };
+
+  private:
+    NuSoundHandle *previous;
+    NuSoundHandle *next;
     NuSoundVoice *voice;
-    NuList<NuSoundEffect *> effects;
+    NuList<Callback *> callbacks;
+    friend class NuSoundVoice;
 
   public:
     NuSoundHandle();
@@ -450,7 +689,27 @@ class NuSoundHandle {
     void operator==(NuSoundHandle const &other);
 }; // namespace NuSoundSystem
 
+#if defined(__arm__)
+// Original ARM constructors: clock 0x2f2af8, system 0x2ee5f4;
+// InitAudioDevice 0x2fce38 passes this+0x110 to slCreateEngine.
+static_assert(sizeof(NuSoundClock) == 0x30, "ARM sound clock layout");
+static_assert(__builtin_offsetof(NuSoundSystem, factory_list) == 0x5c, "ARM voice factory offset");
+static_assert(__builtin_offsetof(NuSoundSystem, initialised) == 0x10c, "ARM audio update gate offset");
+static_assert(__builtin_offsetof(NuSoundSystem, engine_object) == 0x110, "ARM OpenSL engine handle offset");
+#else
+static_assert(sizeof(void *) != 4 || sizeof(NuSoundClock) == 0x2c, "Android sound clock layout");
+static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, factory_list) == 0x58, "Android voice factory offset");
+static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, initialised) == 0x108, "Android audio update gate offset");
+static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, engine_object) == 0x10c,
+              "Android OpenSL engine handle offset");
+#endif
+static_assert(sizeof(void *) != 4 || sizeof(NuSoundVoiceFactoryList) == 0xc, "Android voice factory list layout");
+static_assert(sizeof(void *) != 4 || __builtin_offsetof(NuSoundSystem, clock) == 8, "Android sound clock offset");
+
 class NuSoundOutOfMemCallback {
   public:
-    virtual void operator()() = 0;
+    // Slot names are descriptive; the reference establishes their order,
+    // 32-bit size argument, and boolean result through indirect calls.
+    virtual bool OnAllocationFailure(u32 size) = 0;
+    virtual bool OnAllocationFailureMinusTwo(u32 size) = 0;
 };

--- a/src/nu2api/nusound/nusound_voice.cpp
+++ b/src/nu2api/nusound/nusound_voice.cpp
@@ -8,12 +8,23 @@
 #include "decomp.h"
 
 #include "nu2api/nucore/nuthread.h"
+#include "nu2api/numath/nuvec.h"
+#include "nu2api/numath/nufloat.h"
+#include "nu2api/numath/numtx.h"
 #include "nu2api/nusound/nusound_bus.hpp"
 #include "nu2api/nusound/nusound_source.hpp"
 
 #include <string.h>
+#include <math.h>
+
+extern f32 NuATan2f(f32, f32);
 
 pthread_mutex_t NuSoundVoice::sStateCriticalSection = PTHREAD_MUTEX_INITIALIZER;
+static_assert(sizeof(void *) != 4 || offsetof(NuSoundVoice, volume) == 0xfc, "voice volume offset");
+static_assert(sizeof(void *) != 4 || offsetof(NuSoundVoice, falloff_a) == 0x100, "voice falloff offset");
+static_assert(sizeof(void *) != 4 || offsetof(NuSoundVoice, mix_flags) == 0x119, "voice mix flags offset");
+static_assert(sizeof(void *) != 4 || offsetof(NuSoundVoice, state) == 0x140, "voice playback state offset");
+static_assert(sizeof(void *) != 4 || offsetof(NuVoiceAndroid, player_object) == 0x14c, "Android player handle offset");
 
 // ---------------------------------------------------------------------------
 // construction / destruction
@@ -22,27 +33,18 @@ pthread_mutex_t NuSoundVoice::sStateCriticalSection = PTHREAD_MUTEX_INITIALIZER;
 NuSoundVoice::NuSoundVoice(NuSoundSource *sound_source, bool loop) {
     this->field_0x24 = NULL;
     this->field_0x28 = NULL;
-    this->effects_start = NULL;
-    this->effects_end = NULL;
-    this->effects_tail = NULL;
-    this->field20_0x4c = 0;
-    this->field23_0x58 = 0;
-    this->field57_0x80 = NULL;
-    this->field58_0x84 = NULL;
-    this->field59_0x88 = NULL;
-    this->field60_0x8c = NULL;
-    this->field61_0x90 = NULL;
-    this->field62_0x94 = NULL;
-    this->field121_0x120 = NULL;
-    this->field122_0x124 = NULL;
-    this->field123_0x128 = NULL;
-    this->field124_0x12c = NULL;
-    this->field125_0x130 = NULL;
-    this->field126_0x134 = NULL;
-    this->field127_0x138 = 0;
-    this->weak_ptr_obj.head = NULL;
-    this->weak_ptr_obj.tail = NULL;
-    this->weak_ptr_obj.weak_count = 0;
+    for (u32 i = 0; i < 2; ++i) {
+        positional_references[i].object = NULL;
+        positional_references[i].next = NULL;
+        positional_references[i].previous = NULL;
+    }
+    handles_head = reinterpret_cast<NuSoundHandle *>(&handles_start);
+    handles_tail = reinterpret_cast<NuSoundHandle *>(&handles_end);
+    handles_start.previous = NULL;
+    handles_start.next = handles_tail;
+    handles_end.previous = handles_head;
+    handles_end.next = NULL;
+    handle_count = 0;
     this->queued_buffers = 0;
 
     // The source is locked for the lifetime of the voice and keeps the stream
@@ -51,8 +53,6 @@ NuSoundVoice::NuSoundVoice(NuSoundSource *sound_source, bool loop) {
     sound_source->Lock();
     sound_source->VoiceReference();
     this->sound_source = sound_source;
-
-    memset(this->mix_gains, 0, sizeof(this->mix_gains));
 
     this->field63_0x98 = 0.0f;
     this->field64_0x9c = 0.0f;
@@ -70,30 +70,67 @@ NuSoundVoice::NuSoundVoice(NuSoundSource *sound_source, bool loop) {
     this->field72_0xbc = 0.0f;
     this->field73_0xc0 = 0.0f;
     this->field74_0xc4 = 1.0f;
-    this->field_0x104 = 0;
-    this->field_0x108 = 0;
     this->field113_0x10c = 1.0f; // LFE gain
     this->field114_0x110 = 0;
     this->field115_0x114 = 1;
-    this->field116_0x118 = 0;
+    this->control_118 = 0;
     this->output_bus = NuSoundSystem::sMasterBus;
-    this->field15_0x38 = NULL;
-    this->field16_0x3c = NuSoundSystem::sDefaultRoutingTable;
+    this->field15_0x38 = static_cast<NuSoundSystem::DownmixType>(0);
+    this->field16_0x3c = NuSoundSystem::GetDefaultRoutingTable();
+    this->listeners = NULL;
+    this->field56_0x7c = NULL;
     this->surround_mode = 2; // 2D omni
     this->falloff_type = 0;
     this->field130_0x144 = 1.0f;
     this->field131_0x148 = -1;
 
-    this->flags2 = (u8)(this->flags2 & 0xf6 | loop << 3);
-    this->flags2 &= 0xf9;
-    this->flags = (u8)(this->flags & 0xf0 | 0x10); // mix update on the first Update
+    this->flags = (u8)(this->flags & 0xf6 | loop << 3);
+    this->flags &= 0xf9;
+    this->mix_flags = (u8)(this->mix_flags & 0xf0 | 0x10);
 
     this->SetState(PLAYSTATE_STOPPED); // libTTapp.so ctor tail (0x3275b9)
+    memset(this->mix_gains, 0, sizeof(this->mix_gains));
 }
 
 NuSoundVoice::~NuSoundVoice() {
+    NuSoundHandle *end = handles_tail;
+    for (NuSoundHandle *handle = handles_head->next; handle != end; handle = handle->next) {
+        handle->SetVoice(NULL);
+    }
+    while (handle_count != 0) {
+        NuSoundHandle *handle = handles_head->next;
+        if (handle->previous != NULL) handle->previous->next = handle->next;
+        if (handle->next != NULL) handle->next->previous = handle->previous;
+        handle->next = NULL;
+        handle->previous = NULL;
+        --handle_count;
+    }
     this->sound_source->VoiceRelease();
     this->sound_source->Unlock();
+    while (handle_count != 0) {
+        NuSoundHandle *handle = handles_head->next;
+        if (handle->previous != NULL) handle->previous->next = handle->next;
+        if (handle->next != NULL) handle->next->previous = handle->previous;
+        handle->next = NULL;
+        handle->previous = NULL;
+        --handle_count;
+        delete handle;
+    }
+    for (i32 i = 1; i >= 0; --i) {
+        NuSoundEffect::ManagedReference &ref = positional_references[i];
+        if (ref.object != NULL) {
+            if (ref.next == &ref) {
+                ref.object->references = NULL;
+            } else {
+                ref.next->previous = ref.previous;
+                ref.previous->next = ref.next;
+                if (ref.object->references == &ref) ref.object->references = ref.next;
+            }
+            ref.object = NULL;
+            ref.next = NULL;
+            ref.previous = NULL;
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -116,15 +153,15 @@ void NuSoundVoice::SetState(PlayState state) {
 }
 
 bool NuSoundVoice::GetAutoDelete() const {
-    return (this->flags2 & 1) != 0;
+    return (this->flags & 1) != 0;
 }
 
 void NuSoundVoice::SetAutoDelete(bool auto_delete) {
-    this->flags2 = (u8)(this->flags2 & 0xfe | auto_delete);
+    this->flags = (u8)(this->flags & 0xfe | auto_delete);
 }
 
 void NuSoundVoice::SetMixUpdate(bool mix_update) {
-    this->flags = (u8)(this->flags & 0xef | mix_update << 4);
+    this->mix_flags = (u8)(this->mix_flags & 0xef | mix_update << 4);
 }
 
 void NuSoundVoice::SetVolume(f32 volume) {
@@ -158,14 +195,12 @@ void NuSoundVoice::Play() {
     if (this->queued_buffers == 0) {
         // Ask the source for the initial buffers; the streamer (or the sample
         // itself) hands them back through SubmitBuffer.
-        u32 num_buffers = this->sound_source->GetNumInitialBuffers();
-        for (u32 i = 0; i < num_buffers; i++) {
-            if ((this->flags2 & 8) == 0 && (this->flags2 & 2) != 0) {
+        for (i32 i = 0; i < (i32)this->sound_source->GetNumInitialBuffers(); i++) {
+            if ((this->flags & 8) == 0 && (this->flags & 2) != 0) {
                 break;
             }
-            NuSoundWeakPtr<NuSoundBufferCallback> callback;
-            callback.Set(this);
-            this->sound_source->RequestBuffer((this->flags2 >> 3) & 1, callback);
+            this->sound_source->RequestBuffer(
+                (this->flags >> 3) & 1, NuSoundWeakPtr<NuSoundBufferCallback>(this));
         }
     }
 
@@ -178,15 +213,15 @@ void NuSoundVoice::Pause() {
     if (this->GetState() == PLAYSTATE_PLAYING) {
         this->PauseHardwareVoice();
         this->SetState(PLAYSTATE_PAUSED);
-        this->flags = (u8)(this->flags & 0xf0 | (this->flags + 1) & 0xf);
     }
+    this->mix_flags = (u8)(this->mix_flags & 0xf0 | (this->mix_flags + 1) & 0xf);
 }
 
 void NuSoundVoice::Resume() {
-    u8 flags = this->flags;
+    u8 flags = this->mix_flags;
     if ((flags & 0xf) != 0) {
         flags = (u8)(flags & 0xf0 | (flags & 0xf) + 0xf & 0xf);
-        this->flags = flags;
+        this->mix_flags = flags;
     }
     if ((flags & 0xf) != 0) {
         return;
@@ -198,7 +233,7 @@ void NuSoundVoice::Resume() {
         this->SetState(PLAYSTATE_PLAYING);
     }
 
-    this->flags &= 0xf0;
+    this->mix_flags &= 0xf0;
 }
 
 void NuSoundVoice::Stop(bool with_effects) {
@@ -224,44 +259,63 @@ void NuSoundVoice::Stop(bool with_effects) {
 // ---------------------------------------------------------------------------
 
 void NuSoundVoice::Update(f32 frametime) {
-    if ((this->flags2 & 4) != 0 && this->CheckStopEffects()) {
+    if ((this->flags & 4) != 0 && this->CheckStopEffects()) {
         this->Stop(true);
     }
 
     this->UpdateEffects(frametime, NuSoundEffect::EffectProcessStage::ZERO);
 
-    if ((this->flags & 0x10) != 0 || this->GetState() == PLAYSTATE_STOPPED) {
+    if ((this->mix_flags & 0x10) != 0 || this->GetState() == PLAYSTATE_STOPPED) {
         this->UpdateMix(frametime);
     }
 
     this->UpdateEffects(frametime, NuSoundEffect::EffectProcessStage::ONE);
 
-    this->UpdateHardwareVoice(frametime);
     this->ApplyHardwareVoiceMix();
+    this->UpdateHardwareVoice(frametime);
 }
 
 void NuSoundVoice::UpdateMix(f32 frametime) {
-    f32 bus_gains[8] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
-
     this->CalculatePositionalMix();
+    f32 bus_gains[8] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
 
     if (this->output_bus != NULL) {
         this->output_bus->ApplyFinalMix(bus_gains);
     }
 
     f32 attenuation = this->CalculateEffectAttenuation();
-    f32 pitch_scale = this->CalculateEffectPitchScale();
+    this->field67_0xa8 = bus_gains[2] * attenuation * this->field67_0xa8;
+    this->field68_0xac = this->CalculateEffectPitchScale();
     f32 volume = this->volume;
 
     for (u32 i = 0; i < 8; i++) {
         this->mix_gains[i] *= bus_gains[i] * attenuation * volume;
     }
 
-    this->field67_0xa8 = bus_gains[2] * attenuation * this->field67_0xa8;
-    this->field68_0xac = pitch_scale;
 }
 
 void NuSoundVoice::CalculatePositionalMix() {
+    memset(mix_gains, 0, sizeof(mix_gains));
+    field67_0xa8 = 0.0f;
+    field65_0xa0 = 1.0f;
+    field63_0x98 = 0.0f;
+    field64_0x9c = 0.0f;
+    field66_0xa4 = field69_0xb0;
+    for (u32 i = 0; i < 2; ++i) {
+        NuSoundEffect::ManagedReference &ref = positional_references[i];
+        if (ref.object != NULL) {
+            if (ref.next == &ref) {
+                ref.object->references = NULL;
+            } else {
+                ref.next->previous = ref.previous;
+                ref.previous->next = ref.next;
+                if (ref.object->references == &ref) ref.object->references = ref.next;
+            }
+            ref.object = NULL;
+            ref.next = NULL;
+            ref.previous = NULL;
+        }
+    }
     if (this->surround_mode == 2) {
         // 2D omni: every channel at full gain except the LFE channel, which
         // keeps the voice's low-frequency mix.
@@ -277,22 +331,195 @@ void NuSoundVoice::CalculatePositionalMix() {
         return;
     }
 
-    // The 3D positional paths (surround modes 0/1/3/4 with listener matrices)
-    // are not exercised by the title music; left unimplemented on purpose.
+    if (surround_mode == 4) {
+        memmove(mix_gains, field56_0x7c, sizeof(mix_gains));
+        return;
+    }
+    if (surround_mode == 1) {
+        VuVec focus_position = position;
+        f32 distance = 0.0f;
+        NuSoundListener *focus = NuSoundSystem::GetNearestFocusListener(*listeners, focus_position, distance);
+        if (focus == NULL || !(falloff_b > distance)) return;
+        VuVec real_position = position;
+        NuSoundListener *real = NuSoundSystem::GetNearestRealListener(*listeners, real_position);
+        if (real == NULL) return;
+        const f32 *head = reinterpret_cast<const f32 *>(real->GetHeadMatrix());
+        VuVec relative(head[12] - direction.x, head[13] - direction.y, head[14] - direction.z, 0.0f);
+        f32 coefficients[8] = {};
+        f32 inner = field69_0xb0;
+        f32 outer = inner + field71_0xb8;
+        outer = outer < 360.0f ? outer : 360.0f;
+        CalculatePositionalCoefficients(coefficients, relative, *real->GetHeadMatrix(), inner, outer);
+        f32 attenuation = CalculateFalloffAttenuation(distance);
+        for (u32 i = 0; i < 8; ++i) {
+            f32 gain = attenuation * coefficients[i];
+            mix_gains[i] = focus->GetSensitivity() * gain;
+        }
+        if (NuSoundSystem::GetOutputChannelConfig() > 5) {
+            f32 gain = attenuation * field113_0x10c;
+            mix_gains[3] = focus->GetSensitivity() * gain;
+        }
+        field67_0xa8 = focus->GetSensitivity() * attenuation;
+        NuSoundListener *selected[2] = {real, focus};
+        for (u32 i = 0; i < 2; ++i) {
+            NuSoundEffect::ManagedReference &ref = positional_references[i];
+            NuSoundEffect::ManagedReference *head_ref = selected[i]->references;
+            if (head_ref == NULL) {
+                selected[i]->references = &ref;
+                ref.next = &ref;
+                ref.previous = &ref;
+            } else {
+                ref.next = head_ref->next;
+                ref.previous = head_ref;
+                head_ref->next = &ref;
+                ref.next->previous = &ref;
+            }
+            ref.object = reinterpret_cast<NuSoundEffect::ReferenceTarget *>(selected[i]);
+        }
+        field65_0xa0 = attenuation;
+        field64_0x9c = distance;
+        return;
+    }
+    if (surround_mode == 3) {
+        VuVec focus_position = position;
+        f32 distance = 0.0f;
+        NuSoundListener *focus = NuSoundSystem::GetNearestFocusListener(*listeners, focus_position, distance);
+        if (focus == NULL || !(falloff_b > distance)) return;
+        f32 attenuation = CalculateFalloffAttenuation(distance);
+        field67_0xa8 = attenuation;
+        for (u32 i = 0; i < 8; ++i) mix_gains[i] = focus->GetSensitivity() * attenuation;
+        f32 lfe = attenuation * field113_0x10c;
+        mix_gains[3] = focus->GetSensitivity() * lfe;
+        field67_0xa8 = focus->GetSensitivity() * attenuation;
+        NuSoundEffect::ManagedReference &ref = positional_references[1];
+        NuSoundEffect::ManagedReference *head_ref = focus->references;
+        if (head_ref == NULL) {
+            focus->references = &ref;
+            ref.next = &ref;
+            ref.previous = &ref;
+        } else {
+            ref.next = head_ref->next;
+            ref.previous = head_ref;
+            head_ref->next = &ref;
+            ref.next->previous = &ref;
+        }
+        ref.object = reinterpret_cast<NuSoundEffect::ReferenceTarget *>(focus);
+        field65_0xa0 = attenuation;
+        field64_0x9c = distance;
+        return;
+    }
+    if (surround_mode == 0) {
+        VuVec real_position = position;
+        NuSoundListener *real = NuSoundSystem::GetNearestRealListener(*listeners, real_position);
+        VuVec focus_position = position;
+        f32 distance = 0.0f;
+        NuSoundListener *focus = NuSoundSystem::GetNearestFocusListener(*listeners, focus_position, distance);
+        if (real == NULL || !(focus->GetSensitivity() > 0.0f) || !(falloff_b > distance)) return;
+        f32 attenuation = CalculateFalloffAttenuation(distance);
+        if (!(attenuation > 0.0f)) return;
+        VuVec head_position = position;
+        f32 head_distance = real->GetHeadDistance(head_position);
+        f32 second_distance = 0.0f;
+        NuSoundListener *second = NULL;
+        for (NuSoundListener *listener = listeners->head->next; listener != listeners->tail; listener = listener->next) {
+            if (listener == real || !listener->IsEnabled()) continue;
+            VuVec candidate_position = position;
+            second_distance = listener->GetHeadDistance(candidate_position);
+            if (6.0f > second_distance - head_distance) {
+                second = listener;
+                break;
+            }
+        }
+        f32 coefficients[2][8] = {};
+        f32 angle = 0.0f;
+        if (real->Get2DScreenPosition() != NULL) {
+            NUMTX identity;
+            NuMtxSetIdentity(&identity);
+            f32 z = 1.0f - real->Get2DScreenPosition()->y;
+            f32 x = real->Get2DScreenPosition()->x;
+            VuVec screen_position(x, 0.0f, z, 1.0f);
+            f32 outer = field69_0xb0 + field71_0xb8;
+            outer = outer < 360.0f ? outer : 360.0f;
+            CalculatePositionalCoefficients(mix_gains, screen_position,
+                reinterpret_cast<const VuMtx &>(identity), field69_0xb0, outer);
+        } else {
+            angle = CalculateFieldAngle(head_distance);
+            f32 outer = angle + field71_0xb8;
+            outer = outer < 360.0f ? outer : 360.0f;
+            VuVec first_position = position;
+            CalculatePositionalCoefficients(coefficients[0], first_position, *real->GetHeadMatrix(), angle, outer);
+            if (second != NULL) {
+                f32 second_angle = CalculateFieldAngle(second_distance);
+                // The reference retains the first listener's outer angle here.
+                VuVec second_position = position;
+                CalculatePositionalCoefficients(coefficients[1], second_position, *second->GetHeadMatrix(), second_angle, outer);
+                for (u32 i = 0; i < 8; ++i)
+                    mix_gains[i] = coefficients[0][i] > coefficients[1][i] ? coefficients[0][i] : coefficients[1][i];
+            } else {
+                memmove(mix_gains, coefficients[0], sizeof(mix_gains));
+            }
+        }
+        for (u32 i = 0; i < 8; ++i) mix_gains[i] = (focus->GetSensitivity() * attenuation) * mix_gains[i];
+        if (NuSoundSystem::GetOutputChannelConfig() > 5) {
+            f32 lfe = attenuation * field113_0x10c;
+            mix_gains[3] = focus->GetSensitivity() * lfe;
+        }
+        field67_0xa8 = focus->GetSensitivity() * attenuation;
+        NuSoundListener *selected[2] = {real, focus};
+        for (u32 i = 0; i < 2; ++i) {
+            NuSoundEffect::ManagedReference &ref = positional_references[i];
+            NuSoundEffect::ManagedReference *head_ref = selected[i]->references;
+            if (head_ref == NULL) {
+                selected[i]->references = &ref;
+                ref.next = &ref;
+                ref.previous = &ref;
+            } else {
+                ref.next = head_ref->next;
+                ref.previous = head_ref;
+                head_ref->next = &ref;
+                ref.next->previous = &ref;
+            }
+            ref.object = reinterpret_cast<NuSoundEffect::ReferenceTarget *>(selected[i]);
+        }
+        field65_0xa0 = attenuation;
+        field63_0x98 = head_distance;
+        field64_0x9c = distance;
+        field66_0xa4 = angle;
+    }
 }
 
 bool NuSoundVoice::AreStopEffectsRunning() const {
-    return (this->flags2 & 4) != 0;
+    if ((flags & 4) != 0) {
+        for (NuListNode<NuSoundEffect *> *node = static_cast<NuListNode<NuSoundEffect *> *>(effects.Head()); node != effects.Tail(); node = static_cast<NuListNode<NuSoundEffect *> *>(node->GetNext())) {
+            NuSoundEffect *effect = node->value;
+            if (effect->unknown_08[1] == 1 && effect->unknown_08[2] == 1) return true;
+        }
+    }
+    return false;
 }
 
 bool NuSoundVoice::CheckStopEffects() {
-    // Stop effects only exist while the effects list is non-empty.
+    if ((flags & 4) != 0) {
+        for (NuListNode<NuSoundEffect *> *node = static_cast<NuListNode<NuSoundEffect *> *>(effects.Head()); node != effects.Tail(); node = static_cast<NuListNode<NuSoundEffect *> *>(node->GetNext())) {
+            NuSoundEffect *effect = node->value;
+            if (effect->unknown_08[1] == 1 && effect->unknown_08[2] == 1) return false;
+        }
+    }
     return true;
 }
 
 void NuSoundVoice::UpdateEffects(f32 frametime, NuSoundEffect::EffectProcessStage stage) {
-    (void)frametime;
-    (void)stage;
+    NuListNode<NuSoundEffect *> *node = static_cast<NuListNode<NuSoundEffect *> *>(effects.Head());
+    while (node != effects.Tail()) {
+        NuSoundEffect *effect = node->value;
+        node = static_cast<NuListNode<NuSoundEffect *> *>(node->GetNext());
+        if (effect->unknown_08[0] == static_cast<u32>(stage) && effect->enabled) {
+            effect->ProcessVoice(this, frametime);
+        }
+        if (effect->unknown_08[2] == 2 && !effect->system_owned) {
+            RemoveEffect(effect);
+        }
+    }
 }
 
 void NuSoundVoice::CheckStarvedBuffers() {
@@ -302,173 +529,346 @@ void NuSoundVoice::CheckStarvedBuffers() {
 // remaining original surface (off the title music path; kept as stubs)
 // ---------------------------------------------------------------------------
 
-void NuSoundVoice::AddEffect(NuSoundEffect *) {
+bool NuSoundVoice::AddEffect(NuSoundEffect *effect) {
+    if (effects.length != 0) {
+        NuListNodeBase *last = effects.tail->GetPrev();
+        NuListNodeBase *node = effects.Head();
+        for (;;) {
+            if (static_cast<NuListNode<NuSoundEffect *> *>(node)->value == effect) return false;
+            if (node == last) break;
+            node = node->GetNext();
+        }
+    }
+    bool attached = effect->AttachVoice(this);
+    if (attached) NuSoundMemory::PushNuListNode(effects, effect);
+    return attached;
 }
 
 bool NuSoundVoice::BeginStopEffects() {
-    return false;
+    if ((flags & 4) == 0) {
+        for (NuListNode<NuSoundEffect *> *node = static_cast<NuListNode<NuSoundEffect *> *>(effects.Head()); node != effects.Tail(); node = static_cast<NuListNode<NuSoundEffect *> *>(node->GetNext())) {
+            NuSoundEffect *effect = node->value;
+            if (effect->unknown_08[1] == 1) {
+                effect->Enable();
+                flags |= 4;
+            }
+        }
+    }
+    return (flags & 4) != 0;
 }
 
 f32 NuSoundVoice::CalculateEffectAttenuation() {
-    return 1.0f;
+    f32 value = 1.0f;
+    for (NuListNode<NuSoundEffect *> *node = static_cast<NuListNode<NuSoundEffect *> *>(effects.Head()); node != effects.Tail(); node = static_cast<NuListNode<NuSoundEffect *> *>(node->GetNext())) {
+        value *= node->value->attenuation;
+    }
+    return value;
 }
 
 f32 NuSoundVoice::CalculateEffectPitchScale() {
+    f32 value = 1.0f;
+    for (NuListNode<NuSoundEffect *> *node = static_cast<NuListNode<NuSoundEffect *> *>(effects.Head()); node != effects.Tail(); node = static_cast<NuListNode<NuSoundEffect *> *>(node->GetNext())) {
+        value *= node->value->pitch_scale;
+    }
+    return value;
+}
+
+f32 NuSoundVoice::CalculateFalloffAttenuation(f32 distance) {
+    if (distance > falloff_a) {
+        if (falloff_type == 0) {
+            return (falloff_b - distance) / (falloff_b - falloff_a);
+        }
+        if (falloff_type == 1) {
+            f32 factor = (falloff_b - distance) / (falloff_b - falloff_a);
+            f32 scaled = (1.0f - factor) * 10.0f + 1.0f;
+            return 1.0f / (scaled * scaled);
+        }
+    }
     return 1.0f;
 }
 
-void NuSoundVoice::CalculateFalloffAttenuation(f32) {
+f32 NuSoundVoice::CalculateFieldAngle(f32 distance) {
+    f32 angle = field69_0xb0;
+    if (field73_0xc0 > distance) {
+        if (field72_0xbc > distance) return field70_0xb4;
+        f32 scale = (field73_0xc0 - distance) / (field73_0xc0 - field72_0xbc);
+        angle += scale * (field70_0xb4 - angle);
+    }
+    return angle;
 }
 
-void NuSoundVoice::CalculateFieldAngle(f32) {
+void NuSoundVoice::CalculatePositionalCoefficients(f32 *gains, VuVec const &position,
+                                                VuMtx const &mtx, f32 inner_angle, f32 outer_angle) {
+    NUVEC local;
+    NuVecInvMtxTransform(&local, (NUVEC *)&position, (numtx_s *)&mtx);
+    f32 angle = NuFmod(NuATan2f(local.x, local.z) * 180.0f / 3.1415927410125732f, 360.0f);
+    outer_angle *= 0.5f;
+    f32 outer_left = NuFmod(angle - outer_angle, 360.0f);
+    f32 outer_right = NuFmod(angle + outer_angle, 360.0f);
+    inner_angle *= 0.5f;
+    f32 inner_left = NuFmod(angle - inner_angle, 360.0f);
+    f32 inner_right = NuFmod(angle + inner_angle, 360.0f);
+    // The reference visits both wrapped representations before the positive
+    // center endpoint. Existing nonzero gains are preserved; LFE is untouched.
+    const f32 speaker_angles[] = {-360, -330, -270, -210, -150, -90, -30,
+                                   0,   30,   90,  150,  210, 270, 330, 360};
+    const u32 channels[] = {2, 1, 5, 7, 6, 4, 0, 2, 1, 5, 7, 6, 4, 0, 2};
+    for (u32 i = 0; i < 15; ++i) {
+        f32 speaker = speaker_angles[i];
+        u32 channel = channels[i];
+        if (gains[channel] == 0.0f && speaker > outer_left && outer_right > speaker) {
+            if (speaker > inner_left && inner_right > speaker) {
+                gains[channel] = 1.0f;
+            } else {
+                bool left = speaker - angle < 0.0f;
+                f32 outer = left ? outer_left : outer_right;
+                f32 inner = left ? inner_left : inner_right;
+                f32 gain = fabsf((outer - speaker) / (outer - inner));
+                gains[channel] = gain < 1.0f ? gain : 1.0f;
+            }
+        }
+    }
 }
 
-void NuSoundVoice::CalculatePositionalCoefficients(f32 *, VuVec const &, VuMtx const &, f32, f32) {
+i32 NuSoundVoice::GetControllerBits() const {
+    return control_118;
 }
 
-void NuSoundVoice::GetControllerBits() const {
+const VuVec * NuSoundVoice::GetDirection() const {
+    return &direction;
 }
 
-void NuSoundVoice::GetDirection() const {
+NuSoundSystem::DownmixType NuSoundVoice::GetDownmixerType() const {
+    return field15_0x38;
 }
 
-void NuSoundVoice::GetDownmixerType() const {
+NuSoundEffect *NuSoundVoice::GetEffect(NuSoundEffect::EffectType type) {
+    for (NuListNode<NuSoundEffect *> *node = static_cast<NuListNode<NuSoundEffect *> *>(effects.Head()); node != effects.Tail(); node = static_cast<NuListNode<NuSoundEffect *> *>(node->GetNext())) {
+        NuSoundEffect *effect = node->value;
+        if (effect->unknown_08[3] == static_cast<u32>(type)) return effect;
+    }
+    return NULL;
 }
 
-void NuSoundVoice::GetEffect(NuSoundEffect::EffectType) {
+NuSoundSystem::FalloffType NuSoundVoice::GetFalloffType() const {
+    return static_cast<NuSoundSystem::FalloffType>(falloff_type);
 }
 
-void NuSoundVoice::GetFalloffType() const {
+f32 NuSoundVoice::GetFar() const {
+    return falloff_b;
 }
 
-void NuSoundVoice::GetFar() const {
+f32 NuSoundVoice::GetLowFrequencyMix() const {
+    return field113_0x10c;
 }
 
-void NuSoundVoice::GetLowFrequencyMix() const {
+f32 NuSoundVoice::GetNear() const {
+    return falloff_a;
 }
 
-void NuSoundVoice::GetNear() const {
+u32 NuSoundVoice::GetNumEffects() const {
+    return effects.length;
 }
 
-void NuSoundVoice::GetNumEffects() const {
+NuSoundBus * NuSoundVoice::GetOutputBus() const {
+    return output_bus;
 }
 
-void NuSoundVoice::GetOutputBus() const {
+f32 NuSoundVoice::GetPenetration() const {
+    return field74_0xc4;
 }
 
-void NuSoundVoice::GetPenetration() const {
+f32 NuSoundVoice::GetPitch() const {
+    return pitch;
 }
 
-void NuSoundVoice::GetPitch() const {
+f32 NuSoundVoice::GetPlaybackPositionSeconds() {
+    u64 samples = GetPlaybackPositionSamples();
+    i32 rate = static_cast<i32>(sound_source->GetStreamDesc()->GetSampleRate());
+    return static_cast<f32>(samples) / static_cast<f32>(rate);
 }
 
-void NuSoundVoice::GetPlaybackPositionSeconds() {
+const VuVec *NuSoundVoice::GetPosition() const {
+    return &position;
 }
 
-void NuSoundVoice::GetPosition() const {
+f32 NuSoundVoice::GetReverbWetMix() const {
+    return field130_0x144;
 }
 
-void NuSoundVoice::GetReverbWetMix() const {
+NuSoundRoutingTable * NuSoundVoice::GetRoutingTable() const {
+    return field16_0x3c;
 }
 
-void NuSoundVoice::GetRoutingTable() const {
+f32 NuSoundVoice::GetSpeakerBleedAngle() const {
+    return field71_0xb8;
 }
 
-void NuSoundVoice::GetSpeakerBleedAngle() const {
+f32 NuSoundVoice::GetSpeakerBleedFar() const {
+    return field73_0xc0;
 }
 
-void NuSoundVoice::GetSpeakerBleedFar() const {
+f32 NuSoundVoice::GetSpeakerBleedNear() const {
+    return field72_0xbc;
 }
 
-void NuSoundVoice::GetSpeakerBleedNear() const {
+f32 NuSoundVoice::GetSpeakerFieldAngleMax() const {
+    return field70_0xb4;
 }
 
-void NuSoundVoice::GetSpeakerFieldAngleMax() const {
+f32 NuSoundVoice::GetSpeakerFieldAngleMin() const {
+    return field69_0xb0;
 }
 
-void NuSoundVoice::GetSpeakerFieldAngleMin() const {
+f32 NuSoundVoice::GetStartOffset() const {
+    return field114_0x110;
 }
 
-void NuSoundVoice::GetStartOffset() const {
+NuSoundSystem::SurroundMode NuSoundVoice::GetSurroundMode() const {
+    return static_cast<NuSoundSystem::SurroundMode>(surround_mode);
 }
 
-void NuSoundVoice::GetSurroundMode() const {
+const VuVec *NuSoundVoice::GetVelocity() const {
+    return &velocity;
 }
 
-void NuSoundVoice::GetVelocity() const {
+f32 NuSoundVoice::GetVolume() const {
+    return volume;
 }
 
-void NuSoundVoice::GetVolume() const {
-}
-
-void NuSoundVoice::IsLooping() const {
+bool NuSoundVoice::IsLooping() const {
+    return (flags & 8) != 0;
 }
 
 void NuSoundVoice::RegisterHandle(NuSoundHandle *) {
 }
 
-void NuSoundVoice::RemoveEffect(NuSoundEffect *) {
+void NuSoundVoice::RemoveEffect(NuSoundEffect *effect) {
+    NuListNodeBase *found = effects.Head();
+    while (found != effects.tail && static_cast<NuListNode<NuSoundEffect *> *>(found)->value != effect) found = found->next;
+    if (found == effects.tail) return;
+    effect->DetachVoice(this);
+    if (effects.length != 0) {
+        NuListNodeBase *last = effects.tail->prev;
+        NuListNodeBase *node = effects.Head();
+        unsigned int removed = 0;
+        for (;;) {
+            if (static_cast<NuListNode<NuSoundEffect *> *>(node)->value == effect) {
+                bool is_last = node == last;
+                NuListNodeBase *next = node->next;
+                NuListNodeBase *previous = node->prev;
+                if (previous != NULL) previous->next = next;
+                if (next != NULL) next->prev = previous;
+                NuMemoryGet()->GetThreadMem()->BlockFree(node, 0);
+                ++removed;
+                if (is_last) break;
+                node = next;
+                if (node == last) break;
+                // The original advances again after removing a non-final node.
+                node = node->next;
+            } else {
+                if (node == last) break;
+                node = node->next;
+            }
+        }
+        effects.length -= removed;
+    }
+    NuSoundSystem::sAllocdMemory[0] -= sizeof(NuListNode<NuSoundEffect *>);
 }
 
-void NuSoundVoice::SetControllerBits(i32) {
+
+
+void NuSoundVoice::SetControllerBits(i32 bits) {
+    control_118 = static_cast<u8>(bits);
 }
 
 void NuSoundVoice::SetCustomSurroundMix(f32 *) {
 }
 
-void NuSoundVoice::SetDirection(VuVec *) {
+void NuSoundVoice::SetDirection(VuVec *value) {
+    if (value != NULL) {
+        direction.x = value->x;
+        direction.y = value->y;
+        direction.z = value->z;
+        direction.w = value->w;
+        NuVecNorm(reinterpret_cast<NUVEC *>(&direction), reinterpret_cast<NUVEC *>(&direction));
+    }
 }
 
-void NuSoundVoice::SetDownmixerType(NuSoundSystem::DownmixType) {
+void NuSoundVoice::SetDownmixerType(NuSoundSystem::DownmixType type) {
+    field15_0x38 = type;
 }
 
-void NuSoundVoice::SetFalloff(f32, f32, NuSoundSystem::FalloffType) {
+void NuSoundVoice::SetFalloff(f32 near, f32 far, NuSoundSystem::FalloffType type) {
+    if (near >= 0.0f && far > near) {
+        falloff_a = near;
+        falloff_b = far;
+        falloff_type = static_cast<u32>(type);
+    }
 }
 
-void NuSoundVoice::SetLowFrequencyMix(f32) {
+void NuSoundVoice::SetLowFrequencyMix(f32 mix) {
+    field113_0x10c = mix;
 }
 
-void NuSoundVoice::SetOutputBus(NuSoundBus *) {
+void NuSoundVoice::SetOutputBus(NuSoundBus *bus) {
+    output_bus = bus == NULL ? NuSoundSystem::sMasterBus : bus;
 }
 
-void NuSoundVoice::SetOutputDevices(i32) {
+void NuSoundVoice::SetOutputDevices(i32 devices) {
+    field115_0x114 = devices;
 }
 
-void NuSoundVoice::SetPenetration(f32) {
+void NuSoundVoice::SetPenetration(f32 penetration) {
+    field74_0xc4 = penetration;
 }
 
-void NuSoundVoice::SetPosition(VuVec *) {
+void NuSoundVoice::SetPosition(VuVec *value) {
+    if (value != NULL) position = *value;
 }
 
 void NuSoundVoice::SetReverbWetMix(f32 mix) {
     this->field130_0x144 = mix;
 }
 
-void NuSoundVoice::SetRoutingTable(NuSoundRoutingTable *) {
+void NuSoundVoice::SetRoutingTable(NuSoundRoutingTable *table) {
+    field16_0x3c = table;
 }
 
-void NuSoundVoice::SetSpeakerBleedAngle(f32) {
+void NuSoundVoice::SetSpeakerBleedAngle(f32 angle) {
+    field71_0xb8 = angle;
 }
 
-void NuSoundVoice::SetSpeakerBleedFar(f32) {
+void NuSoundVoice::SetSpeakerBleedFar(f32 distance) {
+    field73_0xc0 = distance;
 }
 
-void NuSoundVoice::SetSpeakerBleedNear(f32) {
+void NuSoundVoice::SetSpeakerBleedNear(f32 distance) {
+    field72_0xbc = distance;
 }
 
-void NuSoundVoice::SetSpeakerFieldAngle(f32, f32) {
+void NuSoundVoice::SetSpeakerFieldAngle(f32 minimum, f32 maximum) {
+    field69_0xb0 = minimum;
+    field70_0xb4 = maximum;
 }
 
-void NuSoundVoice::SetStartOffset(f32) {
+void NuSoundVoice::SetStartOffset(f32 offset) {
+    field114_0x110 = offset;
 }
 
-void NuSoundVoice::SetListeners(NuEList<NuSoundListener, DefaultElist> const *) {
+void NuSoundVoice::SetListeners(NuEList<NuSoundListener, DefaultElist> const *value) {
+    listeners = value;
 }
 
-void NuSoundVoice::SetSurroundMode(NuSoundSystem::SurroundMode) {
+void NuSoundVoice::SetSurroundMode(NuSoundSystem::SurroundMode value) {
+    surround_mode = static_cast<u32>(value);
 }
 
-void NuSoundVoice::SetVelocity(VuVec const &) {
+void NuSoundVoice::SetVelocity(VuVec const &value) {
+    velocity.x = value.x;
+    velocity.y = value.y;
+    velocity.z = value.z;
+    velocity.w = value.w;
 }
 
 void NuSoundVoice::UnregisterHandle(NuSoundHandle *) {

--- a/src/nu2api/nusound/nusound_voice.hpp
+++ b/src/nu2api/nusound/nusound_voice.hpp
@@ -32,7 +32,7 @@ struct VuVec;
 // The voice doubles as the NuSoundBufferCallback the sample hands filled
 // buffers to (the original dispatched through the callback vtable slot +8,
 // which is NuVoiceAndroid::SubmitBuffer).
-class NuSoundBufferCallback {
+class NuSoundBufferCallback : public NuSoundWeakPtrObj<NuSoundBufferCallback> {
   public:
     virtual ~NuSoundBufferCallback() {
     }
@@ -51,7 +51,6 @@ class NuSoundVoice : public NuSoundBufferCallback {
     // the start of the voice). queued_buffers counts buffers handed to the
     // hardware but not yet consumed; Play() refuses to double-start while it
     // is non-zero.
-    NuSoundWeakPtrObj<NuSoundVoice> weak_ptr_obj;
     u32 queued_buffers;
 
     // System intrusive list links.
@@ -64,29 +63,19 @@ class NuSoundVoice : public NuSoundBufferCallback {
     u8 flags2; // bit0: auto delete; bit1: last buffer queued; bit2: stop effects
                // running; bit3: looping (from the CreateVoice loop argument)
 
-    NuSoundRoutingTable *field15_0x38;
-    void *field16_0x3c; // default routing table
+    u32 surround_mode;
+    NuSoundSystem::DownmixType field15_0x38;
+    NuSoundRoutingTable *field16_0x3c;
 
     // Effects list (elist nodes at +0x40..+0x48).
-    NuEListNode<NuSoundEffect> *effects_start;
-    NuEListNode<NuSoundEffect> *effects_end;
-    NuEListNode<NuSoundEffect> *effects_tail;
-
-    u32 field20_0x4c;
-    u32 field23_0x58;
+    NuList<NuSoundEffect *> effects;
 
     // +0x5c..0x7c: the eight output channel gains (the positional mix).
     f32 mix_gains[8];
 
     void *field56_0x7c;
 
-    void *field57_0x80;
-    void *field58_0x84;
-    void *field59_0x88;
-
-    void *field60_0x8c;
-    void *field61_0x90;
-    void *field62_0x94;
+    NuSoundEffect::ManagedReference positional_references[2];
 
     f32 field63_0x98;
     f32 field64_0x9c;
@@ -95,8 +84,6 @@ class NuSoundVoice : public NuSoundBufferCallback {
     f32 field67_0xa8; // final mix scalar fed to the hardware volume
     f32 field68_0xac; // pitch scale
 
-    f32 falloff_a;    // 1.0
-    f32 falloff_b;    // 6.0
     f32 field69_0xb0; // 20.0
     f32 field70_0xb4; // 180.0
     f32 field71_0xb8; // 70.0
@@ -104,25 +91,30 @@ class NuSoundVoice : public NuSoundBufferCallback {
     f32 field73_0xc0;
     f32 field74_0xc4; // 1.0
 
-    f32 volume; // +0xfc (SetVolume clamps to 0..1)
-    f32 pitch;  // +0x100 (SetPitch clamps to >= 0)
-    u32 field_0x104;
-    u32 field_0x108;
+    VuVec position;
+    VuVec direction;
+    VuVec velocity;
+    f32 pitch;  // +0xf8
+    f32 volume; // +0xfc
+    f32 falloff_a; // +0x100
+    f32 falloff_b; // +0x104
+    u32 falloff_type; // +0x108
 
     f32 field113_0x10c; // LFE gain
-    u32 field114_0x110;
+    f32 field114_0x110;
     u32 field115_0x114; // 1
-    u32 field116_0x118;
+    u8 control_118;
+    u8 mix_flags;
+    u8 control_11a;
+    u8 control_11b;
 
     NuSoundBus *output_bus; // +0x11c, defaults to NuSoundSystem::sMasterBus
 
-    void *field121_0x120;
-    void *field122_0x124;
-    void *field123_0x128;
-    void *field124_0x12c;
-    void *field125_0x130;
-    void *field126_0x134;
-    u32 field127_0x138;
+    struct HandleLinks { NuSoundHandle *previous; NuSoundHandle *next; } handles_start, handles_end;
+    NuSoundHandle *handles_head;
+    NuSoundHandle *handles_tail;
+    u32 handle_count;
+    NuEList<NuSoundListener, DefaultElist> const *listeners;
 
     PlayState state; // +0x140, guarded by sStateCriticalSection
     f32 field130_0x144;
@@ -136,6 +128,11 @@ class NuSoundVoice : public NuSoundBufferCallback {
 
     // NuSoundBufferCallback: implemented by NuVoiceAndroid (the device write).
     void SubmitBuffer(NuSoundBuffer *buffer) override = 0;
+    virtual void CheckStarvedBuffers();
+    virtual u64 GetPlaybackPositionSamples() = 0;
+    virtual void Update(f32 frametime);
+    virtual bool CreateHardwareVoice() = 0;
+    virtual void DestroyHardwareVoice() = 0;
 
     // Play state.
     PlayState GetState() const;
@@ -155,7 +152,6 @@ class NuSoundVoice : public NuSoundBufferCallback {
     void UnregisterHandle(NuSoundHandle *handle);
 
     // Per-frame processing (NuSoundSystem::Update calls this on every voice).
-    void Update(f32 frametime);
     void UpdateMix(f32 frametime);
     void CalculatePositionalMix();
     bool BeginStopEffects();
@@ -164,49 +160,48 @@ class NuSoundVoice : public NuSoundBufferCallback {
     f32 CalculateEffectAttenuation();
     f32 CalculateEffectPitchScale();
     void UpdateEffects(f32 frametime, NuSoundEffect::EffectProcessStage stage);
-    void CheckStarvedBuffers();
 
     // Platform half, dispatched through the object vtable in the original.
     virtual void StartHardwareVoice() = 0;               // vtable +0x20
     virtual void StopHardwareVoice() = 0;                // vtable +0x24
     virtual void PauseHardwareVoice() = 0;               // vtable +0x28
     virtual void ResumeHardwareVoice() = 0;              // vtable +0x2c
-    virtual void UpdateHardwareVoice(f32 frametime) = 0; // vtable +0x30
+    virtual void UpdateHardwareVoice(f32 frametime) {  // vtable +0x30
+    }
     virtual void ApplyHardwareVoiceMix() = 0;            // vtable +0x34
-    virtual u64 GetPlaybackPositionSamples() = 0;
 
     // Remaining original surface (off the title music path; kept as stubs).
-    void AddEffect(NuSoundEffect *effect);
-    void CalculateFalloffAttenuation(f32 distance);
-    void CalculateFieldAngle(f32 angle);
+    bool AddEffect(NuSoundEffect *effect);
+    f32 CalculateFalloffAttenuation(f32 distance);
+    f32 CalculateFieldAngle(f32 distance);
     void CalculatePositionalCoefficients(f32 *gains, VuVec const &position, VuMtx const &mtx, f32 falloff_a,
                                          f32 falloff_b);
-    void GetControllerBits() const;
-    void GetDirection() const;
-    void GetDownmixerType() const;
-    void GetEffect(NuSoundEffect::EffectType type);
-    void GetFalloffType() const;
-    void GetFar() const;
-    void GetLowFrequencyMix() const;
-    void GetNear() const;
-    void GetNumEffects() const;
-    void GetOutputBus() const;
-    void GetPenetration() const;
-    void GetPitch() const;
-    void GetPlaybackPositionSeconds();
-    void GetPosition() const;
-    void GetReverbWetMix() const;
-    void GetRoutingTable() const;
-    void GetSpeakerBleedAngle() const;
-    void GetSpeakerBleedFar() const;
-    void GetSpeakerBleedNear() const;
-    void GetSpeakerFieldAngleMax() const;
-    void GetSpeakerFieldAngleMin() const;
-    void GetStartOffset() const;
-    void GetSurroundMode() const;
-    void GetVelocity() const;
-    void GetVolume() const;
-    void IsLooping() const;
+    i32 GetControllerBits() const;
+    const VuVec * GetDirection() const;
+    NuSoundSystem::DownmixType GetDownmixerType() const;
+    NuSoundEffect *GetEffect(NuSoundEffect::EffectType type);
+    NuSoundSystem::FalloffType GetFalloffType() const;
+    f32 GetFar() const;
+    f32 GetLowFrequencyMix() const;
+    f32 GetNear() const;
+    u32 GetNumEffects() const;
+    NuSoundBus * GetOutputBus() const;
+    f32 GetPenetration() const;
+    f32 GetPitch() const;
+    f32 GetPlaybackPositionSeconds();
+    const VuVec *GetPosition() const;
+    f32 GetReverbWetMix() const;
+    NuSoundRoutingTable * GetRoutingTable() const;
+    f32 GetSpeakerBleedAngle() const;
+    f32 GetSpeakerBleedFar() const;
+    f32 GetSpeakerBleedNear() const;
+    f32 GetSpeakerFieldAngleMax() const;
+    f32 GetSpeakerFieldAngleMin() const;
+    f32 GetStartOffset() const;
+    NuSoundSystem::SurroundMode GetSurroundMode() const;
+    const VuVec *GetVelocity() const;
+    f32 GetVolume() const;
+    bool IsLooping() const;
     void RemoveEffect(NuSoundEffect *effect);
     void SetControllerBits(i32 bits);
     void SetCustomSurroundMix(f32 *mix);
@@ -232,9 +227,6 @@ class NuSoundVoice : public NuSoundBufferCallback {
   protected:
     // The 3D positional state; only the surround_mode == 2 (2D omni) path is
     // exercised by the title music.
-    u32 surround_mode;
-    u8 falloff_type;
-    NuEList<NuSoundListener, DefaultElist> const *listeners;
 };
 
 class NuVoiceAndroid : public NuSoundVoice {
@@ -266,7 +258,7 @@ class NuVoiceAndroid : public NuSoundVoice {
     // NuSoundBufferCallback: the device write (Enqueue).
     void SubmitBuffer(NuSoundBuffer *buffer) override;
 
-    void CreateHardwareVoice();
+    bool CreateHardwareVoice();
     bool RealiseObject();
     bool GetInterfaces();
     void StartHardwareVoice() override;
@@ -275,7 +267,7 @@ class NuVoiceAndroid : public NuSoundVoice {
     void ResumeHardwareVoice() override;
     void UpdateHardwareVoice(f32 frametime) override;
     void ApplyHardwareVoiceMix() override;
-    void UpdateQueue();
+    bool UpdateQueue();
     bool UpdateState();
     void UpdateSamplePlaybackCount();
     u64 GetPlaybackPositionSamples() override;

--- a/src/nu2api/nusound/nusound_voice_android.cpp
+++ b/src/nu2api/nusound/nusound_voice_android.cpp
@@ -19,15 +19,17 @@
 #include "nu2api/nusound/nusound_streamer.hpp"
 
 #include <math.h>
+#include <stdio.h>
+#include <string.h>
 
 namespace {
 
     // OpenSL interface vtable slots as used by libTTapp.so.
     typedef u32 (*ObjectRealizeFn)(void *, u32);
-    typedef u32 (*ObjectResumeFn)(void *);
+    typedef u32 (*ObjectResumeFn)(void *, u32);
     typedef u32 (*ObjectGetStateFn)(void *, u32 *);
     typedef u32 (*ObjectGetInterfaceFn)(void *, const void *, void **);
-    typedef u32 (*ObjectDestroyFn)(void *);
+    typedef void (*ObjectDestroyFn)(void *);
     typedef u32 (*EngineCreateAudioPlayerFn)(void *, void **, void *, void *, u32, const void **, const u32 *);
     typedef u32 (*PlaySetPlayStateFn)(void *, u32);
     typedef u32 (*PlayGetPlayStateFn)(void *, u32 *);
@@ -36,10 +38,14 @@ namespace {
     typedef u32 (*PlaySetCallbackEventsMaskFn)(void *, u32);
     typedef u32 (*QueueEnqueueFn)(void *, void *, u32);
     typedef u32 (*QueueClearFn)(void *);
-    typedef u32 (*QueueGetStateFn)(void *, u32 *);
-    typedef u32 (*VolumeSetVolumeLevelFn)(void *, i32);
+    struct QueueState {
+        u32 count;
+        u32 index;
+    };
+    typedef u32 (*QueueGetStateFn)(void *, QueueState *);
+    typedef u32 (*VolumeSetVolumeLevelFn)(void *, i16);
     typedef u32 (*VolumeEnableStereoPositionFn)(void *, u32);
-    typedef u32 (*VolumeSetStereoPositionFn)(void *, i32);
+    typedef u32 (*VolumeSetStereoPositionFn)(void *, i16);
 
 #define SL_SLOT(itf, fn_type, byte_offset) (*(fn_type *)((char *)(*(void **)(itf)) + (byte_offset)))
 
@@ -56,7 +62,11 @@ NuVoiceAndroid::NuVoiceAndroid(NuSoundSource *sound_source, bool loop) : NuSound
     this->field4_0x158 = NULL;
     this->volume_interface = NULL;
 
-    pthread_mutex_init(&this->mutex, NULL);
+    pthread_mutexattr_t attributes;
+    pthread_mutexattr_init(&attributes);
+    pthread_mutexattr_settype(&attributes, 1);
+    pthread_mutex_init(&this->mutex, &attributes);
+    pthread_mutexattr_destroy(&attributes);
 
     this->field7_0x164 = 0;
     this->field8_0x168 = 0;
@@ -65,8 +75,7 @@ NuVoiceAndroid::NuVoiceAndroid(NuSoundSource *sound_source, bool loop) : NuSound
     this->field11_0x174 = 0;
     this->field12_0x178 = 0;
 
-    this->last_volume_level = -0x8000; // muted until the first mix arrives
-    this->hardware_flags = 0;
+    this->hardware_flags &= 0xf0;
 
     // libTTapp.so ctor tail (0x32c1ae): the platform voice builds its OpenSL
     // player immediately, before any Play.
@@ -89,14 +98,17 @@ void NuVoiceAndroid::SubmitBuffer(NuSoundBuffer *buffer) {
 
     u32 max_buffer_size = this->sound_source->GetMaxBufferSize();
     NuSoundBuffer::Context &context = buffer->GetCurrentContext();
-    // libTTapp.so 0x32bbbe: the enqueue length is the buffer context's
-    // read_size (the decoded/loaded byte count).
-    u32 size = (u32)context.read_size;
+    // libTTapp.so 0x32bbbe reads the context field at +8 for enqueue length.
+    u32 size = (u32)context.size2;
 
-    // The original formatted a debug line (source name + block count) that was
-    // never printed; it has no observable effect and is omitted here.
+    u32 block_count = size / this->sound_source->GetStreamDesc()->GetBlockSize();
 
     pthread_mutex_lock(&this->mutex);
+
+    char debug_line[256] = {0};
+    sprintf(debug_line + strlen(debug_line), "%s ", this->sound_source->GetName());
+    strcat(debug_line, "Submit   ");
+    sprintf(debug_line + strlen(debug_line), "%12d ", block_count);
 
     if (size != 0) {
         u32 error =
@@ -106,7 +118,7 @@ void NuVoiceAndroid::SubmitBuffer(NuSoundBuffer *buffer) {
     }
 
     if (size < max_buffer_size) {
-        this->flags2 |= 2; // 0x32bd0e
+        this->flags |= 2; // 0x32bd0e
         if (size == 0) {
             this->hardware_flags |= 2; // 0x32bd16
         }
@@ -119,61 +131,66 @@ void NuVoiceAndroid::SubmitBuffer(NuSoundBuffer *buffer) {
 // device lifecycle
 // ---------------------------------------------------------------------------
 
-void NuVoiceAndroid::CreateHardwareVoice() {
+bool NuVoiceAndroid::CreateHardwareVoice() {
     NuSoundSource *source = this->sound_source;
     if (source == NULL) {
-        return;
+        return false;
     }
     NuSoundStreamDesc *desc = source->GetStreamDesc();
     if (desc == NULL) {
-        return;
+        return false;
     }
 
-    u32 channels = (u32)desc->GetNumChannels();
-    if (channels != 1 && channels != 2) {
-        return;
+    u32 pcm_format[7];
+    pcm_format[0] = 2;
+    pcm_format[1] = desc->GetNumChannels();
+    if (pcm_format[1] == 1) {
+        pcm_format[5] = 4;
+    } else if (pcm_format[1] == 2) {
+        pcm_format[5] = 3;
+    } else {
+        return false;
     }
     // OpenSL speaker mask: front-centre for mono, front-left|front-right for
     // stereo.
-    u32 speaker_mask = (channels == 1) ? 4 : 3;
-
-    u32 rate_millis = (u32)desc->GetSampleRate() * 1000;
-    if (NuSoundAndroid::IsValidSampleRate(rate_millis) == false) {
-        return;
+    pcm_format[2] = desc->GetSampleRate() * 1000;
+    if (NuSoundAndroid::IsValidSampleRate(pcm_format[2]) == false) {
+        return false;
     }
 
-    u32 bits = (u32)desc->GetBitsPerChannel();
-    if (NuSoundAndroid::IsValidBitRate(bits) == false) {
-        return;
+    pcm_format[3] = desc->GetBitsPerChannel();
+    if (NuSoundAndroid::IsValidBitRate(pcm_format[3]) == false) {
+        return false;
     }
 
+    pcm_format[4] = desc->GetBitsPerChannel();
+    pcm_format[6] = 2;
     // SLDataLocator_AndroidSimpleBufferQueue { locator type, numBuffers = 2 }.
     u32 locator[2] = {0x800007bd, 2};
     // SLDataFormat_PCM { format type, channels, rate (milliHz), bits,
     // container bits, channel mask, little endian }.
-    u32 pcm_format[7] = {2, channels, rate_millis, bits, bits, speaker_mask, 2};
     void *audio_src[2] = {locator, pcm_format};
 
     // Output mix sink.
-    NuSoundSystem *system = NuSoundSystem::GetInstance();
-    void *mix_locator[2] = {(void *)4, system->output_mix};
+    void *mix_locator[2] = {(void *)4, NuSoundSystem::Get()->output_mix};
     void *audio_sink[2] = {mix_locator, NULL};
 
     const void *iids[2] = {SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_VOLUME};
     const u32 required[2] = {1, 1};
 
-    void *engine_itf = system->audio_engine;
-    u32 error = SL_SLOT(engine_itf, EngineCreateAudioPlayerFn, 8)(engine_itf, &this->player_object, audio_src,
+    EngineCreateAudioPlayerFn create_player =
+        SL_SLOT(NuSoundSystem::Get()->audio_engine, EngineCreateAudioPlayerFn, 8);
+    u32 error = create_player(NuSoundSystem::Get()->audio_engine, &this->player_object, audio_src,
                                                                   audio_sink, 2, iids, required);
     if (NuSoundAndroid::ReportErrorCode(error, "Create audio player") != 0) {
-        return;
+        return false;
     }
 
     if (this->RealiseObject() == false) {
-        return;
+        return false;
     }
 
-    this->GetInterfaces();
+    return this->GetInterfaces();
 }
 
 bool NuVoiceAndroid::RealiseObject() {
@@ -235,13 +252,13 @@ void NuVoiceAndroid::StopHardwareVoice() {
         return;
     }
 
-    u32 error = SL_SLOT(this->play_interface, PlaySetPlayStateFn, 4)(this->play_interface, 1);
+    u32 error = SL_SLOT(this->play_interface, PlaySetPlayStateFn, 0)(this->play_interface, 1);
     NuSoundAndroid::ReportErrorCode(error, "Set the player's state to stopped");
 
     error = SL_SLOT(this->queue_interface, QueueClearFn, 4)(this->queue_interface);
     NuSoundAndroid::ReportErrorCode(error, "Cleared the buffer queue");
 
-    this->flags2 &= 0xfd;
+    this->flags &= 0xfd;
 }
 
 void NuVoiceAndroid::PauseHardwareVoice() {
@@ -249,7 +266,7 @@ void NuVoiceAndroid::PauseHardwareVoice() {
         return;
     }
 
-    u32 error = SL_SLOT(this->play_interface, PlaySetPlayStateFn, 4)(this->play_interface, 2);
+    u32 error = SL_SLOT(this->play_interface, PlaySetPlayStateFn, 0)(this->play_interface, 2);
     NuSoundAndroid::ReportErrorCode(error, "Set the player's state to paused");
 }
 
@@ -258,7 +275,7 @@ void NuVoiceAndroid::ResumeHardwareVoice() {
         return;
     }
 
-    u32 error = SL_SLOT(this->play_interface, PlaySetPlayStateFn, 4)(this->play_interface, 3);
+    u32 error = SL_SLOT(this->play_interface, PlaySetPlayStateFn, 0)(this->play_interface, 3);
     NuSoundAndroid::ReportErrorCode(error, "Set the player's state to playing (resume)");
 }
 
@@ -299,13 +316,13 @@ bool NuVoiceAndroid::UpdateState() {
             return true;
         }
         // 0x32c260: object vtable slot 0x4 (SLObjectItf::Resume).
-        error = SL_SLOT(this->player_object, ObjectResumeFn, 4)(this->player_object);
+        error = SL_SLOT(this->player_object, ObjectResumeFn, 4)(this->player_object, 0);
         return NuSoundAndroid::ReportErrorCode(error, "resume the player object") == 0;
     }
 
     // Realized: a looping voice re-realizes and restarts per the voice state;
     // a non-looping voice is finished.
-    if ((this->flags2 & 8) != 0) {
+    if ((this->flags & 8) != 0) {
         if (this->RealiseObject() == false) {
             return false;
         }
@@ -335,33 +352,34 @@ bool NuVoiceAndroid::UpdateState() {
     return false;
 }
 
-void NuVoiceAndroid::UpdateQueue() {
+bool NuVoiceAndroid::UpdateQueue() {
     if (this->queue_interface == NULL || *(void **)this->queue_interface == NULL) {
-        return;
+        return true;
     }
 
-    u32 count = 0;
-    u32 error = SL_SLOT(this->queue_interface, QueueGetStateFn, 8)(this->queue_interface, &count);
+    QueueState state;
+    u32 error = SL_SLOT(this->queue_interface, QueueGetStateFn, 8)(this->queue_interface, &state);
     if (NuSoundAndroid::ReportErrorCode(error, "Get queue state") != 0) {
-        return;
+        return false;
     }
 
-    if (this->sound_source->feed_type == NuSoundSource::FeedType::STREAMING && (this->flags2 & 2) == 0) {
+    if (this->sound_source->feed_type == NuSoundSource::FeedType::STREAMING && (this->flags & 2) == 0) {
         // Starvation watchdog: remember whether the queue ever ran ahead, and
         // request a refill as soon as it runs low.
         // libTTapp.so 0x32c37e..0x32c3ad reads and writes voice+0x17e,
-        // NuVoiceAndroid::hardware_flags. Using NuSoundVoice::flags (+0x31)
+        // NuVoiceAndroid::hardware_flags. Using NuSoundVoice::flags (+0x30)
         // left bit 4 invisible to UpdateHardwareVoice and delayed every refill
         // until HEADATEND.
         if ((this->hardware_flags & 8) == 0) {
-            if (count > 1) {
+            if (state.count > 1) {
                 this->hardware_flags |= 8;
             }
-        } else if (count < 2) {
+        } else if (state.count < 2) {
             this->hardware_flags &= 0xf7;
             this->hardware_flags |= 4;
         }
     }
+    return true;
 }
 
 void NuVoiceAndroid::UpdateHardwareVoice(f32 frametime) {
@@ -380,14 +398,14 @@ void NuVoiceAndroid::UpdateHardwareVoice(f32 frametime) {
             this->Stop(true);
 
             u32 state = 3;
-            u32 error = SL_SLOT(this->play_interface, PlayGetPlayStateFn, 8)(this->play_interface, &state);
+            u32 error = SL_SLOT(this->play_interface, PlayGetPlayStateFn, 4)(this->play_interface, &state);
             NuSoundAndroid::ReportErrorCode(error, "Get the player state");
             if (state == 1) {
                 this->hardware_flags &= 0xfd;
             }
         }
     } else {
-        u32 error = SL_SLOT(this->play_interface, PlaySetPlayStateFn, 4)(this->play_interface, 3);
+        u32 error = SL_SLOT(this->play_interface, PlaySetPlayStateFn, 0)(this->play_interface, 3);
         u32 reported = NuSoundAndroid::ReportErrorCode(error, "Set the player's state to playing");
         if (reported == 0) {
             this->hardware_flags &= 0xfe;
@@ -398,9 +416,8 @@ void NuVoiceAndroid::UpdateHardwareVoice(f32 frametime) {
         // The queue drained: ask the source for the next buffer (streaming
         // fills are asynchronous through the streamer, the voice is the
         // callback).
-        NuSoundWeakPtr<NuSoundBufferCallback> callback;
-        callback.Set(this);
-        this->sound_source->RequestBuffer((this->flags2 >> 3) & 1, callback);
+        this->sound_source->RequestBuffer(
+            (this->flags >> 3) & 1, NuSoundWeakPtr<NuSoundBufferCallback>(this));
         this->hardware_flags &= 0xfb;
     }
 
@@ -414,12 +431,12 @@ void NuVoiceAndroid::ApplyHardwareVoiceMix() {
 
     f32 gain = this->field67_0xa8;
     i16 level = -0x8000;
-    if (gain >= 0.01f) {
+    if (!(gain < 0.01f)) {
         level = (i16)(i32)(log10((f64)gain) * 2000.0);
     }
 
     if (level != this->last_volume_level) {
-        u32 error = SL_SLOT(this->volume_interface, VolumeSetVolumeLevelFn, 0xc)(this->volume_interface, level);
+        u32 error = SL_SLOT(this->volume_interface, VolumeSetVolumeLevelFn, 0)(this->volume_interface, level);
         NuSoundAndroid::ReportErrorCode(error, "Volume SetVolumeLevel");
         this->last_volume_level = level;
     }
@@ -430,16 +447,21 @@ void NuVoiceAndroid::ApplyHardwareVoiceMix() {
         // Mono sources are panned through the stereo position interface from
         // the eight positional gains.
         f32 stereo_gains[64] = {0};
-        NuSoundMixer mixer((NuSoundSystem::ChannelConfig){1}, (NuSoundSystem::ChannelConfig){2},
-                           (NuSoundMixer::OutputLayout){1}, *(NuSoundSystem::DownmixType *)this->field16_0x3c,
-                           this->field15_0x38);
+        NuSoundMixer mixer(static_cast<NuSoundSystem::ChannelConfig>(1), static_cast<NuSoundSystem::ChannelConfig>(2),
+                           static_cast<NuSoundMixer::OutputLayout>(1), this->field15_0x38, this->field16_0x3c);
         mixer.Mix(this->mix_gains, stereo_gains);
+
+        f32 maximum = stereo_gains[0] > stereo_gains[1] ? stereo_gains[0] : stereo_gains[1];
+        i16 position = 0;
+        if (maximum > 0.0f) {
+            position = (i16)(i32)((stereo_gains[1] - stereo_gains[0]) * (1.0f / maximum) * 1000.0f);
+        }
 
         u32 error = SL_SLOT(this->volume_interface, VolumeEnableStereoPositionFn, 0x14)(this->volume_interface, 1);
         NuSoundAndroid::ReportErrorCode(error, "Volume EnableStereoPosition(true)");
 
         error = SL_SLOT(this->volume_interface, VolumeSetStereoPositionFn, 0x1c)(this->volume_interface,
-                                                                                 (i32)(stereo_gains[0] * 1000.0f));
+                                                                                 position);
         NuSoundAndroid::ReportErrorCode(error, "Volume SetStereoPosition");
     } else {
         u32 error = SL_SLOT(this->volume_interface, VolumeEnableStereoPositionFn, 0x14)(this->volume_interface, 0);
@@ -456,21 +478,24 @@ void NuVoiceAndroid::OnPlayerEvent(u32 event) {
         return;
     }
 
-    pthread_mutex_lock(&this->mutex);
-
-    bool finished;
     if (this->sound_source->feed_type == NuSoundSource::FeedType::STREAMING) {
+        pthread_mutex_lock(&this->mutex);
         // Streaming: a looping stream always refills; a non-looping one stops
         // refilling once its last buffer has been queued.
-        finished = (this->flags2 & 8) == 0 && (this->flags2 & 2) != 0;
+        if ((this->flags & 8) != 0) {
+            this->hardware_flags |= 4;
+        } else if ((this->flags & 2) != 0) {
+            this->hardware_flags |= 2;
+        } else {
+            this->hardware_flags |= 4;
+        }
     } else {
-        finished = (this->flags2 & 8) == 0;
-    }
-
-    if (finished) {
-        this->hardware_flags |= 2; // 0x32c8c3
-    } else {
-        this->hardware_flags |= 4; // 0x32c900
+        pthread_mutex_lock(&this->mutex);
+        if ((this->flags & 8) != 0) {
+            this->hardware_flags |= 4;
+        } else {
+            this->hardware_flags |= 2;
+        }
     }
 
     pthread_mutex_unlock(&this->mutex);
@@ -500,7 +525,7 @@ void NuVoiceAndroid::UpdateSamplePlaybackCount() {
 
     NuSoundSource *source = this->sound_source;
     NuSoundStreamDesc *desc = source->GetStreamDesc();
-    u32 rate = (u32)desc->GetSampleRate();
+    i32 rate = desc->GetSampleRate();
     u32 position = (rate / 1000) * millisec;
 
     if (source->feed_type != NuSoundSource::FeedType::STREAMING) {
@@ -512,21 +537,22 @@ void NuVoiceAndroid::UpdateSamplePlaybackCount() {
     // Streaming sources report a block-wrapped position: the device position
     // counts inside the two stream buffers, the wrap counters turn it into an
     // absolute sample count.
-    u32 max_buffer_size = source->GetMaxBufferSize();
-    u32 block_size = (u32)desc->GetBlockSize();
+    i32 max_buffer_size = source->GetMaxBufferSize();
+    i32 block_size = desc->GetBlockSize();
     u64 block_samples = (u64)max_buffer_size / (u64)block_size;
+    u64 block_position = (u64)position % block_samples;
 
     u64 prev = ((u64)(u32)this->field8_0x168 << 32) | (u32)this->field7_0x164;
-    if (position < (u32)(prev >> 32) || (position == (u32)(prev >> 32) && position < (u32)prev)) {
-        u32 wrap_lo = this->field9_0x16c + 1;
-        this->field10_0x170 += (u32)(this->field9_0x16c + 1 < wrap_lo ? 0 : 1);
-        this->field9_0x16c = wrap_lo;
-    }
-    this->field7_0x164 = (i32)position;
-    this->field8_0x168 = (i32)((u64)position >> 32);
-
     u64 wrap = ((u64)(u32)this->field10_0x170 << 32) | (u32)this->field9_0x16c;
-    u64 estimate = (u64)(position % (u32)block_samples) + block_samples * wrap;
+    if (block_position < prev) {
+        ++wrap;
+        this->field9_0x16c = (i32)wrap;
+        this->field10_0x170 = (i32)(wrap >> 32);
+    }
+    this->field7_0x164 = (i32)block_position;
+    this->field8_0x168 = (i32)(block_position >> 32);
+
+    u64 estimate = block_position + block_samples * wrap;
 
     u64 samples;
     if ((estimate >> 32) != 0 || position < (u32)estimate) {
@@ -558,9 +584,18 @@ NuSoundVoice *NuSoundVoiceFactoryAndroid_PCM::CreateVoice(NuSoundSource *source,
 }
 
 NuSoundVoiceFactoryList::NuSoundVoiceFactoryList() {
-    for (u32 i = 0; i < 16; i++) {
-        this->factories[i] = NULL;
+    factories = NULL;
+    capacity = 0;
+    count = 0;
+    NuSoundVoiceFactory **storage = static_cast<NuSoundVoiceFactory **>(
+        NuMemoryGet()->GetThreadMem()->_BlockReAlloc(NULL, 16 * sizeof(*factories), 4, 0x41, "", 0));
+    if (storage != factories) {
+        for (u32 i = 0; i < count; i++) storage[i] = factories[i];
+        NuMemoryGet()->GetThreadMem()->BlockFree(factories, 0);
     }
+    capacity = 16;
+    factories = storage;
+    count = 16;
 }
 
 void NuSoundVoiceFactoryList::RegisterFactory(NuSoundVoiceFactory *factory, NuSoundStreamDesc::DataFormat format) {

--- a/src/nu2api/nusound/nusound_weakptr.cpp
+++ b/src/nu2api/nusound/nusound_weakptr.cpp
@@ -4,5 +4,51 @@ NuCriticalSection NuSoundWeakPtrListNode::sPtrListLock("NuSoundCriticalSection::
 NuCriticalSection NuSoundWeakPtrListNode::sPtrAccessLock("NuSoundCriticalSection::mCriticalSection");
 
 class NuSoundBufferCallback;
+
+// The original callback/OGG destructors call this shared template body.
+template <typename T> NuSoundWeakPtrObj<T>::~NuSoundWeakPtrObj() {
+    NuSoundWeakPtrListNode::sPtrListLock.Lock();
+
+    NuSoundWeakPtrListNode *node = GetLinks(head)->next;
+    while (node != tail) {
+        node->Clear();
+        node = node->next;
+    }
+
+    while (weak_count != 0) {
+        node = GetLinks(head)->next;
+        if (node->prev != NULL) GetLinks(node->prev)->next = node->next;
+        if (node->next != NULL) GetLinks(node->next)->prev = node->prev;
+        node->next = NULL;
+        node->prev = NULL;
+        --weak_count;
+    }
+
+    NuSoundWeakPtrListNode::sPtrListLock.Unlock();
+
+    // The embedded list's destructor follows the owner's locked detach pass.
+    while (weak_count != 0) {
+        node = GetLinks(head)->next;
+        if (node->prev != NULL) GetLinks(node->prev)->next = node->next;
+        if (node->next != NULL) GetLinks(node->next)->prev = node->prev;
+        node->next = NULL;
+        node->prev = NULL;
+        --weak_count;
+        delete node;
+    }
+}
+
+template <typename T> void NuSoundWeakPtr<T>::Set(T *ptr) {
+    NuSoundWeakPtrListNode::sPtrListLock.Lock();
+    if (this->obj != (void *)ptr) {
+        if (this->obj != NULL) this->obj->Unlink(this);
+        if (ptr != NULL) ((NuSoundWeakPtrObj<T> *)ptr)->Link(this);
+        this->obj = (NuSoundWeakPtrObj<T> *)ptr;
+    }
+    NuSoundWeakPtrListNode::sPtrListLock.Unlock();
+}
+
 template class NuSoundWeakPtrObj<NuSoundBufferCallback>;
 template class NuSoundWeakPtr<NuSoundBufferCallback>;
+class NuSoundVoice;
+template void NuSoundWeakPtr<NuSoundVoice>::Set(NuSoundVoice *);

--- a/src/nu2api/nusound/nusound_weakptr.hpp
+++ b/src/nu2api/nusound/nusound_weakptr.hpp
@@ -27,71 +27,63 @@ struct NuSoundWeakPtrListNode {
 
 template <typename T> class NuSoundWeakPtrObj {
   public:
-    u8 padding[0x14];
+    struct Links { NuSoundWeakPtrListNode *prev; NuSoundWeakPtrListNode *next; } start, end;
 
     NuSoundWeakPtrListNode *head;
     NuSoundWeakPtrListNode *tail;
     i32 weak_count;
 
   public:
+    static Links *GetLinks(NuSoundWeakPtrListNode *node) {
+        return node != NULL
+                   ? reinterpret_cast<Links *>(reinterpret_cast<char *>(node) + sizeof(void *))
+                   : NULL;
+    }
+
+    NuSoundWeakPtrObj() {
+        head = reinterpret_cast<NuSoundWeakPtrListNode *>(reinterpret_cast<char *>(&start) - sizeof(void *));
+        tail = reinterpret_cast<NuSoundWeakPtrListNode *>(reinterpret_cast<char *>(&end) - sizeof(void *));
+        start.prev = NULL;
+        start.next = tail;
+        end.prev = head;
+        end.next = NULL;
+        weak_count = 0;
+    }
+
     void Link(NuSoundWeakPtrListNode *node) {
         NuSoundWeakPtrListNode::sPtrListLock.Lock();
 
-        // Append the node at the tail of this object's weak-pointer list
-        // (libTTapp.so 0x315320: the new node chains onto the current tail
-        // and the list bookkeeping moves to it).
-        node->prev = this->tail;
-        node->next = NULL;
-
-        if (this->tail != NULL) {
-            this->tail->next = node;
-        } else {
-            this->head = node;
-        }
-
-        this->tail = node;
+        NuSoundWeakPtrListNode *insertion_point = tail;
+        Links *tail_links = GetLinks(insertion_point);
+        NuSoundWeakPtrListNode *previous = tail_links->prev;
+        tail_links->prev = node;
+        node->prev = previous;
+        GetLinks(previous)->next = node;
+        node->next = insertion_point;
         this->weak_count++;
 
         NuSoundWeakPtrListNode::sPtrListLock.Unlock();
     }
 
     void Unlink(NuSoundWeakPtrListNode *node) {
-        LOG_DEBUG("Unlinking node %p from weak pointer list %p", node, this);
-
         NuSoundWeakPtrListNode::sPtrListLock.Lock();
 
-        if (node->prev != NULL) {
-            node->prev->next = node->next;
-        } else {
-            this->head = node->next;
+        if (node->next != NULL || node->prev != NULL) {
+            --this->weak_count;
+            if (node->prev != NULL) {
+                GetLinks(node->prev)->next = node->next;
+            }
+            if (node->next != NULL) {
+                GetLinks(node->next)->prev = node->prev;
+            }
+            node->next = NULL;
+            node->prev = NULL;
         }
-        if (node->next != NULL) {
-            node->next->prev = node->prev;
-        } else {
-            this->tail = node->prev;
-        }
-
-        this->weak_count--;
-
-        node->prev = NULL;
-        node->next = NULL;
 
         NuSoundWeakPtrListNode::sPtrListLock.Unlock();
     }
 
-    ~NuSoundWeakPtrObj() {
-        NuSoundWeakPtrListNode::sPtrListLock.Lock();
-
-        // Drop every weak pointer still registered against this object.
-        NuSoundWeakPtrListNode *node = this->head;
-        while (node != NULL) {
-            NuSoundWeakPtrListNode *next = node->next;
-            node->Clear();
-            node = next;
-        }
-
-        NuSoundWeakPtrListNode::sPtrListLock.Unlock();
-    }
+    virtual ~NuSoundWeakPtrObj();
 };
 
 template <typename T> class NuSoundWeakPtr : public NuSoundWeakPtrListNode {
@@ -100,6 +92,25 @@ template <typename T> class NuSoundWeakPtr : public NuSoundWeakPtrListNode {
 
   public:
     NuSoundWeakPtr() : obj(NULL) {
+        this->prev = NULL;
+        this->next = NULL;
+    }
+
+    explicit NuSoundWeakPtr(T *ptr) : obj(NULL) {
+        this->prev = NULL;
+        this->next = NULL;
+        this->Set(ptr);
+    }
+
+    NuSoundWeakPtr(const NuSoundWeakPtr &other) : obj(NULL) {
+        this->prev = NULL;
+        this->next = NULL;
+        this->Set((T *)other.obj);
+    }
+
+    NuSoundWeakPtr &operator=(const NuSoundWeakPtr &other) {
+        this->Set((T *)other.obj);
+        return *this;
     }
 
     virtual ~NuSoundWeakPtr() {
@@ -117,22 +128,5 @@ template <typename T> class NuSoundWeakPtr : public NuSoundWeakPtrListNode {
         this->obj = NULL;
     }
 
-    void Set(T *ptr) {
-        NuSoundWeakPtrListNode::sPtrListLock.Lock();
-
-        if (this->obj != (void *)ptr) {
-            if (this->obj != NULL) {
-                this->obj->Unlink(this);
-            }
-
-            if (ptr != NULL) {
-                // Register this weak pointer in the target's list.
-                ((NuSoundWeakPtrObj<T> *)ptr)->Link(this);
-            }
-
-            this->obj = (NuSoundWeakPtrObj<T> *)ptr;
-        }
-
-        NuSoundWeakPtrListNode::sPtrListLock.Unlock();
-    }
+    void Set(T *ptr);
 };


### PR DESCRIPTION
The reconstructed library lacked the JNI and Android runtime implementations needed by the original APK. This restores activity/surface/input and asset/OBB interfaces, EGL/GLES setup, OpenSL ES and sound runtime behavior, and associated rendering dependencies. An NDK r8e ARMv7 target now builds a replacement `libTTapp.so` while retaining the original APK's Java code.

Platform selection stays in the toolchain, ABI assertions, and host compatibility boundary. Per-source optimization and source ownership were corrected from the original instruction shapes. No injected assembly, new per-function optimization attributes, assertion bypasses, or matching-score exceptions were added.

**ARMv7 is only for runtime testing on real Android hardware, not for assembly matching.** Android x86 (`--config=target`) remains the matching target against `res/libTTapp.so`. Every matching percentage and regression comparison below and in the generated report is for x86. ARM ABI/layout checks support device execution; they do not establish an ARM matching target.

### Matching against main (Android x86)

Compared independent builds of main `90c48f9261ac37d1ec8944d0f00f299774034af4` and this branch against the same reference ELF using **ttdecomp objdiff-cli 3.8.1**. The main working checkout was not used. `matching.json` and the README were regenerated with the report generator used by pre-commit.

| Metric | Main | This PR |
|---|---:|---:|
| Whole-binary fuzzy match | 18.173262% | 19.808786% |
| Exact function matches | 1,021 | 1,182 |
| Exact matched code bytes | 40,829 | 44,456 |

**+1.635524 percentage points; +161 exact function matches; no lost exact matches.**

Regression cleanup reduced 126 named score declines to four, all below one percentage point. These remaining register/scheduling and linked-address differences are explicitly retained, not hidden:

| Function | Main | This PR | Original bytes |
|---|---:|---:|---:|
| `NuRenderDevice::SelectEGLConfig()` | 96.884610% | 96.019230% | 247 |
| `NuHGobjEvalAnim2Root_3` | 99.932205% | 99.677960% | 257 |
| `NuVisiEvaluate` | 96.850000% | 96.662500% | 312 |
| `NuHGobjRndrMtxDwa` | 53.963577% | 53.913906% | 1,122 |

These functions contain 1,938 original bytes in total. Their combined decrease is 3.933207 fuzzy-weighted byte equivalents, not a literal changed-byte count.

### Validation

- x86 target and ARMv7 builds pass; target linkage rejects undefined references.
- Full WebAssembly build passes locally on Windows, including HTML/JS/WASM linking.
- All four repository checks pass: optimization map, duplicate definitions, host boundary, and Pages tests.
- Symbol check passes: no unignored missing symbols and no extra-symbol baseline changes.
- `git diff --check` passes.
- Full optional pre-commit/native/clang-tidy coverage remains unverified on this host; required pkg-config development dependencies are missing. Its report generator and the checks above were run separately.

### Host build compatibility

The WASM/native build follow-up scopes Android layout checks through the existing `DECOMP_ASSERT` boundary, adds the missing `<cfloat>` include, fixes native root-source selection to use the JNI stub, and separates the Android GLES extension-pointer table from a host adapter with private storage names. This avoids collisions with Emscripten's GL function exports. Android matching scores remain unchanged after these fixes.

### Device limitation

An earlier ARM build installed in the original APK reached its title/splash on a OnePlus N200 running Android 12. **Touch did not respond, and menu/gameplay is not verified.** The final matching fixes have not been retested on the device. This PR does not claim complete Android playability.

The replacement Java application, APKs, device backups, signing material, and logs are excluded. See `doc/android-matching.md` for the implementation and validation record.
