### PR TITLE
Checkpoint gameplay flow and results decompilation

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -230,7 +230,7 @@
   "moduleExtensions": {
     "@@emsdk+//:emscripten_cache.bzl%emscripten_cache": {
       "general": {
-        "bzlTransitiveDigest": "TxiJJMUJEr/iCqE9Twl5vHvpI8PoR3B7R6bOc67o4C8=",
+        "bzlTransitiveDigest": "wgEOVL/Fy/GcNauGIfYibujPx+UQZdExgMRnYUSm8LE=",
         "usagesDigest": "3FZOrh6cgKSGsvsDdttegirGE5eRTUH7+qTAtZ7PDqE=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # _saga_
 
-![Progress](https://img.shields.io/badge/matching-25.23%25-red)
+![Progress](https://img.shields.io/badge/matching-25.70%25-red)
 [![Bazel build](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml/badge.svg)](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml)
 [![Discord](https://img.shields.io/discord/1467775700894224555?color=%235865F2&logo=discord&logoColor=%23FFFFFF)](https://discord.gg/2HJuMtzA7q)
 [![status & wasm build](https://img.shields.io/badge/status%20%26%20wasm%20build-click%20here-orange?style=flat)](https://ttdecomp.github.io/saga/)
@@ -61,27 +61,27 @@ See https://ttdecomp.github.io/saga/
 | `(root)` | 61.8% | 0.0% |
 | `MechInputTouch` | 9.7% | 6.1% |
 | `editor` | 3.2% | 1.7% |
-| `gameapi` | 14.8% | 1.8% |
+| `gameapi` | 15.0% | 1.8% |
 | `gameframework` | 99.9% | 5.9% |
 | `gamelib` | 15.9% | 4.9% |
 | `java` | 96.0% | 0.0% |
-| `legoapi` | 20.2% | 8.1% |
+| `legoapi` | 20.9% | 8.1% |
 | `legoapi/actions` | 10.9% | 1.3% |
 | `legoapi/ai` | 16.2% | 0.0% |
 | `legoapi/audio` | 53.0% | 10.3% |
-| `legoapi/characters` | 19.5% | 5.7% |
+| `legoapi/characters` | 20.0% | 5.7% |
 | `legoapi/core` | 25.6% | 6.6% |
-| `legoapi/cutscenes` | 28.6% | 3.9% |
-| `legoapi/gizmo` | 16.9% | 3.9% |
-| `legoapi/gizmos` | 42.7% | 30.8% |
-| `legoapi/items` | 12.8% | 4.1% |
-| `legoapi/menus` | 17.0% | 6.2% |
-| `legoapi/misc` | 11.0% | 4.0% |
+| `legoapi/cutscenes` | 31.2% | 3.9% |
+| `legoapi/gizmo` | 17.3% | 3.9% |
+| `legoapi/gizmos` | 42.6% | 30.8% |
+| `legoapi/items` | 14.0% | 4.1% |
+| `legoapi/menus` | 19.8% | 6.4% |
+| `legoapi/misc` | 11.3% | 4.1% |
 | `legoapi/props` | 28.8% | 2.2% |
-| `legoapi/render` | 15.7% | 7.3% |
+| `legoapi/render` | 16.7% | 7.3% |
 | `legoapi/world` | 24.6% | 6.4% |
-| `legogame` | 57.2% | 10.7% |
-| `nu2api` | 42.0% | 19.1% |
+| `legogame` | 57.3% | 10.7% |
+| `nu2api` | 42.2% | 19.2% |
 
 <!-- matching-table-end -->
 

--- a/doc/decomp/12-gameplay-regression-audit.md
+++ b/doc/decomp/12-gameplay-regression-audit.md
@@ -146,6 +146,53 @@ Ghidra. Both gate group selection on the original loaded-sample state.
 `PickupCoin` and `LegoSingle` are groups in the shipped configuration;
 their missing playback still needs loaded-state/runtime tracing.
 
+## Flow-loader checkpoint (in progress)
+
+The two-pass `LoadGizFlow` parser and its box, collapse, condition, action,
+and gizmo callbacks are reconstructed from the original binary. Timer,
+random, and special constructors now return the registered gizmo, as the
+loader expects. Runtime allocations use the recovered structure sizes.
+
+This remains unfinished: `ResetGizFlow`, `ResetGizFlowPointers`, and
+`ProcessGizFlow` still need reconstruction before level-object visibility
+and progression can be considered fixed. No successful gameplay result is
+claimed for this checkpoint. Initial target comparison gives `LoadGizFlow`
+79.453%, `createGizSpecial` 87.879%, `createGizRandom` 13.991%, and
+`createGizTimer` 0%. The latter two retain their current default optimization
+settings; their original optimized instruction shapes remain unresolved.
+
+## End-level results reconstruction (in progress)
+
+The original results-stage table at ELF `0x6236c0` contains 34 records of
+`0x20` bytes, including its sentinel. Registration, coin counting/drawing,
+prompt menu drawing/input, save-stage control, packet finishing, and
+exit/fade updates have been reconstructed from the original functions.
+`STATUSPACKET_s` remains `0x14c` bytes; callback and result fields now have
+types matching their original offsets.
+
+This is **not yet a fix for the black screen**. `InitStatusScreen` remains
+unimplemented, as do several award draw/update callbacks. Its original
+`0x18ab`-byte implementation creates the mode-specific stage sequence and
+performs completion/reward bookkeeping. Do not bypass these stages or
+substitute unconditional rewards to make the screen advance. Original
+pseudocode alone is insufficient to call the reconstruction matched.
+
+One dependency had conflated `StatusCollectList` with `Game_CompletionSave`.
+The former is eight character IDs, terminated by `-1`; the latter points
+at completion points, gold-brick count, and completion flags. The original
+`newCharactersCollected` returns the number of IDs. Its list and return
+value are now recovered, and completion queries use the original save
+pointer instead of interpreting those IDs as a pointer.
+
+`AddGoldBrickMessage` belongs with the results-screen-local
+`goldbrickmsgcount`, returns `1`, and resets through the results initializer.
+Its reconstructed instruction sequence matches apart from address/layout
+operands (objdiff **99.824%**, original size 68 bytes).
+`LevelComplete_LSW_Update` is only **51.968%** matched; its control flow has
+been reconstructed, but it is not an instruction match. Target and native
+builds pass. No end-level runtime success or Cantina return has been
+verified for this work yet.
+
 ## Pickup mode filtering and priority sound dispatch
 
 `GizmoPickups_SetOnOff` was empty. Its original mode-dependent pickup-type

--- a/matching.json
+++ b/matching.json
@@ -1,16 +1,16 @@
 {
   "schema_version": 1,
   "measures": {
-    "fuzzy_match_percent": 25.23344,
+    "fuzzy_match_percent": 25.69756,
     "total_code": "4722419",
-    "matched_code": "55981",
-    "matched_code_percent": 1.1854305,
+    "matched_code": "55990",
+    "matched_code_percent": 1.1856213,
     "total_data": "14606528",
     "matched_data": "543696",
     "matched_data_percent": 3.722281,
     "total_functions": 13459,
-    "matched_functions": 1256,
-    "matched_functions_percent": 9.332046,
+    "matched_functions": 1257,
+    "matched_functions_percent": 9.339476,
     "total_units": 1
   },
   "text": {
@@ -22348,7 +22348,7 @@
           "address": 1615696,
           "offset": 725728,
           "size": 920,
-          "match_percent": 2.466368
+          "match_percent": 74.65022
         },
         {
           "name": "_ZL20Action_ReleaseVictimP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPPciif",
@@ -22596,7 +22596,7 @@
           "address": 1639968,
           "offset": 750000,
           "size": 616,
-          "match_percent": 29.76
+          "match_percent": 29.845715
         },
         {
           "name": "_ZL20Action_CompleteLevelP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPPciif",
@@ -22748,7 +22748,7 @@
           "address": 1652784,
           "offset": 762816,
           "size": 704,
-          "match_percent": 9.751351
+          "match_percent": 9.67027
         },
         {
           "name": "_ZL19Action_SetStateAreaP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPPciif",
@@ -22780,7 +22780,7 @@
           "address": 1659392,
           "offset": 769424,
           "size": 797,
-          "match_percent": 74.99074
+          "match_percent": 75.19907
         },
         {
           "name": "_ZL22Action_SetUseOneAtOnceP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPPciif",
@@ -22868,7 +22868,7 @@
           "address": 1668208,
           "offset": 778240,
           "size": 733,
-          "match_percent": 2.251309
+          "match_percent": 77.13612
         },
         {
           "name": "_ZL16Action_AddDebrisP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPPciif",
@@ -23148,7 +23148,7 @@
           "address": 1713520,
           "offset": 823552,
           "size": 6967,
-          "match_percent": 1.035887
+          "match_percent": 1.042788
         },
         {
           "name": "_ZL15Condition_TimerP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPcPv",
@@ -23500,7 +23500,7 @@
           "address": 4140224,
           "offset": 3250256,
           "size": 663,
-          "match_percent": 96.820984
+          "match_percent": 96.54321
         },
         {
           "name": "_ZL18Action_GoToLocatorP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPPciif",
@@ -45415,7 +45415,7 @@
           "address": 1157024,
           "offset": 267056,
           "size": 372,
-          "match_percent": 45.83654
+          "match_percent": 44.634617
         },
         {
           "name": "_ZL13ActionMusicFnv",
@@ -46595,7 +46595,7 @@
           "address": 2022720,
           "offset": 1132752,
           "size": 218,
-          "match_percent": 7.924528
+          "match_percent": 68.471695
         },
         {
           "name": "_Z21CollectCharcters_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -46603,7 +46603,7 @@
           "address": 2022944,
           "offset": 1132976,
           "size": 1409,
-          "match_percent": 1.726619
+          "match_percent": 77.13669
         },
         {
           "name": "_Z21CollectCharcters_SkipP14STATUS_STAGE_sP14STATUSPACKET_s",
@@ -46611,7 +46611,7 @@
           "address": 2024368,
           "offset": 1134400,
           "size": 131,
-          "match_percent": 10.0
+          "match_percent": 99.95238
         },
         {
           "name": "_Z27CollectCharactersOff_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -46619,7 +46619,7 @@
           "address": 2027184,
           "offset": 1137216,
           "size": 101,
-          "match_percent": 15.0
+          "match_percent": 64.96429
         },
         {
           "name": "_Z23CollectCharcters_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -46627,7 +46627,7 @@
           "address": 2034256,
           "offset": 1144288,
           "size": 321,
-          "match_percent": 6.176471
+          "match_percent": 99.92647
         },
         {
           "name": "_Z28TakeOverYodaSeekDistanceHackP12GameObject_sS0_P7nuvec_s",
@@ -46667,7 +46667,7 @@
           "address": 2428896,
           "offset": 1538928,
           "size": 342,
-          "match_percent": 8.035714
+          "match_percent": 32.0
         },
         {
           "name": "_Z9MapToGridP7nuvec_sS0_PiS1_S0_P14nutexmanager_s",
@@ -46905,7 +46905,7 @@
           "address": 1989104,
           "offset": 1099136,
           "size": 352,
-          "match_percent": 0.0
+          "match_percent": 70.29091
         },
         {
           "name": "_Z16RegenerateHeartsP12GameObject_s",
@@ -51284,7 +51284,7 @@
           "address": 2019824,
           "offset": 1129856,
           "size": 9,
-          "match_percent": 27.5
+          "match_percent": 32.5
         },
         {
           "name": "_Z17GetClientMineInfoPP7nuvec_sPPyS3_",
@@ -51300,7 +51300,7 @@
           "address": 2447232,
           "offset": 1557264,
           "size": 732,
-          "match_percent": 1.27907
+          "match_percent": 0.0
         },
         {
           "name": "_Z18FinishLoop_Networkv",
@@ -52747,7 +52747,7 @@
           "address": 2020112,
           "offset": 1130144,
           "size": 118,
-          "match_percent": 12.352942
+          "match_percent": 39.411766
         },
         {
           "name": "_Z18GoldBrick_LSW_SkipP14STATUS_STAGE_sP14STATUSPACKET_s",
@@ -52755,7 +52755,7 @@
           "address": 2020240,
           "offset": 1130272,
           "size": 49,
-          "match_percent": 32.307693
+          "match_percent": 99.84615
         },
         {
           "name": "_Z20GoldBrick_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -52763,7 +52763,7 @@
           "address": 2024512,
           "offset": 1134544,
           "size": 1134,
-          "match_percent": 1.85022
+          "match_percent": 66.202644
         },
         {
           "name": "_Z15Fade_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -52771,7 +52771,7 @@
           "address": 2026784,
           "offset": 1136816,
           "size": 230,
-          "match_percent": 6.363637
+          "match_percent": 47.454544
         },
         {
           "name": "_Z15Exit_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -52779,7 +52779,7 @@
           "address": 2027024,
           "offset": 1137056,
           "size": 153,
-          "match_percent": 10.769231
+          "match_percent": 99.589745
         },
         {
           "name": "_Z24LevelComplete_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -52787,7 +52787,7 @@
           "address": 2033632,
           "offset": 1143664,
           "size": 609,
-          "match_percent": 3.333333
+          "match_percent": 51.968254
         },
         {
           "name": "_Z18GoldBrick_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -52795,7 +52795,7 @@
           "address": 2035824,
           "offset": 1145856,
           "size": 1047,
-          "match_percent": 2.153846
+          "match_percent": 47.964104
         },
         {
           "name": "_Z22LevelComplete_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -52803,7 +52803,7 @@
           "address": 2044928,
           "offset": 1154960,
           "size": 274,
-          "match_percent": 6.268657
+          "match_percent": 0.0
         },
         {
           "name": "_Z16RelocateCutSceneP13NUGCUTSCENE_sP9variptr_u",
@@ -54636,7 +54636,7 @@
           "address": 4912832,
           "offset": 4022864,
           "size": 373,
-          "match_percent": 98.77686
+          "match_percent": 98.900826
         },
         {
           "name": "_Z12LoadGizmoSysP10GIZMOSYS_sPvPc",
@@ -54700,7 +54700,7 @@
           "address": 4934432,
           "offset": 4044464,
           "size": 563,
-          "match_percent": 3.828125
+          "match_percent": 79.453125
         },
         {
           "name": "_Z25GizmoBlowupResetNameTablev",
@@ -57482,7 +57482,7 @@
           "address": 4944528,
           "offset": 4054560,
           "size": 332,
-          "match_percent": 12.833333
+          "match_percent": 13.990741
         }
       ]
     },
@@ -57521,7 +57521,7 @@
           "address": 4940784,
           "offset": 4050816,
           "size": 409,
-          "match_percent": 4.242424
+          "match_percent": 87.878784
         },
         {
           "name": "_Z18GizSpecial_GetNameP12GIZSPECIAL_s",
@@ -57560,7 +57560,7 @@
           "address": 4938080,
           "offset": 4048112,
           "size": 220,
-          "match_percent": 4.230769
+          "match_percent": 0.0
         }
       ]
     },
@@ -61254,7 +61254,7 @@
           "address": 1871904,
           "offset": 981936,
           "size": 5493,
-          "match_percent": 3.968186
+          "match_percent": 0.0
         },
         {
           "name": "_Z22GizForce_RegisterGizmoi",
@@ -62713,7 +62713,7 @@
           "address": 4695280,
           "offset": 3805312,
           "size": 125,
-          "match_percent": 10.769231
+          "match_percent": 85.92308
         },
         {
           "name": "_Z15AddToGoldBricksv",
@@ -62721,7 +62721,7 @@
           "address": 4695456,
           "offset": 3805488,
           "size": 130,
-          "match_percent": 10.243902
+          "match_percent": 86.36585
         },
         {
           "name": "_Z15ResetCoinPacketP12COINPACKET_s",
@@ -62793,7 +62793,7 @@
           "address": 5097280,
           "offset": 4207312,
           "size": 2688,
-          "match_percent": 0.777778
+          "match_percent": 31.779629
         },
         {
           "name": "_Z23Collection_GotAnyOfTypeij",
@@ -62809,7 +62809,7 @@
           "address": 5100384,
           "offset": 4210416,
           "size": 143,
-          "match_percent": 0.0
+          "match_percent": 94.8
         },
         {
           "name": "_Z20Collection_GetIDListP12COLLECTION_sjjPsPiS2_i",
@@ -64047,7 +64047,7 @@
           "address": 2020352,
           "offset": 1130384,
           "size": 34,
-          "match_percent": 42.0
+          "match_percent": 99.9
         },
         {
           "name": "_Z16MiniKit_LSW_SkipP14STATUS_STAGE_sP14STATUSPACKET_s",
@@ -64055,7 +64055,7 @@
           "address": 2022000,
           "offset": 1132032,
           "size": 141,
-          "match_percent": 12.352942
+          "match_percent": 90.5
         },
         {
           "name": "_Z18MiniKit_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -64063,7 +64063,7 @@
           "address": 2025648,
           "offset": 1135680,
           "size": 1130,
-          "match_percent": 2.060086
+          "match_percent": 66.39914
         },
         {
           "name": "_Z22AllMiniKits_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -64071,7 +64071,7 @@
           "address": 2028512,
           "offset": 1138544,
           "size": 231,
-          "match_percent": 7.636363
+          "match_percent": 56.563637
         },
         {
           "name": "_Z20AllMiniKits_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -64079,7 +64079,7 @@
           "address": 2046832,
           "offset": 1156864,
           "size": 1467,
-          "match_percent": 0.902778
+          "match_percent": 0.0
         },
         {
           "name": "_Z16MiniKit_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -64087,7 +64087,7 @@
           "address": 2048304,
           "offset": 1158336,
           "size": 2863,
-          "match_percent": 1.25
+          "match_percent": 37.385418
         },
         {
           "name": "_Z19ResetMinikitCounterv",
@@ -64111,7 +64111,7 @@
           "address": 2436144,
           "offset": 1546176,
           "size": 158,
-          "match_percent": 13.170732
+          "match_percent": 99.82927
         },
         {
           "name": "_Z21AddStatusMiniKitPartsv",
@@ -64207,7 +64207,7 @@
           "address": 4989984,
           "offset": 4100016,
           "size": 169,
-          "match_percent": 95.98077
+          "match_percent": 98.48077
         },
         {
           "name": "_Z20SpecialMiniKits_DrawP11WORLDINFO_s",
@@ -67194,14 +67194,6 @@
           "match_percent": 90.24258
         },
         {
-          "name": "_Z19AddGoldBrickMessageP14STATUSPACKET_ss",
-          "demangled_name": "AddGoldBrickMessage(STATUSPACKET_s*, short)",
-          "address": 2428768,
-          "offset": 1538800,
-          "size": 68,
-          "match_percent": 93.94118
-        },
-        {
           "name": "_Z17ResetGameMessagesv",
           "demangled_name": "ResetGameMessages()",
           "address": 4869296,
@@ -67746,7 +67738,7 @@
           "address": 4371936,
           "offset": 3481968,
           "size": 3480,
-          "match_percent": 8.811575
+          "match_percent": 8.539704
         },
         {
           "name": "Text3D",
@@ -67754,7 +67746,7 @@
           "address": 4375424,
           "offset": 3485456,
           "size": 149,
-          "match_percent": 13.548388
+          "match_percent": 99.96774
         },
         {
           "name": "Text3DEx2",
@@ -67770,7 +67762,7 @@
           "address": 4375840,
           "offset": 3485872,
           "size": 488,
-          "match_percent": 82.578316
+          "match_percent": 69.445786
         },
         {
           "name": "SmartTextEx",
@@ -67778,7 +67770,7 @@
           "address": 4381664,
           "offset": 3491696,
           "size": 4373,
-          "match_percent": 14.090414
+          "match_percent": 13.14488
         },
         {
           "name": "SmartText",
@@ -70069,7 +70061,7 @@
           "address": 2019808,
           "offset": 1129840,
           "size": 9,
-          "match_percent": 62.5
+          "match_percent": 100.0
         },
         {
           "name": "_Z18BonusTime_LSW_SkipP14STATUS_STAGE_sP14STATUSPACKET_s",
@@ -70109,7 +70101,7 @@
           "address": 2019968,
           "offset": 1130000,
           "size": 45,
-          "match_percent": 32.307693
+          "match_percent": 99.92308
         },
         {
           "name": "_Z23SuperStoryTime_LSW_SkipP14STATUS_STAGE_sP14STATUSPACKET_s",
@@ -70117,7 +70109,7 @@
           "address": 2020016,
           "offset": 1130048,
           "size": 42,
-          "match_percent": 32.307693
+          "match_percent": 99.92308
         },
         {
           "name": "_Z22BonusComplete_LSW_SkipP14STATUS_STAGE_sP14STATUSPACKET_s",
@@ -70125,7 +70117,7 @@
           "address": 2020064,
           "offset": 1130096,
           "size": 34,
-          "match_percent": 42.0
+          "match_percent": 99.9
         },
         {
           "name": "_Z17RedBrick_LSW_SkipP14STATUS_STAGE_sP14STATUSPACKET_s",
@@ -70133,7 +70125,7 @@
           "address": 2020304,
           "offset": 1130336,
           "size": 34,
-          "match_percent": 42.0
+          "match_percent": 99.9
         },
         {
           "name": "_Z17TrueHero_LSW_SkipP14STATUS_STAGE_sP14STATUSPACKET_s",
@@ -70141,7 +70133,7 @@
           "address": 2020400,
           "offset": 1130432,
           "size": 34,
-          "match_percent": 42.0
+          "match_percent": 99.9
         },
         {
           "name": "_Z18ChallangeCash_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -70165,7 +70157,7 @@
           "address": 2021856,
           "offset": 1131888,
           "size": 131,
-          "match_percent": 16.153847
+          "match_percent": 99.92308
         },
         {
           "name": "_Z19TrueHero_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -70173,7 +70165,7 @@
           "address": 2022144,
           "offset": 1132176,
           "size": 570,
-          "match_percent": 4.285714
+          "match_percent": 77.05357
         },
         {
           "name": "_Z15Save_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -70181,7 +70173,7 @@
           "address": 2027296,
           "offset": 1137328,
           "size": 275,
-          "match_percent": 6.363637
+          "match_percent": 13.530303
         },
         {
           "name": "_Z22BonusComplete_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -70189,7 +70181,7 @@
           "address": 2027584,
           "offset": 1137616,
           "size": 493,
-          "match_percent": 4.117647
+          "match_percent": 99.15686
         },
         {
           "name": "_Z19BonusWin_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -70197,7 +70189,7 @@
           "address": 2028080,
           "offset": 1138112,
           "size": 233,
-          "match_percent": 8.076923
+          "match_percent": 49.153847
         },
         {
           "name": "_Z19RedBrick_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -70205,7 +70197,7 @@
           "address": 2028320,
           "offset": 1138352,
           "size": 185,
-          "match_percent": 9.767442
+          "match_percent": 54.697674
         },
         {
           "name": "_Z24SuperStoryScore_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -70221,7 +70213,7 @@
           "address": 2029872,
           "offset": 1139904,
           "size": 751,
-          "match_percent": 2.727273
+          "match_percent": 72.2013
         },
         {
           "name": "_Z25SuperStoryTime_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -70229,7 +70221,7 @@
           "address": 2030624,
           "offset": 1140656,
           "size": 808,
-          "match_percent": 2.53012
+          "match_percent": 53.614456
         },
         {
           "name": "_Z16Coins_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -70237,7 +70229,7 @@
           "address": 2031440,
           "offset": 1141472,
           "size": 608,
-          "match_percent": 2.978723
+          "match_percent": 53.90071
         },
         {
           "name": "_Z23SuperStoryTime_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -70253,7 +70245,7 @@
           "address": 2033056,
           "offset": 1143088,
           "size": 286,
-          "match_percent": 6.774194
+          "match_percent": 54.725807
         },
         {
           "name": "_Z24BonusComplete_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -70261,7 +70253,7 @@
           "address": 2033344,
           "offset": 1143376,
           "size": 285,
-          "match_percent": 6.885246
+          "match_percent": 83.95082
         },
         {
           "name": "_Z15Prompt_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -70269,7 +70261,7 @@
           "address": 2034592,
           "offset": 1144624,
           "size": 329,
-          "match_percent": 7.058824
+          "match_percent": 0.0
         },
         {
           "name": "_Z17Prompt_LSW_UpdateP14STATUS_STAGE_sP14STATUSPACKET_sf",
@@ -70277,7 +70269,7 @@
           "address": 2034928,
           "offset": 1144960,
           "size": 885,
-          "match_percent": 1.752577
+          "match_percent": 0.0
         },
         {
           "name": "_Z17RedBrick_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -70285,7 +70277,7 @@
           "address": 2036880,
           "offset": 1146912,
           "size": 745,
-          "match_percent": 3.0
+          "match_percent": 67.442856
         },
         {
           "name": "_Z17TrueHero_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -70293,7 +70285,7 @@
           "address": 2037632,
           "offset": 1147664,
           "size": 2168,
-          "match_percent": 1.009615
+          "match_percent": 16.70673
         },
         {
           "name": "_Z22getFinishedStatusAlphaP14STATUSPACKET_s",
@@ -70309,7 +70301,7 @@
           "address": 2043872,
           "offset": 1153904,
           "size": 722,
-          "match_percent": 2.937063
+          "match_percent": 28.895105
         },
         {
           "name": "_Z18BonusTime_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -70317,7 +70309,7 @@
           "address": 2044608,
           "offset": 1154640,
           "size": 307,
-          "match_percent": 6.0
+          "match_percent": 46.9
         },
         {
           "name": "_Z14Coins_LSW_DrawP14STATUS_STAGE_sP14STATUSPACKET_si",
@@ -70325,7 +70317,7 @@
           "address": 2045216,
           "offset": 1155248,
           "size": 1605,
-          "match_percent": 1.3125
+          "match_percent": 54.178123
         },
         {
           "name": "_Z24LSW_registerStatusScreenv",
@@ -70333,7 +70325,7 @@
           "address": 2051168,
           "offset": 1161200,
           "size": 110,
-          "match_percent": 17.5
+          "match_percent": 80.833336
         },
         {
           "name": "_Z16SetDrawGoldBrickP14STATUSPACKET_si",
@@ -70376,6 +70368,14 @@
           "match_percent": 54.55238
         },
         {
+          "name": "_Z19AddGoldBrickMessageP14STATUSPACKET_ss",
+          "demangled_name": "AddGoldBrickMessage(STATUSPACKET_s*, short)",
+          "address": 2428768,
+          "offset": 1538800,
+          "size": 68,
+          "match_percent": 99.82353
+        },
+        {
           "name": "_Z14AddStatusStageP14STATUSPACKET_sii",
           "demangled_name": "AddStatusStage(STATUSPACKET_s*, int, int)",
           "address": 2428848,
@@ -70397,7 +70397,7 @@
           "address": 2429472,
           "offset": 1539504,
           "size": 6315,
-          "match_percent": 0.303688
+          "match_percent": 3.571222
         },
         {
           "name": "_Z16StatusIconsOnOfff",
@@ -70413,7 +70413,7 @@
           "address": 2442128,
           "offset": 1552160,
           "size": 1885,
-          "match_percent": 1.039604
+          "match_percent": 34.022278
         },
         {
           "name": "_Z18UpdateStatusScreenP11WORLDINFO_s",
@@ -70421,7 +70421,7 @@
           "address": 2447968,
           "offset": 1558000,
           "size": 879,
-          "match_percent": 2.142857
+          "match_percent": 55.709183
         },
         {
           "name": "_Z18UpdateAchievementsP14STATUSPACKET_s",
@@ -70437,7 +70437,7 @@
           "address": 2448864,
           "offset": 1558896,
           "size": 67,
-          "match_percent": 21.0
+          "match_percent": 15.8
         },
         {
           "name": "_Z11NewGameModev",
@@ -70945,22 +70945,6 @@
           "offset": 2825776,
           "size": 2404,
           "match_percent": 0.591304
-        },
-        {
-          "name": "_ZL13remapChildreni",
-          "demangled_name": "remapChildren(int)",
-          "address": 4927392,
-          "offset": 4037424,
-          "size": 1301,
-          "match_percent": 1.178248
-        },
-        {
-          "name": "_ZL11remapParenti",
-          "demangled_name": "remapParent(int)",
-          "address": 4928800,
-          "offset": 4038832,
-          "size": 1397,
-          "match_percent": 1.089385
         }
       ]
     },
@@ -73689,7 +73673,7 @@
           "address": 1306096,
           "offset": 416128,
           "size": 6194,
-          "match_percent": 0.407767
+          "match_percent": 37.948544
         },
         {
           "name": "_Z14DrawBonusScorefiifPi",
@@ -73753,7 +73737,7 @@
           "address": 1316752,
           "offset": 426784,
           "size": 12845,
-          "match_percent": 2.026722
+          "match_percent": 6.2238
         },
         {
           "name": "_Z19DrawForceBackEffectP12nuhspecial_s",
@@ -73961,7 +73945,7 @@
           "address": 2400800,
           "offset": 1510832,
           "size": 6077,
-          "match_percent": 9.375578
+          "match_percent": 9.315449
         },
         {
           "name": "_Z17DrawSubItemMenu3Dv",
@@ -74033,7 +74017,7 @@
           "address": 2444016,
           "offset": 1554048,
           "size": 656,
-          "match_percent": 3.442623
+          "match_percent": 93.83607
         },
         {
           "name": "_Z16DrawStatusScreenP11WORLDINFO_s",
@@ -74561,7 +74545,7 @@
           "address": 4810208,
           "offset": 3920240,
           "size": 693,
-          "match_percent": 3.255814
+          "match_percent": 87.4186
         },
         {
           "name": "_Z11DrawStreaksv",
@@ -81457,14 +81441,6 @@
           "offset": 3783424,
           "size": 192,
           "match_percent": 98.49056
-        },
-        {
-          "name": "_ZL10loadSumBoxP8nufpar_s",
-          "demangled_name": "loadSumBox(nufpar_s*)",
-          "address": 4923888,
-          "offset": 4033920,
-          "size": 40,
-          "match_percent": 99.90909
         }
       ]
     },
@@ -83440,7 +83416,7 @@
           "address": 2191728,
           "offset": 1301760,
           "size": 379,
-          "match_percent": 4.329897
+          "match_percent": 3.917526
         },
         {
           "name": "_Z20DeathStarBattleDInitP11WORLDINFO_s",
@@ -84302,7 +84278,7 @@
           "address": 2254336,
           "offset": 1364368,
           "size": 86,
-          "match_percent": 17.5
+          "match_percent": 18.333334
         },
         {
           "name": "_Z16SarlaccPitB_InitP11WORLDINFO_s",
@@ -85189,7 +85165,7 @@
           "address": 1161344,
           "offset": 271376,
           "size": 1077,
-          "match_percent": 86.168724
+          "match_percent": 87.81481
         },
         {
           "name": "_Z19InitGameAfterConfigv",
@@ -85197,7 +85173,7 @@
           "address": 1165552,
           "offset": 275584,
           "size": 5015,
-          "match_percent": 35.62188
+          "match_percent": 35.417465
         },
         {
           "name": "_Z18StoreLevelProgressP11WORLDINFO_s",
@@ -105259,238 +105235,6 @@
           "match_percent": 44.444443
         },
         {
-          "name": "_ZL13xFlowBoxCountP8nufpar_s",
-          "demangled_name": "xFlowBoxCount(nufpar_s*)",
-          "address": 4921120,
-          "offset": 4031152,
-          "size": 23,
-          "match_percent": 27.5
-        },
-        {
-          "name": "_ZL11xStartInvisP8nufpar_s",
-          "demangled_name": "xStartInvis(nufpar_s*)",
-          "address": 4921152,
-          "offset": 4031184,
-          "size": 24,
-          "match_percent": 27.5
-        },
-        {
-          "name": "_ZL9xEndDeactP8nufpar_s",
-          "demangled_name": "xEndDeact(nufpar_s*)",
-          "address": 4921184,
-          "offset": 4031216,
-          "size": 24,
-          "match_percent": 27.5
-        },
-        {
-          "name": "_ZL9xEndInvisP8nufpar_s",
-          "demangled_name": "xEndInvis(nufpar_s*)",
-          "address": 4921216,
-          "offset": 4031248,
-          "size": 24,
-          "match_percent": 27.5
-        },
-        {
-          "name": "_ZL8xReverseP8nufpar_s",
-          "demangled_name": "xReverse(nufpar_s*)",
-          "address": 4921248,
-          "offset": 4031280,
-          "size": 24,
-          "match_percent": 27.5
-        },
-        {
-          "name": "_ZL13xReverseInvisP8nufpar_s",
-          "demangled_name": "xReverseInvis(nufpar_s*)",
-          "address": 4921280,
-          "offset": 4031312,
-          "size": 25,
-          "match_percent": 27.5
-        },
-        {
-          "name": "_ZL12xNotFreeplayP8nufpar_s",
-          "demangled_name": "xNotFreeplay(nufpar_s*)",
-          "address": 4921312,
-          "offset": 4031344,
-          "size": 24,
-          "match_percent": 27.5
-        },
-        {
-          "name": "_ZL13xNotStoryModeP8nufpar_s",
-          "demangled_name": "xNotStoryMode(nufpar_s*)",
-          "address": 4921344,
-          "offset": 4031376,
-          "size": 24,
-          "match_percent": 27.5
-        },
-        {
-          "name": "_ZL11xOutputOnlyP8nufpar_s",
-          "demangled_name": "xOutputOnly(nufpar_s*)",
-          "address": 4921376,
-          "offset": 4031408,
-          "size": 25,
-          "match_percent": 27.5
-        },
-        {
-          "name": "_ZL14xGizRandomTimeP8nufpar_s",
-          "demangled_name": "xGizRandomTime(nufpar_s*)",
-          "address": 4921408,
-          "offset": 4031440,
-          "size": 23,
-          "match_percent": 27.5
-        },
-        {
-          "name": "_ZL14xMonitorInputsP8nufpar_s",
-          "demangled_name": "xMonitorInputs(nufpar_s*)",
-          "address": 4921440,
-          "offset": 4031472,
-          "size": 24,
-          "match_percent": 31.428572
-        },
-        {
-          "name": "_ZL14xConditionTypeP8nufpar_s",
-          "demangled_name": "xConditionType(nufpar_s*)",
-          "address": 4923216,
-          "offset": 4033248,
-          "size": 136,
-          "match_percent": 7.391305
-        },
-        {
-          "name": "_ZL9xCollapseP8nufpar_s",
-          "demangled_name": "xCollapse(nufpar_s*)",
-          "address": 4923360,
-          "offset": 4033392,
-          "size": 187,
-          "match_percent": 6.875
-        },
-        {
-          "name": "_ZL10xChild_ColP8nufpar_s",
-          "demangled_name": "xChild_Col(nufpar_s*)",
-          "address": 4923552,
-          "offset": 4033584,
-          "size": 92,
-          "match_percent": 10.476191
-        },
-        {
-          "name": "_ZL11xParent_ColP8nufpar_s",
-          "demangled_name": "xParent_Col(nufpar_s*)",
-          "address": 4923648,
-          "offset": 4033680,
-          "size": 126,
-          "match_percent": 9.642858
-        },
-        {
-          "name": "_ZL11xAIAssistIDP8nufpar_s",
-          "demangled_name": "xAIAssistID(nufpar_s*)",
-          "address": 4923776,
-          "offset": 4033808,
-          "size": 57,
-          "match_percent": 15.714286
-        },
-        {
-          "name": "_ZL10xNumGizmosP8nufpar_s",
-          "demangled_name": "xNumGizmos(nufpar_s*)",
-          "address": 4923840,
-          "offset": 4033872,
-          "size": 40,
-          "match_percent": 34.545456
-        },
-        {
-          "name": "_ZL18xRand_OutputChanceP8nufpar_s",
-          "demangled_name": "xRand_OutputChance(nufpar_s*)",
-          "address": 4923936,
-          "offset": 4033968,
-          "size": 73,
-          "match_percent": 15.0
-        },
-        {
-          "name": "_ZL16xRand_NumOutputsP8nufpar_s",
-          "demangled_name": "xRand_NumOutputs(nufpar_s*)",
-          "address": 4924016,
-          "offset": 4034048,
-          "size": 40,
-          "match_percent": 34.545456
-        },
-        {
-          "name": "_ZL8xFlowBoxP8nufpar_s",
-          "demangled_name": "xFlowBox(nufpar_s*)",
-          "address": 4924064,
-          "offset": 4034096,
-          "size": 608,
-          "match_percent": 2.179487
-        },
-        {
-          "name": "_ZL5xNameP8nufpar_s",
-          "demangled_name": "xName(nufpar_s*)",
-          "address": 4924672,
-          "offset": 4034704,
-          "size": 84,
-          "match_percent": 11.0
-        },
-        {
-          "name": "_ZL10xGizmoNameP8nufpar_s",
-          "demangled_name": "xGizmoName(nufpar_s*)",
-          "address": 4924768,
-          "offset": 4034800,
-          "size": 84,
-          "match_percent": 11.0
-        },
-        {
-          "name": "_ZL7xActionP8nufpar_s",
-          "demangled_name": "xAction(nufpar_s*)",
-          "address": 4924864,
-          "offset": 4034896,
-          "size": 626,
-          "match_percent": 2.060606
-        },
-        {
-          "name": "_ZL6xGizmoP8nufpar_s",
-          "demangled_name": "xGizmo(nufpar_s*)",
-          "address": 4925504,
-          "offset": 4035536,
-          "size": 1043,
-          "match_percent": 1.236364
-        },
-        {
-          "name": "_ZL9xGizTimerP8nufpar_s",
-          "demangled_name": "xGizTimer(nufpar_s*)",
-          "address": 4926560,
-          "offset": 4036592,
-          "size": 40,
-          "match_percent": 34.545456
-        },
-        {
-          "name": "_ZL10xGizmoTypeP8nufpar_s",
-          "demangled_name": "xGizmoType(nufpar_s*)",
-          "address": 4926608,
-          "offset": 4036640,
-          "size": 84,
-          "match_percent": 12.857142
-        },
-        {
-          "name": "_ZL10xConditionP8nufpar_s",
-          "demangled_name": "xCondition(nufpar_s*)",
-          "address": 4927136,
-          "offset": 4037168,
-          "size": 251,
-          "match_percent": 5.15625
-        },
-        {
-          "name": "_ZL6xChildP8nufpar_s",
-          "demangled_name": "xChild(nufpar_s*)",
-          "address": 4928704,
-          "offset": 4038736,
-          "size": 90,
-          "match_percent": 14.615385
-        },
-        {
-          "name": "_ZL7xParentP8nufpar_s",
-          "demangled_name": "xParent(nufpar_s*)",
-          "address": 4930208,
-          "offset": 4040240,
-          "size": 163,
-          "match_percent": 5.5
-        },
-        {
           "name": "_ZL13RE_end_radiusP8nufpar_s",
           "demangled_name": "RE_end_radius(nufpar_s*)",
           "address": 5122432,
@@ -118060,9 +117804,11 @@
         "legoapi/characters/motion/animation.cpp.o",
         "legoapi/core/config/config.cpp.o",
         "legoapi/core/config/saveload.cpp.o",
+        "legoapi/core/net/netplay.cpp.o",
         "legoapi/gizmo/gizmos/gizmos_newblowup.cpp.o",
         "legoapi/gizmo/object/gizportal.cpp.o",
         "legoapi/gizmo/object/gizrandom.cpp.o",
+        "legoapi/gizmo/object/giztimers.cpp.o",
         "legoapi/gizmo/object/giztorpedo.cpp.o",
         "legoapi/items/base/animpacket.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
@@ -118320,9 +118066,11 @@
         "legoapi/characters/motion/animation.cpp.o",
         "legoapi/core/config/config.cpp.o",
         "legoapi/core/config/saveload.cpp.o",
+        "legoapi/core/net/netplay.cpp.o",
         "legoapi/gizmo/gizmos/gizmos_newblowup.cpp.o",
         "legoapi/gizmo/object/gizportal.cpp.o",
         "legoapi/gizmo/object/gizrandom.cpp.o",
+        "legoapi/gizmo/object/giztimers.cpp.o",
         "legoapi/gizmo/object/giztorpedo.cpp.o",
         "legoapi/items/base/animpacket.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
@@ -118524,9 +118272,11 @@
         "legoapi/characters/motion/animation.cpp.o",
         "legoapi/core/config/config.cpp.o",
         "legoapi/core/config/saveload.cpp.o",
+        "legoapi/core/net/netplay.cpp.o",
         "legoapi/gizmo/gizmos/gizmos_newblowup.cpp.o",
         "legoapi/gizmo/object/gizportal.cpp.o",
         "legoapi/gizmo/object/gizrandom.cpp.o",
+        "legoapi/gizmo/object/giztimers.cpp.o",
         "legoapi/gizmo/object/giztorpedo.cpp.o",
         "legoapi/items/base/animpacket.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
@@ -119150,9 +118900,11 @@
         "legoapi/characters/motion/animation.cpp.o",
         "legoapi/core/config/config.cpp.o",
         "legoapi/core/config/saveload.cpp.o",
+        "legoapi/core/net/netplay.cpp.o",
         "legoapi/gizmo/gizmos/gizmos_newblowup.cpp.o",
         "legoapi/gizmo/object/gizportal.cpp.o",
         "legoapi/gizmo/object/gizrandom.cpp.o",
+        "legoapi/gizmo/object/giztimers.cpp.o",
         "legoapi/gizmo/object/giztorpedo.cpp.o",
         "legoapi/items/base/animpacket.cpp.o",
         "legoapi/items/base/apiobject.cpp.o",
@@ -122257,6 +122009,390 @@
       "candidate_units": [
         "MechInputTouch/MechObjectInterface.cpp.o",
         "legoapi/gizmo/base/gizmo.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL13xFlowBoxCountP8nufpar_s",
+      "demangled_name": "xFlowBoxCount(nufpar_s*)",
+      "address": 4921120,
+      "offset": 4031152,
+      "size": 23,
+      "match_percent": 99.75,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL11xStartInvisP8nufpar_s",
+      "demangled_name": "xStartInvis(nufpar_s*)",
+      "address": 4921152,
+      "offset": 4031184,
+      "size": 24,
+      "match_percent": 99.75,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL9xEndDeactP8nufpar_s",
+      "demangled_name": "xEndDeact(nufpar_s*)",
+      "address": 4921184,
+      "offset": 4031216,
+      "size": 24,
+      "match_percent": 99.75,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL9xEndInvisP8nufpar_s",
+      "demangled_name": "xEndInvis(nufpar_s*)",
+      "address": 4921216,
+      "offset": 4031248,
+      "size": 24,
+      "match_percent": 99.75,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL8xReverseP8nufpar_s",
+      "demangled_name": "xReverse(nufpar_s*)",
+      "address": 4921248,
+      "offset": 4031280,
+      "size": 24,
+      "match_percent": 99.75,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL13xReverseInvisP8nufpar_s",
+      "demangled_name": "xReverseInvis(nufpar_s*)",
+      "address": 4921280,
+      "offset": 4031312,
+      "size": 25,
+      "match_percent": 99.75,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL12xNotFreeplayP8nufpar_s",
+      "demangled_name": "xNotFreeplay(nufpar_s*)",
+      "address": 4921312,
+      "offset": 4031344,
+      "size": 24,
+      "match_percent": 99.75,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL13xNotStoryModeP8nufpar_s",
+      "demangled_name": "xNotStoryMode(nufpar_s*)",
+      "address": 4921344,
+      "offset": 4031376,
+      "size": 24,
+      "match_percent": 99.75,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL11xOutputOnlyP8nufpar_s",
+      "demangled_name": "xOutputOnly(nufpar_s*)",
+      "address": 4921376,
+      "offset": 4031408,
+      "size": 25,
+      "match_percent": 99.75,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL14xGizRandomTimeP8nufpar_s",
+      "demangled_name": "xGizRandomTime(nufpar_s*)",
+      "address": 4921408,
+      "offset": 4031440,
+      "size": 23,
+      "match_percent": 99.75,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL14xMonitorInputsP8nufpar_s",
+      "demangled_name": "xMonitorInputs(nufpar_s*)",
+      "address": 4921440,
+      "offset": 4031472,
+      "size": 24,
+      "match_percent": 98.71429,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL14xConditionTypeP8nufpar_s",
+      "demangled_name": "xConditionType(nufpar_s*)",
+      "address": 4923216,
+      "offset": 4033248,
+      "size": 136,
+      "match_percent": 99.78261,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL9xCollapseP8nufpar_s",
+      "demangled_name": "xCollapse(nufpar_s*)",
+      "address": 4923360,
+      "offset": 4033392,
+      "size": 187,
+      "match_percent": 99.791664,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL10xChild_ColP8nufpar_s",
+      "demangled_name": "xChild_Col(nufpar_s*)",
+      "address": 4923552,
+      "offset": 4033584,
+      "size": 92,
+      "match_percent": 99.7619,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL11xParent_ColP8nufpar_s",
+      "demangled_name": "xParent_Col(nufpar_s*)",
+      "address": 4923648,
+      "offset": 4033680,
+      "size": 126,
+      "match_percent": 99.71429,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL11xAIAssistIDP8nufpar_s",
+      "demangled_name": "xAIAssistID(nufpar_s*)",
+      "address": 4923776,
+      "offset": 4033808,
+      "size": 57,
+      "match_percent": 99.85714,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL10xNumGizmosP8nufpar_s",
+      "demangled_name": "xNumGizmos(nufpar_s*)",
+      "address": 4923840,
+      "offset": 4033872,
+      "size": 40,
+      "match_percent": 99.818184,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL10loadSumBoxP8nufpar_s",
+      "demangled_name": "loadSumBox(nufpar_s*)",
+      "address": 4923888,
+      "offset": 4033920,
+      "size": 40,
+      "match_percent": 99.818184,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "legoapi/world/levelconfig.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL18xRand_OutputChanceP8nufpar_s",
+      "demangled_name": "xRand_OutputChance(nufpar_s*)",
+      "address": 4923936,
+      "offset": 4033968,
+      "size": 73,
+      "match_percent": 99.888885,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL16xRand_NumOutputsP8nufpar_s",
+      "demangled_name": "xRand_NumOutputs(nufpar_s*)",
+      "address": 4924016,
+      "offset": 4034048,
+      "size": 40,
+      "match_percent": 99.818184,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL8xFlowBoxP8nufpar_s",
+      "demangled_name": "xFlowBox(nufpar_s*)",
+      "address": 4924064,
+      "offset": 4034096,
+      "size": 608,
+      "match_percent": 99.79487,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL5xNameP8nufpar_s",
+      "demangled_name": "xName(nufpar_s*)",
+      "address": 4924672,
+      "offset": 4034704,
+      "size": 84,
+      "match_percent": 99.9,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL10xGizmoNameP8nufpar_s",
+      "demangled_name": "xGizmoName(nufpar_s*)",
+      "address": 4924768,
+      "offset": 4034800,
+      "size": 84,
+      "match_percent": 99.9,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL7xActionP8nufpar_s",
+      "demangled_name": "xAction(nufpar_s*)",
+      "address": 4924864,
+      "offset": 4034896,
+      "size": 626,
+      "match_percent": 3.430303,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL6xGizmoP8nufpar_s",
+      "demangled_name": "xGizmo(nufpar_s*)",
+      "address": 4925504,
+      "offset": 4035536,
+      "size": 1043,
+      "match_percent": 67.65818,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL9xGizTimerP8nufpar_s",
+      "demangled_name": "xGizTimer(nufpar_s*)",
+      "address": 4926560,
+      "offset": 4036592,
+      "size": 40,
+      "match_percent": 99.818184,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL10xGizmoTypeP8nufpar_s",
+      "demangled_name": "xGizmoType(nufpar_s*)",
+      "address": 4926608,
+      "offset": 4036640,
+      "size": 84,
+      "match_percent": 99.85714,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL10xConditionP8nufpar_s",
+      "demangled_name": "xCondition(nufpar_s*)",
+      "address": 4927136,
+      "offset": 4037168,
+      "size": 251,
+      "match_percent": 96.1875,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL13remapChildreni",
+      "demangled_name": "remapChildren(int)",
+      "address": 4927392,
+      "offset": 4037424,
+      "size": 1301,
+      "match_percent": 0.0,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "legoapi/misc/androidbatman.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL6xChildP8nufpar_s",
+      "demangled_name": "xChild(nufpar_s*)",
+      "address": 4928704,
+      "offset": 4038736,
+      "size": 90,
+      "match_percent": 99.80769,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL11remapParenti",
+      "demangled_name": "remapParent(int)",
+      "address": 4928800,
+      "offset": 4038832,
+      "size": 1397,
+      "match_percent": 0.0,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "legoapi/misc/androidbatman.cpp.o"
+      ]
+    },
+    {
+      "name": "_ZL7xParentP8nufpar_s",
+      "demangled_name": "xParent(nufpar_s*)",
+      "address": 4930208,
+      "offset": 4040240,
+      "size": 163,
+      "match_percent": 99.85,
+      "candidate_units": [
+        "legoapi/gizmo/base/gizmo_sys.cpp.o",
+        "nu2api/nufile/nufpar.cpp.o"
       ]
     },
     {
@@ -130927,8 +131063,8 @@
   "summary": {
     "bazel_units": 503,
     "functions": 13454,
-    "assigned_functions": 12180,
-    "ambiguous_functions": 226,
+    "assigned_functions": 12148,
+    "ambiguous_functions": 258,
     "unassigned_functions": 1048
   }
 }

--- a/src/gameapi/ai/aisys/aisys.cpp
+++ b/src/gameapi/ai/aisys/aisys.cpp
@@ -10,9 +10,11 @@
 #include "legoapi/characters/core/players.h"
 #include "legoapi/characters/motion.h"
 #include "legoapi/characters/motion/gameanim.h"
+#include "legoapi/core/input/gamepads.h"
 #include "legoapi/core/input/qrand.h"
 #include "legoapi/gizmo/base/gizmo.h"
 #include "legoapi/gizmos/object/gizobstacles.h"
+#include "legoapi/gizmos/traps/gizforce.h"
 #include "legoapi/gizmos/transport/grapples.h"
 #include "legoapi/items/objects/gameobjects.h"
 #include "legoapi/ai/core/ai_sys_stubs.h"
@@ -33,6 +35,8 @@ extern void oneAtOnce_SetInitDistPerRow(f32 distance);
 extern bool oneAtOnce_CanAttack(GameObject_s *object, GameObject_s *opponent);
 extern f32 oneAtOnce_GetHoldRange(GameObject_s *object);
 extern void Hint_CancelCurrent();
+extern void PlayRepeatSfx(char *name, i32 sfx_id, f32 initial_delay, char play_count, f32 interval,
+                          nuvec_s *position);
 extern void ResetAICreature(GameObject_s *object, AISYS_s *system);
 extern void DeactivateGameObject(GameObject_s *object);
 extern void Player_ClearContext(GameObject_s *object, i32 mode);
@@ -454,14 +458,70 @@ __used__ static i32 Action_Explode(AISYS *sys, AISCRIPTPROCESS *processor, AIPAC
 
 __used__ static i32 Action_PlaySfx(AISYS *sys, AISCRIPTPROCESS *processor, AIPACKET *packet, char **params, i32 param_4,
                                    i32 param_5, f32 param_6) {
-    (void)sys;
-    (void)processor;
     (void)packet;
-    (void)params;
-    (void)param_4;
-    (void)param_5;
     (void)param_6;
-    return 0;
+    if (param_5 == 0 || param_4 <= 0) {
+        return 1;
+    }
+
+    NUVEC position = {1.0e9f, 1.0e9f, 1.0e9f};
+    NUVEC *position_ptr = NULL;
+    char *name = NULL;
+    char play_count = 1;
+    f32 repeat_delay = 0.0f;
+    f32 start_delay = 0.0f;
+
+    for (i32 index = 0; index < param_4; ++index) {
+        char *value = NuStrIStr(params[index], const_cast<char *>("name="));
+        if (value != NULL) {
+            name = value + 5;
+            continue;
+        }
+        value = NuStrIStr(params[index], const_cast<char *>("playcount="));
+        if (value != NULL) {
+            play_count = static_cast<char>(AIParamToFloat(processor, value + 10));
+            continue;
+        }
+        value = NuStrIStr(params[index], const_cast<char *>("repdelay="));
+        if (value != NULL) {
+            repeat_delay = AIParamToFloat(processor, value + 9);
+            continue;
+        }
+        value = NuStrIStr(params[index], const_cast<char *>("startdelay="));
+        if (value != NULL) {
+            start_delay = AIParamToFloat(processor, value + 11);
+            continue;
+        }
+        value = NuStrIStr(params[index], const_cast<char *>("x="));
+        if (value != NULL) {
+            position.x = AIParamToFloat(processor, value + 2);
+            continue;
+        }
+        value = NuStrIStr(params[index], const_cast<char *>("y="));
+        if (value != NULL) {
+            position.y = AIParamToFloat(processor, value + 2);
+            continue;
+        }
+        value = NuStrIStr(params[index], const_cast<char *>("z="));
+        if (value != NULL) {
+            position.z = AIParamToFloat(processor, value + 2);
+            continue;
+        }
+        value = NuStrIStr(params[index], const_cast<char *>("character_pos="));
+        if (value != NULL) {
+            GameObject_s *object = GetNamedGameObject(sys, value + 14);
+            position_ptr = &object->apiobj.collision_position;
+        }
+    }
+
+    if (position_ptr == NULL &&
+        (position.x != 1.0e9f || position.y != 1.0e9f || position.z != 1.0e9f)) {
+        position_ptr = &position;
+    }
+    if (name != NULL) {
+        PlayRepeatSfx(name, -1, start_delay, play_count, repeat_delay, position_ptr);
+    }
+    return 1;
 }
 
 __used__ static i32 Action_SetBoss(AISYS *sys, AISCRIPTPROCESS *processor, AIPACKET *packet, char **params, i32 param_4,
@@ -847,15 +907,106 @@ __used__ static i32 Action_TakeOver(AISYS *sys, AISCRIPTPROCESS *processor, AIPA
     return 0;
 }
 
-__used__ static i32 Action_UseForce(AISYS *sys, AISCRIPTPROCESS *processor, AIPACKET *packet, char **params,
-                                    i32 param_4, i32 param_5, f32 param_6) {
-    (void)sys;
-    (void)processor;
-    (void)packet;
-    (void)params;
-    (void)param_4;
-    (void)param_5;
-    (void)param_6;
+__used__ static i32 Action_UseForce(AISYS *, AISCRIPTPROCESS *processor, AIPACKET *packet, char **params,
+                                    i32 param_count, i32 first_time, f32 elapsed) {
+    if (packet == NULL || packet->owner == NULL || packet->owner->apiobj.objptr == NULL) {
+        return 1;
+    }
+
+    GameObject_s *object = packet->owner->apiobj.objptr;
+    i32 triggered_by_hit = 0;
+    GIZFORCE_s *force;
+
+    if (first_time != 0) {
+        processor->action_data_3 = NULL;
+        if (param_count <= 0) {
+            return 1;
+        }
+
+        GIZFORCE_s *candidates[16];
+        i32 candidate_count = 0;
+        for (i32 index = 0; index < param_count; ++index) {
+            if (NuStrICmp(params[index], "throwable") == 0) {
+                processor->action_data_1 = 1;
+            } else if (NuStrICmp(params[index], "inrange") == 0) {
+                processor->action_data_2 = 1;
+            } else if (NuStrICmp(params[index], "triggered_by_hit") == 0) {
+                triggered_by_hit = 1;
+            } else {
+                char *name = NuStrIStr(params[index], const_cast<char *>("name"));
+                if (name != NULL) {
+                    name += 5;
+                } else {
+                    name = params[index];
+                }
+                if (name != NULL && candidate_count < 16) {
+                    GIZMO *gizmo = GizmoFindByName(WORLD->gizmo_sys, force_gizmotype_id, name);
+                    if (gizmo != NULL && gizmo->object != NULL) {
+                        force = static_cast<GIZFORCE_s *>(gizmo->object);
+                        candidates[candidate_count] = force;
+                        if ((force->packed_state &
+                             (GIZFORCE_PROGRESS_VISIBLE | (GIZFORCE_STATE_DESTROYED_OR_THROWN << 16))) ==
+                            GIZFORCE_PROGRESS_VISIBLE) {
+                            ++candidate_count;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (candidate_count != 0) {
+            const i32 random_index = qrand() / (0xffff / candidate_count + 1);
+            force = candidates[random_index];
+            processor->action_data_3 = force;
+        } else {
+            force = static_cast<GIZFORCE_s *>(processor->action_data_3);
+        }
+    } else {
+        force = static_cast<GIZFORCE_s *>(processor->action_data_3);
+    }
+
+    if (force == NULL) {
+        return 1;
+    }
+    if ((force->progress_flags & GIZFORCE_PROGRESS_ENABLED) == 0) {
+        return 0;
+    }
+
+    if ((force->config_flags & GIZFORCE_CONFIG_JEDI_BADDIE_ONLY) != 0) {
+        if (CharCategory_IsCategory(object, 1) == 0) {
+            goto invalid_category;
+        }
+    } else if (CharCategory_IsCategory(object, 0) == 0) {
+        goto invalid_category;
+    }
+
+    if (triggered_by_hit != 0) {
+        force->runtime_flags |= GIZFORCE_RUNTIME_PENDING_COMPLETION;
+        return 0;
+    }
+
+    packet->movement_look_target = &force->position;
+    object->pad_gamepad->allocated_5a |= 4;
+    object->gizforce_target = force;
+    if (processor->action_data_1 == 0) {
+        return GizForce_Complete(force) != 0;
+    }
+    if (packet->nearest_opponent == NULL) {
+        object->pad_gamepad->allocated_5a &= static_cast<u8>(~4u);
+        object->gizforce_target = NULL;
+    }
+    return 1;
+
+invalid_category:
+    if (triggered_by_hit != 0) {
+        force->runtime_flags |= GIZFORCE_RUNTIME_PENDING_COMPLETION;
+    } else if (FreePlay != 0) {
+        processor->action_timer -= elapsed;
+        if (0.0f > processor->action_timer) {
+            processor->action_timer = 0.5f;
+            object->pad_gamepad->buttons_pressed |= GAMEPAD_TOGGLERIGHT;
+        }
+    }
     return 0;
 }
 
@@ -2661,7 +2812,7 @@ __used__ static i32 Action_CnxController(AISYS *sys, AISCRIPTPROCESS *processor,
         }
         char range[64];
         NuStrCpy(range, match + 10);
-        char *separator = NuStrIStr(range, "..");
+        char *separator = NuStrIStr(range, "to");
         if (separator == NULL) {
             continue;
         }

--- a/src/globals.h
+++ b/src/globals.h
@@ -241,8 +241,7 @@ struct STATUSCOLLECT_s {
 DECOMP_ASSERT(sizeof(STATUSCOLLECT_s) == 4, "STATUSCOLLECT size");
 
 struct STATUSCOLLECTLIST_s {
-    STATUSCOLLECT_s *ptr;
-    u8 pad_0x04[0x0c];
+    i16 ids[8];
 };
 DECOMP_ASSERT(sizeof(STATUSCOLLECTLIST_s) == 0x10, "STATUSCOLLECTLIST size");
 

--- a/src/host/platform/opensl.cpp
+++ b/src/host/platform/opensl.cpp
@@ -510,6 +510,12 @@ namespace hostsl {
                     return HOST_SL_RESULT_PARAMETER_INVALID;
                 }
                 SDL_ResumeAudioStreamDevice(host_device_stream);
+                SDL_AudioSpec actual = {};
+                int sample_frames = 0;
+                if (SDL_GetAudioDeviceFormat(SDL_GetAudioStreamDevice(host_device_stream), &actual, &sample_frames)) {
+                    LOG_INFO("audio: driver=%s rate=%d Hz buffer=%d frames (%.1f ms)", SDL_GetCurrentAudioDriver(),
+                             actual.freq, sample_frames, 1000.0 * sample_frames / actual.freq);
+                }
             }
 
             MixObject *mix = (MixObject *)calloc(1, sizeof(MixObject));

--- a/src/legoapi/audio/sfx.cpp
+++ b/src/legoapi/audio/sfx.cpp
@@ -122,8 +122,8 @@ i32 Players_AveragePos(nuvec_s *position, SOCKPOSITION_s *socket_position);
 i32 Hub_Outside(void);
 i32 KaminoInside(void);
 i32 KaminoDiscoOn(void);
-i32 DeathStarShieldDown(void);
-i32 SarlaccPitDiscoActive(WORLDINFO_s *world);
+bool DeathStarShieldDown(void);
+bool SarlaccPitDiscoActive(WORLDINFO_s *world);
 
 extern AREADATA *BONUS_GUNSHIP_ADATA;
 extern AREADATA *DAGOBAH_ADATA;

--- a/src/legoapi/characters/core/characters.cpp
+++ b/src/legoapi/characters/core/characters.cpp
@@ -26,6 +26,9 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <math.h>
+#include "legoapi/menus/core/text.h"
+#include "nu2api/numath/nutrig.h"
 
 // LoadPerm1 is one of the few game-level entry points which wires together
 // otherwise C-linkage engine subsystems.  Keep these declarations local: the
@@ -592,10 +595,75 @@ void ResetCharacterBuffer(i32 force_reset) {
     apicharsys->loaded_animation_count = apicharsys->area_animation_count;
 }
 
-void CollectCharcters_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+void NextStatusStage(STATUSPACKET_s *);
+i32 AddToCollection(i32);
+void NewStatusRumbleBuzz(i32, f32, f32, i32);
+void GameAudio_PlaySfx(i32, nuvec_s *, i32, i32);
+extern "C" void PlaySfx(char *, nuvec_s *);
+void Collection_Draw(COLLECTION_s *, f32, f32, f32, APICHARACTERMODELLIST_s *, f32, i32);
+void Collection_GetPos(COLLECTION_s *, i32, f32 *, f32 *);
+void DrawCharIcon(i32, f32, f32, f32, f32, i32, f32, f32, i32, nuhspecial_s *);
+extern f32 ICONSIZE;
+extern i32 STATUS_R, STATUS_G, STATUS_B;
+f32 COLLECTION_Y_STATUS = -0.3f;
+static i32 playedappearsfx;
+static i32 playedmovesfx;
+
+void CollectCharcters_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 active) {
+    COLLECTION_s *collection = (packet->field_0xb0 & 0x80) != 0 ? &VehicleCollection : &CharacterCollection;
+    if (active == 0) return;
+    if (stage->field_0x14 == 0) {
+        const f32 offscreen = (1.0f - fabsf(COLLECTION_Y_STATUS)) + 1.0f;
+        const f32 ratio = stage->field_0x1c != 0.0f && stage->field_0x18 != 0.0f ? stage->field_0x18 / stage->field_0x1c : 0.0f;
+        Collection_Draw(collection, 0.0f, NuTrigTable[(static_cast<i32>(ratio * 16384.0f) >> 1) & 0x7fff] * (COLLECTION_Y_STATUS + offscreen) - offscreen, collection->field_10, NULL, 1.0f, 0);
+        return;
+    }
+    const i32 id = StatusCollectList.ids[stage->field_0x14 - 1];
+    if (id == -1) return;
+    Collection_Draw(collection, 0.0f, COLLECTION_Y_STATUS, collection->field_10, NULL, 1.0f, 0);
+    f32 time = stage->field_0x18;
+    f32 x = 0.0f, y = 0.7f, size = 0.4f, icon_alpha = 1.0f, text_alpha;
+    if (time < 0.5f) {
+        if (time > 0.25f && playedappearsfx == 0) {
+            PlaySfx(const_cast<char *>("Char_Icon_App"), NULL);
+            playedappearsfx = 1;
+            time = stage->field_0x18;
+        }
+        text_alpha = NuTrigTable[(static_cast<i32>((time + time) * 16384.0f) >> 1) & 0x7fff];
+        icon_alpha = time + time;
+    } else if (time < 2.0f) {
+        text_alpha = 1.0f;
+        playedappearsfx = 0;
+        playedmovesfx = 0;
+    } else {
+        text_alpha = 1.0f - NuTrigTable[(static_cast<i32>((time - 2.0f) * 16384.0f) >> 1) & 0x7fff];
+        if (playedmovesfx == 0) {
+            PlaySfx(const_cast<char *>("Char_Icon_Slide"), NULL);
+            playedmovesfx = 1;
+        }
+        const f32 blend = 1.0f - (NuTrigTable[(static_cast<i32>((time - 2.0f) * 32768.0f + 16384.0f) >> 1) & 0x7fff] + 1.0f) * 0.5f;
+        if (InCollectList_Index(id, collection->list, collection->count_y) != -1) {
+            f32 target_x, target_y;
+            Collection_GetPos(collection, id, &target_x, &target_y);
+            f32 target_size = collection->field_10 * ICONSIZE;
+            if (Game_OptionsSave != NULL && Game_OptionsSave->field11_0xb != 0) target_size *= 0.875f;
+            x = target_x * blend + 0.0f;
+            y = (target_y - 0.7f) * blend + 0.7f;
+            size = (target_size - 0.4f) * blend + 0.4f;
+        }
+    }
+    DrawCharIcon(id, x, y, 0.0f, size, 0xa7, icon_alpha, icon_alpha, 1, NULL);
+    SmartTextEx(TTab[CDataList[id].name_id], 0.0f, 0.35f, 1.0f, 0.6f, 0.6f, 0.6f, 0, STATUS_R, STATUS_G, STATUS_B, 1.7f, 1, NULL, 0, static_cast<i32>(text_alpha * 128.0f));
 }
 
-void CollectCharcters_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void CollectCharcters_Skip(STATUS_STAGE_s *stage, STATUSPACKET_s *packet) {
+    if (stage->field_0x14 == 0) stage->field_0x14 = 1;
+    while (StatusCollectList.ids[stage->field_0x14 - 1] != -1) {
+        AddToCollection(StatusCollectList.ids[stage->field_0x14 - 1]);
+        ++stage->field_0x14;
+    }
+    NextStatusStage(packet);
+    NextStatusStage(packet);
 }
 
 void E1CharacterBonus_Init(WORLDINFO_s *) {
@@ -626,10 +694,60 @@ nuhspecial_s *CharScene_FindHSpecial(WORLDINFO_s *world, i32 character_id) {
 void LocalGetNearestLocator(AILOCATOR_s **, i32, float, nuvec_s *, float, i32, float, float) {
 }
 
-void newCharactersCollected(STATUSPACKET_s *) {
+void AddToCompletionPoints(u32);
+
+i32 newCharactersCollected(STATUSPACKET_s *) {
+    i32 count = 0;
+    for (i16 *player_id = Area_PlayerIDList; *player_id != -1 && count < 7; ++player_id) {
+        const i32 id = *player_id;
+        i32 previous = 0;
+        while (previous < count && StatusCollectList.ids[previous] != id) {
+            ++previous;
+        }
+        if (previous != count) {
+            continue;
+        }
+        if (Game_CharacterSave != NULL && (Game_CharacterSave[id] & 1) != 0) {
+            continue;
+        }
+        const i32 index = InCollectList_Index(id, MasterCollection.list, MasterCollection.count_y);
+        if (index != -1 && MasterCollection.list[index].can_buy == 0) {
+            StatusCollectList.ids[count++] = *player_id;
+            if (MasterCollection.list[index].field5_0x9 != 0) {
+                AddToCompletionPoints(POINTS_PER_CHARACTER);
+            }
+        }
+    }
+    StatusCollectList.ids[count] = -1;
+    return count;
 }
 
-void CollectCharcters_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void CollectCharcters_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x1c = 1.0f;
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= 1.0f) {
+            stage->field_0x14 = 1;
+            if (StatusCollectList.ids[0] == -1) {
+                GameAudio_PlaySfx(0x32, NULL, 0, 0);
+                NewStatusRumbleBuzz(-1, 0.6f, 0.0f, 0);
+                NextStatusStage(packet);
+            } else {
+                stage->field_0x18 = 0.0f;
+                stage->field_0x1c = 3.0f;
+            }
+        }
+    } else {
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) {
+            AddToCollection(StatusCollectList.ids[stage->field_0x14 - 1]);
+            PlaySfx(const_cast<char *>("LegoClicks"), NULL);
+            ++stage->field_0x14;
+            stage->field_0x18 = 0.0f;
+            stage->field_0x1c = 3.0f;
+            if (StatusCollectList.ids[stage->field_0x14 - 1] == -1) NextStatusStage(packet);
+        }
+    }
 }
 
 void RegisterGizmoTypes_Indy(variptr_u *, variptr_u *) {
@@ -644,7 +762,12 @@ void SetProtocolDroidFallAnim(GameObject_s *object) {
     object->apiobj.anim_packet.requested_animation = variant >= 1 && variant <= 3 ? fall_animations[variant - 1] : 5;
 }
 
-void CollectCharactersOff_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+void CollectCharactersOff_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 active) {
+    COLLECTION_s *collection = (packet->field_0xb0 & 0x80) != 0 ? &VehicleCollection : &CharacterCollection;
+    if (active == 0) return;
+    f32 alpha = 1.0f;
+    if (stage->field_0x14 > 0 && stage->field_0x1c != 0.0f && stage->field_0x18 != 0.0f) alpha = 1.0f - stage->field_0x18 / stage->field_0x1c;
+    Collection_Draw(collection, 0.0f, COLLECTION_Y_STATUS, collection->field_10, NULL, alpha, 0);
 }
 
 void CollectCharactersOff_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
@@ -661,7 +784,15 @@ void SetGameObjectCharacterData(GameObject_s *obj) {
     ScaleGameObject(obj);
 }
 
-void CollectCharactersOff_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void CollectCharactersOff_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x18 = 0.0f;
+        stage->field_0x1c = 1.0f;
+        stage->field_0x14 = 1;
+    } else if (stage->field_0x14 == 1) {
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) NextStatusStage(packet);
+    }
 }
 
 void TakeOverYodaSeekDistanceHack(GameObject_s *, GameObject_s *, nuvec_s *) {

--- a/src/legoapi/characters/core/playeritems.cpp
+++ b/src/legoapi/characters/core/playeritems.cpp
@@ -6,6 +6,7 @@
 #include "legoapi/characters/motion.h"
 #include "legoapi/characters/motion/gameanim.h"
 #include "legoapi/characters/motion/animlist.h"
+#include "legoapi/core/input/qrand.h"
 #include "legoapi/items/base/apiobject.h"
 #include "legoapi/items/objects/gameobjects.h"
 #include "legoapi/legoapi_types.h"
@@ -23,6 +24,21 @@ i32 GetDefaultIdle(GameObject_s *object);
 void ResetCharacterIdle(GameObject_s *object, i32 mode, i32 animation);
 i32 (*Fighting_WeaponInActionFn)(GameObject_s *) = NULL;
 i32 (*Fighting_WeaponOutActionFn)(GameObject_s *) = NULL;
+
+extern i32 adaptivedifficulty[3];
+
+i8 adtabentries[9][4] = {
+    {-1, -1, -1, -1},
+    {-1, -1, -1, 0},
+    {-1, -1, 0, 0},
+    {-1, 0, 0, 0},
+    {0, 0, 0, 0},
+    {1, 0, 0, 0},
+    {1, 1, 0, 0},
+    {1, 1, 1, 0},
+    {1, 1, 1, 1},
+};
+i8 (*adtab)[4] = &adtabentries[4];
 
 void LoseHelmet(GameObject_s *, i32, i32) {
 }
@@ -185,7 +201,54 @@ void KeepWeaponOut(GameObject_s *object) {
     object->field_0xef8 |= GAMEOBJECT_EF8_FLAG_KEEP_WEAPON_OUT;
 }
 
-void ReleaseHearts() {
+i32 ReleaseHearts() {
+    i32 total_hitpoints = 0;
+    i32 missing_hitpoints = 0;
+
+    GameObject_s *player = Player[0];
+    if (player != NULL && player->apiobj.field_0x287 == 0 && player->hitpoints != 0) {
+        total_hitpoints = player->hitpoints;
+        missing_hitpoints = player->hitpoints - static_cast<i8>(player->current_hp);
+    }
+
+    player = Player[1];
+    if (player != NULL && player->apiobj.field_0x287 == 0 && player->hitpoints != 0) {
+        total_hitpoints += player->hitpoints;
+        missing_hitpoints += player->hitpoints - static_cast<i8>(player->current_hp);
+    }
+
+    if (total_hitpoints == 0) {
+        return 0;
+    }
+
+    if (missing_hitpoints > 0 && MAXPARTS > 0) {
+        for (i32 index = 0; index < MAXPARTS; ++index) {
+            if ((Part[index].active & 1) != 0 && Part[index].type_id == 0xcb) {
+                --missing_hitpoints;
+            }
+        }
+    }
+
+    missing_hitpoints -= Game.save_version;
+    if (Game.save_version <= 5) {
+        missing_hitpoints += 8;
+    } else {
+        missing_hitpoints += 9;
+    }
+
+    i32 release_threshold = total_hitpoints;
+    if (missing_hitpoints <= total_hitpoints) {
+        release_threshold = missing_hitpoints < 0 ? 0 : missing_hitpoints;
+    }
+
+    i32 release_chance = (release_threshold << 16) / total_hitpoints;
+    const i32 difficulty_adjustment = static_cast<i8>(adtab[adaptivedifficulty[0]][1]);
+    if (difficulty_adjustment == 1) {
+        release_chance >>= 1;
+    } else if (difficulty_adjustment == -1) {
+        release_chance += release_chance;
+    }
+    return qrand() < release_chance;
 }
 
 void SlowWeaponOut(GameObject_s *object) {

--- a/src/legoapi/core/net/netplay.cpp
+++ b/src/legoapi/core/net/netplay.cpp
@@ -3,6 +3,13 @@
 #include "legoapi/core/input/qrand.h"
 #include "nu2api/nu3d/nutex.h"
 #include "nu2api/numath/nuvec.h"
+#include "globals.h"
+#include "legoapi/characters/core/players.h"
+#include "legoapi/world/world.h"
+#include "legoapi/world/area.h"
+#include "legoapi/world/level.h"
+#include "legoapi/world/mission.h"
+#include "nu2api/nusound/nusound.h"
 
 struct AIROW_s;
 struct nuqthdr_s;
@@ -88,10 +95,76 @@ void ResetPlayerPacket(PLAYERPACKET_s *packet, CHARACTERDATA_s *) {
 void FinishLoop_Network() {
 }
 
-void FinishStatusPacket(i32) {
+extern STATUSPACKET_s StatusPacket;
+extern FadeSystem FadeSys;
+extern i32 reset_area;
+extern i32 grab_screen_image;
+extern i32 hub_from_mission;
+void NeedScreenGrab(i32);
+void GrabStillScreen();
+void InitChallenge(i32);
+void InitMission(MISSIONSYS_s *, i32);
+
+void FinishStatusPacket(i32 choice) {
+    RememberPlayerIDs(1, static_cast<i16>(StatusPacket.player0_model), static_cast<i16>(StatusPacket.player1_model));
+    if (StatusPacket.finish_callback(WORLD, &StatusPacket, choice) != 0) {
+        return;
+    }
+    NewLData = HUB_LDATA;
+    if (choice == 0) {
+        if ((StatusPacket.mode_flags & 1) != 0 || StatusPacket.challenge_state != 0 || StatusPacket.mission_state != 0) {
+            NewLData = Area_FindNextPlayLevel(ADataList[StatusPacket.area->index].levels[0]);
+            FADETYPE fade = {FADE_TYPE_STILL_WIPE};
+            ResetBits = 0xffffffbf;
+            reset_area = 1;
+            FadeSys.SetFade(fade, 0);
+            NeedScreenGrab(1);
+            GrabStillScreen();
+            if (StatusPacket.challenge_state != 0) {
+                InitChallenge(StatusPacket.area->index);
+            }
+            if (StatusPacket.mission_state != 0) {
+                InitMission(MissionSys, static_cast<i8>(MissionSys->mission->count));
+                NewLData = &LDataList[MissionSys->mission->level];
+            }
+            goto destination_selected;
+        }
+        if (StatusPacket.next_area != -1) {
+            NewLData = &LDataList[ADataList[StatusPacket.next_area].levels[0]];
+            if ((ADataList[StatusPacket.next_area].flags & 2) == 0) {
+                loadareacharacters_no_backdrop_reset = 1;
+                if ((StatusPacket.mode_flags & 4) != 0) {
+                    finishloop_backdroponly = 1;
+                }
+            } else {
+                grab_screen_image = 1;
+            }
+            goto destination_selected;
+        }
+    }
+    if ((StatusPacket.mode_flags & 4) != 0 ||
+        ((StatusPacket.area->flags & 4) != 0 && (StatusPacket.field_0xb0 & 0x40) == 0)) {
+        NewLData = CREDITS_LDATA;
+    }
+destination_selected:
+    if ((StatusPacket.mode_flags & 8) != 0) {
+        NewLData = HUB_LDATA;
+    }
+    if (NewLData->area_index != -1 && (ADataList[NewLData->area_index].flags & 0x40) != 0 &&
+        StatusPacket.mission_state != 0 && MissionSys->mission != NULL) {
+        hub_from_mission = static_cast<i8>(MissionSys->mission->count);
+    }
+    OldBonusScore[0] = BonusScore[0];
+    OldBonusScore[1] = BonusScore[1];
+    if (NewLData == HUB_LDATA) {
+        OldBonusScore[0] = 0;
+        OldBonusScore[1] = 0;
+    }
+    NuSound3StopRumble();
 }
 
-void FinishStatusPacket_LSW(WORLDINFO_s *, STATUSPACKET_s *, i32) {
+i32 FinishStatusPacket_LSW(WORLDINFO_s *, STATUSPACKET_s *, i32) {
+    return 0;
 }
 
 void setObjInNetWaitContext(GameObject_s *, i32) {

--- a/src/legoapi/cutscenes/cutscene_stubs.cpp
+++ b/src/legoapi/cutscenes/cutscene_stubs.cpp
@@ -184,7 +184,7 @@ extern "C" {
     void instNuGCutSceneSetRepeat(void) {
     }
 
-    void instNuGCutSceneStop(void) {
+    void instNuGCutSceneStop(instNUGCUTSCENE_s *) {
     }
 
     void instNuGCutSceneTimeLeft(void) {

--- a/src/legoapi/cutscenes/cutscenes.cpp
+++ b/src/legoapi/cutscenes/cutscenes.cpp
@@ -29,6 +29,11 @@
 #include "nu2api/nusound/nusound.h"
 
 #include <string.h>
+#include <stdio.h>
+#include "legoapi/world/mission.h"
+#include "legoapi/world/levels/episode.h"
+#include "nu2api/numath/nutrig.h"
+#include "nu2api/numath/nufloat.h"
 
 extern i32 ACTIVECUTCOUNT;
 extern "C" i32 CUTDRAWWORLD;
@@ -1459,31 +1464,276 @@ CUTINFO *NewCutScene(CUTINFO *cut, CUTSYS *system, char *name, i32) {
     return cut;
 }
 
-void Exit_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void NextStatusStage(STATUSPACKET_s *);
+void FinishStatusPacket(i32);
+f32 StatusIconsOnOff(f32);
+extern f32 icon_y;
+
+void Exit_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 >= 0) {
+        stage->field_0x18 += elapsed;
+    }
+    if (stage->field_0x18 >= stage->field_0x1c) {
+        NextStatusStage(packet);
+        if (packet->current_gold_brick < packet->stage_count - 1) {
+            stage->field_0x1c = 0.1f;
+        } else {
+            FinishStatusPacket(packet->prompt_choice);
+        }
+    }
 }
 
-void Fade_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void Fade_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x18 = 0.0f;
+        stage->field_0x1c = 0.6f;
+        stage->field_0x14 = 1;
+    } else if (stage->field_0x14 == 1) {
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) {
+            FinishStatusPacket(packet->prompt_choice);
+        }
+        f32 ratio = 0.0f;
+        if (stage->field_0x1c != 0.0f && stage->field_0x18 != 0.0f) {
+            ratio = stage->field_0x18 / stage->field_0x1c;
+        }
+        icon_y = -StatusIconsOnOff(ratio);
+    }
 }
 
 void RelocateCutScene(NUGCUTSCENE_s *, variptr_u *) {
 }
 
-void GoldBrick_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+i32 STATUS_R = 255;
+i32 STATUS_G = 191;
+i32 STATUS_B;
+extern f32 iconalphaoverride;
+extern i16 tTRUEJEDI, tSTORY, tFREEPLAY;
+extern i16 tLEVELCOMPLETE, tFREEPLAYUNLOCKED, tSUPERSTORYCOMPLETE, tBONUSUNLOCKED;
+extern i16 tEPISODEVUNLOCKED, tEPISODEVIUNLOCKED, tCHALLENGECOMPLETE, tOUTOFTIME;
+extern i16 tYOUDIDNTCOLLECTALL10CANISTERS, tMISSIONCOMPLETE, tSTORYCLIPSUNLOCKED;
+extern i16 tEPISODEICOMPLETE, tEPISODEIICOMPLETE, tEPISODEIIICOMPLETE;
+extern i16 tEPISODEIVCOMPLETE, tEPISODEVCOMPLETE, tEPISODEVICOMPLETE;
+f32 getFinishedStatusAlpha(STATUSPACKET_s *);
+bool FreePlayUnlocked();
+void IncreaseScore(u32 *, u64, i32);
+void NewStatusRumbleBuzz(i32, f32, f32, i32);
+void Text_MakeScore(u32, char *);
+void AddFancyMessage(char *, f32, f32, f32, f32, i32, i32);
+void *AddGameMessage(char *, nuvec_s *, f32, nuvec_s *, f32, u8, u8, u8, u32, f32);
+extern "C" void PlaySfx(char *, nuvec_s *);
+extern "C" void Text3D(char *, f32, f32, f32, f32, f32, f32, u32, u8, u8, u8);
+i32 DrawPanel3DObjectNoAlpha(f32, f32, f32, f32, f32, f32, u16, u16, u16, nuhspecial_s *, i32);
+
+void GoldBrick_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 active) {
+    if (active == 0) return;
+    if (stage->field_0x14 > 0) {
+        const f32 time = stage->field_0x18;
+        if (time >= 1.0f && time < stage->field_0x1c - 1.0f) {
+            f32 blend = 1.0f;
+            i32 count = packet->previous_gold_bricks;
+            if (time >= 2.0f) {
+                const f32 end = stage->field_0x1c - 2.0f;
+                if (time >= end) blend = NuTrigTable[(static_cast<i32>((1.0f - (time - end)) * 16384.0f) >> 1) & 0x7fff];
+                count = Game.field_0x7c26[0];
+                if (time < (Game.field_0x7c26[0] - packet->previous_gold_bricks - 1) * 2.5f + 2.0f) {
+                    count = (packet->previous_gold_bricks + 1) + (time - 2.0f) / 2.5f;
+                }
+            } else blend = NuTrigTable[(static_cast<i32>((time - 1.0f) * 16384.0f) >> 1) & 0x7fff];
+            char text[268];
+            sprintf(text, "%i/%i", count, GOLDBRICKPOINTS);
+            SmartTextEx(text, 0.0f, blend * -0.99999994f + 1.3f, 1.0f, 1.5f, 1.5f, 1.5f, 0, 255, 255, 255, 1.7f, 1, NULL, 0, static_cast<i32>(blend * 128.0f));
+            const u32 angle = NuFmod(GlobalTimer.time_elapsed, 4.0f) * 0.25f * 65536.0f;
+            DrawPanel3DObjectNoAlpha(0.0f, blend * 0.99999994f - 1.3f, 1.0f, 1.0f, 1.0f, 1.0f,
+                static_cast<i32>(NuTrigTable[angle & 0x7fff] * 1820.0f), angle, 0, reinterpret_cast<nuhspecial_s *>(&WORLD->lev_objs[0xd3]), 2);
+            if (Game.field_0x7c26[0] > 60) CoinTotal_Draw(*packet->score, (STATSPOSY - STATSPOS2Y) * blend + STATSPOS2Y, CoinTotalScale, 1, 1.0f, 255, 191, 0);
+        }
+    }
+    if ((stage->field_0x14 == 0 || stage->field_0x18 < 1.0f) && packet->mission_state != 0 && packet->previous_gold_bricks < Game.field_0x7c26[0]) iconalphaoverride = 0.0f;
 }
 
-void GoldBrick_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void GoldBrick_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *packet) {
+    if (Game.field_0x7c26[0] < 61) NextStatusStage(packet);
 }
 
-void GoldBrick_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void GoldBrick_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    const i32 count = Game.field_0x7c26[0] - packet->previous_gold_bricks;
+    if (stage->field_0x14 == 0) {
+        stage->field_0x14 = 1;
+        stage->field_0x18 = 0.0f;
+        stage->field_0x1c = (count - 1) * 2.5f + 2.0f + 3.0f + 1.0f + 1.0f;
+    } else if (stage->field_0x14 == 1) {
+        const f32 previous = stage->field_0x18;
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) NextStatusStage(packet);
+        else for (i32 i = 0; i < count; ++i) {
+            const f32 at = i * 2.5f + 2.0f;
+            if (previous < at && stage->field_0x18 >= at) {
+                PlaySfx(const_cast<char *>("TrueJedi_100pc"), NULL);
+                NewStatusRumbleBuzz(-1, 0.6f, 0.0f, 0);
+                const i32 points = packet->previous_gold_bricks + i + 1;
+                char text[252];
+                sprintf(text, "%i/%i", points, GOLDBRICKPOINTS);
+                AddFancyMessage(text, 0.0f, 0.3f, 0.75f, 1.25f, 1, 1);
+                nuvec_s position = {0.0f, 0.0375f, 1.0f};
+                const i16 id = reinterpret_cast<i16 *>(packet->field_0x12c)[i];
+                char *label = TTab[id];
+                if (id == tTRUEJEDI) {
+                    NuStrCpy(text, label);
+                    if (BOTHTRUEJEDIGOLDBRICKS != 0) {
+                        NuStrCat(text, " ");
+                        NuStrCat(text, TTab[(packet->field_0xb0 & 0x40) != 0 ? tFREEPLAY : tSTORY]);
+                    }
+                    label = text;
+                }
+                AddGameMessage(label, &position, 0.7f, &position, 0.7f, 255, 0, 127, 0x4020, 2.0f);
+                if (points > 60) {
+                    IncreaseScore(packet->score, 100000, 0);
+                    CoinTotalScale = 1.5f;
+                    PlaySfx(const_cast<char *>("Shop_BuyCheat"), NULL);
+                    Text_MakeScore(100000, text);
+                    AddFancyMessage(text, 0.0f, -STATSPOSY, 0.5f, 1.25f, 0, 0);
+                }
+            }
+        }
+    }
 }
 
-void LevelComplete_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+void LevelComplete_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 active) {
+    if (active == 0) {
+        if (stage->field_0x12 != 0) {
+            const f32 alpha = getFinishedStatusAlpha(packet);
+            if ((stage->type == 26 && packet->mission_state == 2) || (stage->type == 23 && packet->challenge_state == 2)) {
+                CoinTotal_Draw(*packet->score, STATSPOSY, CoinTotalScale, 1, alpha, 255, 191, 0);
+            }
+        }
+        return;
+    }
+    char text[252];
+    if (stage->field_0x14 > 0) {
+        f32 alpha = 1.0f;
+        if (stage->field_0x18 < 0.5f) alpha = stage->field_0x18 + stage->field_0x18;
+        else if (stage->field_0x18 >= 3.5f) alpha = 1.0f - ((stage->field_0x18 - 3.5f) + (stage->field_0x18 - 3.5f));
+        if (alpha > 0.0f) {
+            const i32 opacity = alpha * 128.0f;
+            i16 first = -1, second = -1;
+            f32 y = 0.1f, scale = 0.7f;
+            i32 red = STATUS_R, green = STATUS_G, blue = STATUS_B;
+            switch (stage->type) {
+                case 14:
+                    strcpy(text, TTab[EDataList[packet->episode_id].text_id]);
+                    SmartTextEx(text, 0.0f, 0.1f, 1.0f, 0.525f, 0.525f, 0.525f, 0, red, green, blue, 1.7f, 1, NULL, 0, opacity);
+                    second = tSUPERSTORYCOMPLETE;
+                    break;
+                case 13:
+                    first = tLEVELCOMPLETE;
+                    if ((PODRACE_ADATA != NULL && packet->area == PODRACE_ADATA) || (BONUS_GUNSHIP_ADATA != NULL && packet->area == BONUS_GUNSHIP_ADATA) || !FreePlayUnlocked()) y = 0.0f;
+                    else second = tFREEPLAYUNLOCKED;
+                    break;
+                case 8: first = tEPISODEVUNLOCKED; second = tEPISODEVIUNLOCKED; break;
+                case 28: first = tBONUSUNLOCKED; y = 0.0f; break;
+                case 23:
+                    y = 0.0f;
+                    if (packet->challenge_state == 2) { first = tCHALLENGECOMPLETE; red = green = blue = 255; }
+                    else first = packet->challenge_state == 3 ? tOUTOFTIME : tYOUDIDNTCOLLECTALL10CANISTERS;
+                    break;
+                case 26:
+                    y = 0.0f;
+                    if (packet->mission_state == 2) { first = tMISSIONCOMPLETE; red = green = blue = 255; }
+                    else first = tOUTOFTIME;
+                    break;
+                case 29: first = tEPISODEICOMPLETE; second = tSTORYCLIPSUNLOCKED; break;
+                case 30: first = tEPISODEIICOMPLETE; second = tSTORYCLIPSUNLOCKED; break;
+                case 31: first = tEPISODEIIICOMPLETE; second = tSTORYCLIPSUNLOCKED; break;
+                case 32: first = tEPISODEIVCOMPLETE; second = tSTORYCLIPSUNLOCKED; break;
+                case 33: first = tEPISODEVCOMPLETE; second = tSTORYCLIPSUNLOCKED; break;
+                default: first = tEPISODEVICOMPLETE; second = tSTORYCLIPSUNLOCKED; break;
+            }
+            if (first != -1) SmartTextEx(TTab[first], 0.0f, y, 1.0f, scale, scale, scale, 0, red, green, blue, 1.7f, 1, NULL, 0, opacity);
+            if (second != -1) SmartTextEx(TTab[second], 0.0f, -0.1f, 1.0f, 0.7f, 0.7f, 0.7f, 0, STATUS_R, STATUS_G, STATUS_B, 1.7f, 1, NULL, 0, opacity);
+        }
+    }
+    if (stage->type != 23 && stage->type != 26) return;
+    if (stage->field_0x14 == 0 || stage->field_0x18 < stage->field_0x1c - 0.5f) iconalphaoverride = 0.0f;
+    else iconalphaoverride = (stage->field_0x18 - (stage->field_0x1c - 0.5f)) * 2.0f;
+    if (stage->type == 26) {
+        if (packet->mission_state != 2) return;
+        if (packet->previous_gold_bricks < Game.field_0x7c26[0]) iconalphaoverride = 0.0f;
+    } else if (packet->challenge_state != 2) return;
+    f32 progress, slide;
+    if (stage->field_0x18 < 0.75f) { progress = 0.0f; slide = stage->field_0x18 / 0.7f; }
+    else if (stage->field_0x18 >= stage->field_0x1c - 0.75f) {
+        progress = 1.0f;
+        slide = 1.0f - (stage->field_0x18 - (stage->field_0x1c - 0.75f)) / 0.75f;
+    } else {
+        progress = (stage->field_0x18 - 0.75f) / (stage->field_0x1c - 0.75f - 0.75f);
+        slide = 1.0f;
+    }
+    const f32 coin_slide = stage->field_0x18 < 0.75f ? slide : 1.0f;
+    u32 score = packet->original_score;
+    IncreaseScore(&score, static_cast<i64>(static_cast<i32>(static_cast<f32>(packet->reward_score - score) * progress)), 0);
+    CoinTotal_Draw(score, (STATSPOSY - STATSPOS2Y) * NuTrigTable[(static_cast<i32>(coin_slide * 16384.0f) >> 1) & 0x7fff] + STATSPOS2Y, CoinTotalScale, 1, 1.0f, 255, 191, 0);
+    f32 remaining = (stage->type == 26 ? static_cast<u16>(packet->mission->time) : packet->area->challenge_trial_time) - packet->elapsed_time;
+    if (remaining < 0.0f) remaining = 0.0f;
+    Text_MakeTime((1.0f - progress) * remaining, 0, 1, 1, text);
+    Text3D(text, 0.0f, -((STATSPOSY - STATSPOS2Y) * NuTrigTable[(static_cast<i32>(slide * 16384.0f) >> 1) & 0x7fff] + STATSPOS2Y), 1.0f, 0.6f, 0.6f, 0.6f, 0, 255, 191, 0);
 }
 
-void LevelComplete_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void LevelComplete_LSW_Skip(STATUS_STAGE_s *stage, STATUSPACKET_s *packet) {
+    if ((stage->type == 26 && packet->mission_state == 2) ||
+        (stage->type == 23 && packet->challenge_state == 2)) {
+        *packet->score = packet->reward_score;
+    }
+    NextStatusStage(packet);
 }
 
-void LevelComplete_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void SetDrawGoldBrick(STATUSPACKET_s *, i32);
+void NewStatusRumbleBuzz(i32, f32, f32, i32);
+extern "C" void PlaySfx(char *, nuvec_s *);
+
+void LevelComplete_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x18 = 0.0f;
+        stage->field_0x1c = 4.0f;
+        stage->field_0x14 = 1;
+        return;
+    }
+    if (stage->field_0x14 != 1) {
+        return;
+    }
+    SetDrawGoldBrick(packet, packet->current_gold_brick);
+    const f32 previous = stage->field_0x18;
+    stage->field_0x18 += elapsed;
+    if (stage->field_0x18 >= stage->field_0x1c) {
+        if ((stage->type == 26 && packet->mission_state == 2) ||
+            (stage->type == 23 && packet->challenge_state == 2)) {
+            *packet->score = packet->reward_score;
+        }
+        NextStatusStage(packet);
+        return;
+    }
+    if (previous < 0.5f && stage->field_0x18 >= 0.5f) {
+        if ((stage->type == 23 && packet->challenge_state == 3) ||
+            (stage->type == 26 && packet->mission_state == 3)) {
+            GameAudio_PlaySfx(0x32, NULL, 0, 0);
+        } else {
+            PlaySfx(const_cast<char *>("StatusAward"), NULL);
+        }
+        NewStatusRumbleBuzz(-1, 0.6f, 0.0f, 0);
+        return;
+    }
+    if ((stage->type != 26 || packet->mission_state != 2) &&
+        (stage->type != 23 || packet->challenge_state != 2)) {
+        return;
+    }
+    const f32 reward_end = stage->field_0x1c - 0.75f;
+    if (previous < reward_end && stage->field_0x18 >= reward_end) {
+        CoinTotalScale = 1.5f;
+        NewStatusRumbleBuzz(-1, 0.0f, 0.1f, 0);
+        PlaySfx(const_cast<char *>("Shop_BuyCheat"), NULL);
+    } else if (stage->field_0x18 >= 0.75f && stage->field_0x18 < reward_end) {
+        PlaySfx(const_cast<char *>("PickupCoin"), NULL);
+    }
 }
 
 static __used__ void Titles_Draw(WORLDINFO_s *) {

--- a/src/legoapi/gizmo/base/gizmo_sys.cpp
+++ b/src/legoapi/gizmo/base/gizmo_sys.cpp
@@ -2,6 +2,10 @@
 #include "decomp.h"
 #include "gameapi/edtools/edfile.h"
 #include "legoapi/gizmo/base/gizmo.h"
+#include "legoapi/gizmos/trigger/giztimer.h"
+#include "legoapi/gizmos/trigger/gizrandom.h"
+#include "legoapi/gizmos/trigger/gizspecial.h"
+#include "nu2api/nufile/nufpar.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -149,13 +153,367 @@ void GizmoSysAddGizmos(GIZMOSYS_s *gizmo_sys, GIZFLOW_s *giz_flow, void *world) 
         ResetGizFlowPointers(giz_flow);
     }
 }
-void *LoadGizFlow(void *world, GIZMOSYS_s *gizmo_sys, char *path, VARIPTR *buf, VARIPTR *buf_end) {
-    (void)world;
-    (void)gizmo_sys;
-    (void)path;
-    (void)buf;
-    (void)buf_end;
-    return NULL;
+// The .git loader uses a count pass followed by a command-table parse.
+// Collapsed editor groups are expanded through signed, sentinel-terminated links.
+struct FLOWREMAP_s {
+    i16 parents[16];
+    i16 children[32];
+    u8 outputs[16];
+};
+DECOMP_ASSERT(sizeof(FLOWREMAP_s) == 0x70, "flow remap ABI");
+struct FLOWGIZREF_s {
+    GIZMO_s *gizmo;
+    char *name;
+};
+struct FLOWACTION_s {
+    FLOWACTION_s *next;
+    char **arguments;
+    i32 argument_count;
+    GIZACTIONDEFN_s *definition;
+};
+DECOMP_ASSERT(sizeof(FLOWACTION_s) == 0x10, "flow action ABI");
+
+extern GIZACTIONDEFN_s *gizactiondefs;
+GIZMO_s *createGizTimer(void *, f32, i32, char *);
+GIZMO_s *createGizRandom(void *, i32, i32 *, char *);
+GIZMO_s *createGizSpecial(void *, char *);
+
+static i32 numRemaps;
+static FLOWREMAP_s *remap;
+static VARIPTR *load_buff, *load_endbuff;
+static i32 load_nflowboxes;
+static GIZFLOW_s *load_gizflow;
+static FLOWBOX_s *load_flowbox;
+static i32 load_nparents, load_nchildren, load_numgizmos;
+static i32 load_parents[16];
+static u8 load_parent_output_ix[16];
+static i32 load_children[32];
+static char load_name[32];
+static i32 load_conditiontype;
+static u8 load_conditionParam;
+static char load_gizmoname[32];
+static i32 load_gizmotype;
+static u16 load_g_flags;
+static u8 load_t_randomTime;
+static f32 load_t_time;
+static i32 load_r_noutputs;
+static i32 load_r_outputChance[8];
+
+static void xFlowBoxCount(NUFPAR *) { ++load_nflowboxes; }
+static void xStartInvis(NUFPAR *) { load_g_flags |= 1; }
+static void xEndDeact(NUFPAR *) { load_g_flags |= 8; }
+static void xEndInvis(NUFPAR *) { load_g_flags |= 2; }
+static void xReverse(NUFPAR *) { load_g_flags |= 4; }
+static void xReverseInvis(NUFPAR *) { load_g_flags |= 0x80; }
+static void xNotFreeplay(NUFPAR *) { load_g_flags |= 0x40; }
+static void xNotStoryMode(NUFPAR *) { load_g_flags |= 0x20; }
+static void xOutputOnly(NUFPAR *) { load_g_flags = 0x10; }
+static void xGizRandomTime(NUFPAR *) { load_t_randomTime = 1; }
+static void xMonitorInputs(NUFPAR *) { load_flowbox->state_flags |= 0x200; }
+static void xNumGizmos(NUFPAR *parser) { load_numgizmos = NuFParGetInt(parser); }
+static void loadSumBox(NUFPAR *parser) { load_conditionParam = NuFParGetInt(parser); }
+static void xGizTimer(NUFPAR *parser) { load_t_time = NuFParGetFloat(parser); }
+static void xRand_NumOutputs(NUFPAR *parser) { load_r_noutputs = NuFParGetInt(parser); }
+static void xRand_OutputChance(NUFPAR *parser) {
+    const i32 index = NuFParGetInt(parser);
+    load_r_outputChance[index] = NuFParGetInt(parser);
+}
+static void xAIAssistID(NUFPAR *parser) {
+    FLOWBOX_s *box = load_flowbox;
+    reinterpret_cast<u8 *>(&box->runtime_id)[0] = NuFParGetInt(parser);
+}
+static void xName(NUFPAR *parser) {
+    NuFParGetWord(parser);
+    if (parser->word_buf != NULL) NuStrNCpy(load_name, parser->word_buf, 32);
+}
+static void xGizmoName(NUFPAR *parser) {
+    NuFParGetWord(parser);
+    if (parser->word_buf != NULL) NuStrNCpy(load_gizmoname, parser->word_buf, 32);
+}
+static void xGizmoType(NUFPAR *parser) {
+    NuFParGetWord(parser);
+    if (parser->word_buf != NULL)
+        load_gizmotype = GizmoGetTypeIDByName(load_gizflow->gizmo_sys, parser->word_buf);
+}
+
+struct FLOWCONDITIONTYPE_s { i32 id; char *name; nufpcomfn *parse; };
+static FLOWCONDITIONTYPE_s ConditionTypes[] = {
+    {0, "All", NULL}, {1, "Any", NULL}, {2, "None", NULL}, {3, "Sum", loadSumBox},
+    {4, "loop", NULL}, {5, "exactly", loadSumBox}, {-1, NULL, NULL},
+};
+static void xConditionType(NUFPAR *parser) {
+    NuFParGetWord(parser);
+    for (i32 index = 0; ConditionTypes[index].id != -1 && load_conditiontype == -1; ++index) {
+        if (NuStrICmp(ConditionTypes[index].name, parser->word_buf) == 0) {
+            load_conditiontype = index;
+            if (ConditionTypes[index].parse != NULL) ConditionTypes[index].parse(parser);
+        }
+    }
+}
+
+static void remapParent(i32 id) {
+    if (load_nparents >= 16) return;
+    for (i32 index = 0; remap[~id].parents[index] != id; ++index) {
+        const i32 parent = remap[~id].parents[index];
+        if (parent < 0) remapParent(parent);
+        else {
+            load_parents[load_nparents] = parent;
+            load_parent_output_ix[load_nparents++] = remap[~id].outputs[index];
+        }
+        if (load_nparents >= 16) return;
+    }
+}
+static void remapChildren(i32 id) {
+    if (load_nchildren >= 32) return;
+    for (i32 index = 0; remap[~id].children[index] != id; ++index) {
+        const i32 child = remap[~id].children[index];
+        if (child < 0) remapChildren(child);
+        else load_children[load_nchildren++] = child;
+        if (load_nchildren >= 32) return;
+    }
+}
+static void xParent(NUFPAR *parser) {
+    if (load_nparents < 16) {
+        const i32 parent = NuFParGetInt(parser);
+        if (parent < 0) {
+            NuFParGetInt(parser);
+            remapParent(parent);
+        } else {
+            const i32 index = load_nparents;
+            load_parents[index] = parent;
+            load_parent_output_ix[index] = NuFParGetInt(parser);
+            ++load_nparents;
+        }
+    }
+}
+static void xChild(NUFPAR *parser) {
+    if (load_nchildren < 32) {
+        const i32 child = NuFParGetInt(parser);
+        if (child < 0) remapChildren(child);
+        else load_children[load_nchildren++] = child;
+    }
+}
+static void xParent_Col(NUFPAR *parser) {
+    if (load_nparents < 16) {
+        remap[numRemaps].parents[load_nparents] = NuFParGetInt(parser);
+        remap[numRemaps].outputs[load_nparents] = NuFParGetInt(parser);
+        ++load_nparents;
+    }
+}
+static void xChild_Col(NUFPAR *parser) {
+    if (load_nchildren < 32) {
+        remap[numRemaps].children[load_nchildren] = NuFParGetInt(parser);
+        ++load_nchildren;
+    }
+}
+
+static void xFlowBox(NUFPAR *);
+static void xCollapse(NUFPAR *);
+static void xCondition(NUFPAR *);
+static void xAction(NUFPAR *);
+static void xGizmo(NUFPAR *);
+static NUFPCOMJMP cfgtab_GitCount[] = {{"FlowBox", xFlowBoxCount}, {NULL, NULL}};
+static NUFPCOMJMP cfgtab_Git[] = {{"FlowBox", xFlowBox}, {"Collapse", xCollapse}, {NULL, NULL}};
+static NUFPCOMJMP cfgtab_Collapse[] = {{"Parent", xParent_Col}, {"Child", xChild_Col}, {NULL, NULL}};
+static NUFPCOMJMP cfgtab_FlowBox[] = {
+    {"Parent", xParent}, {"Child", xChild}, {"Gizmo", xGizmo}, {"Condition", xCondition},
+    {"Action", xAction}, {"Name", xName}, {"Num_Gizmos", xNumGizmos}, {"AIAssistId", xAIAssistID}, {NULL, NULL},
+};
+static NUFPCOMJMP cfgtab_Condition[] = {{"Type", xConditionType}, {"MonitorInputs", xMonitorInputs}, {NULL, NULL}};
+static NUFPCOMJMP cfgtab_Gizmo[] = {
+    {"Type", xGizmoType}, {"Name", xGizmoName}, {"StartInvisible", xStartInvis},
+    {"FinishedInvisible", xEndInvis}, {"FinishedDeactive", xEndDeact}, {"Reverse", xReverse},
+    {"RevInvis", xReverseInvis}, {"NotStoryMode", xNotStoryMode}, {"NotFreeplay", xNotFreeplay},
+    {"OutputOnly", xOutputOnly}, {"Timer", xGizTimer}, {"RandomTime", xGizRandomTime},
+    {"NumRandomOutputs", xRand_NumOutputs}, {"RandomOutputChance", xRand_OutputChance}, {NULL, NULL},
+};
+
+static void xCollapse(NUFPAR *parser) {
+    load_nparents = load_nchildren = 0;
+    NuFParPushCom(parser, cfgtab_Collapse);
+    while (NuFParGetLine(parser)) {
+        NuFParGetWord(parser);
+        if (NuStrICmp(parser->word_buf, "}") == 0) break;
+        NuFParInterpretWord(parser);
+    }
+    NuFParPopCom(parser);
+    remap[numRemaps].parents[load_nparents] = ~numRemaps;
+    remap[numRemaps].children[load_nchildren] = ~numRemaps;
+    ++numRemaps;
+}
+static void xFlowBox(NUFPAR *parser) {
+    load_nparents = load_nchildren = 0;
+    load_numgizmos = 1;
+    NuFParPushCom(parser, cfgtab_FlowBox);
+    while (NuFParGetLine(parser)) {
+        NuFParGetWord(parser);
+        if (NuStrICmp(parser->word_buf, "}") == 0) break;
+        NuFParInterpretWord(parser);
+    }
+    NuFParPopCom(parser);
+    if (load_gizflow != NULL && load_flowbox != NULL) {
+        if (load_nparents != 0) {
+            load_flowbox->parent_count = load_nparents;
+            load_flowbox->parents = reinterpret_cast<FLOWBOX_s **>(GizmoBufferAlloc(load_buff, load_endbuff, load_nparents * sizeof(FLOWBOX_s *)));
+            load_flowbox->output_indices = reinterpret_cast<u8 *>(GizmoBufferAlloc(load_buff, load_endbuff, load_nparents));
+            for (i32 i = 0; i < load_flowbox->parent_count; ++i) {
+                load_flowbox->parents[i] = &load_gizflow->flowboxes[load_parents[i]];
+                load_flowbox->output_indices[i] = load_parent_output_ix[i];
+            }
+        }
+        if (load_nchildren != 0) {
+            load_flowbox->child_count = load_nchildren;
+            load_flowbox->children = reinterpret_cast<FLOWBOX_s **>(GizmoBufferAlloc(load_buff, load_endbuff, load_nchildren * sizeof(FLOWBOX_s *)));
+            for (i32 i = 0; i < load_flowbox->child_count; ++i)
+                load_flowbox->children[i] = &load_gizflow->flowboxes[load_children[i]];
+        }
+        load_flowbox->name = reinterpret_cast<char *>(GizmoBufferAlloc(load_buff, load_endbuff, strlen(load_name) + 1));
+        NuStrCpy(load_flowbox->name, load_name);
+    }
+    --load_nflowboxes;
+    ++load_flowbox;
+}
+static void xCondition(NUFPAR *parser) {
+    if (load_flowbox == NULL) return;
+    load_flowbox->type = 1;
+    load_conditiontype = -1;
+    load_conditionParam = 0xff;
+    NuStrCpy(load_gizmoname, "");
+    NuFParPushCom(parser, cfgtab_Condition);
+    while (NuFParGetLine(parser)) {
+        NuFParGetWord(parser);
+        if (NuStrICmp(parser->word_buf, "}") == 0) break;
+        NuFParInterpretWord(parser);
+    }
+    NuFParPopCom(parser);
+    if (load_conditiontype >= 0) {
+        u8 *data = reinterpret_cast<u8 *>(GizmoBufferAlloc(load_buff, load_endbuff, 4));
+        if (data != NULL) { data[0] = load_conditiontype; data[1] = load_conditionParam; }
+        load_flowbox->data = reinterpret_cast<FLOWBOXGIZMODATA_s *>(data);
+    }
+}
+static void xAction(NUFPAR *parser) {
+    if (load_flowbox == NULL) return;
+    load_flowbox->type = 2;
+    FLOWACTION_s *previous = NULL;
+    char arguments[16][64];
+    while (NuFParGetLine(parser)) {
+        NuFParGetWord(parser);
+        if (NuStrICmp(parser->word_buf, "}") == 0) break;
+        if (gizactiondefs == NULL) continue;
+        GIZACTIONDEFN_s *definition = gizactiondefs;
+        while (definition->name != NULL && NuStrICmp(parser->word_buf, definition->name) != 0) ++definition;
+        if (definition->name == NULL) continue;
+        FLOWACTION_s *action = reinterpret_cast<FLOWACTION_s *>(GizmoBufferAlloc(load_buff, load_endbuff, sizeof(FLOWACTION_s)));
+        if (action == NULL) continue;
+        memset(action, 0, sizeof(*action));
+        if (previous == NULL) load_flowbox->data = reinterpret_cast<FLOWBOXGIZMODATA_s *>(action);
+        else previous->next = action;
+        action->definition = definition;
+        i32 count = 0;
+        while (NuFParGetWord(parser)) {
+            if (NuStrCmp(parser->word_buf, "\\") == 0) NuFParGetLine(parser);
+            else NuStrCpy(arguments[count++], parser->word_buf);
+        }
+        if (count != 0) {
+            action->arguments = reinterpret_cast<char **>(GizmoBufferAlloc(load_buff, load_endbuff, count * sizeof(char *)));
+            if (action->arguments != NULL) {
+                action->argument_count = count;
+                for (i32 i = 0; i < count; ++i) {
+                    const i32 length = NuStrLen(arguments[i]);
+                    char *value = NULL;
+                    if (length != 0) {
+                        value = reinterpret_cast<char *>(GizmoBufferAlloc(load_buff, load_endbuff, length + 1));
+                        NuStrCpy(value, arguments[i]);
+                    }
+                    action->arguments[i] = value;
+                }
+            }
+        }
+        previous = action;
+    }
+}
+static void xGizmo(NUFPAR *parser) {
+    if (load_flowbox == NULL) return;
+    FLOWBOXGIZMODATA_s *data = load_flowbox->data;
+    load_flowbox->type = 0;
+    load_gizmotype = -1;
+    load_g_flags = 0;
+    load_t_randomTime = 0;
+    if (data == NULL) {
+        load_flowbox->data = reinterpret_cast<FLOWBOXGIZMODATA_s *>(GizmoBufferAlloc(load_buff, load_endbuff, sizeof(FLOWBOXGIZMODATA_s)));
+        data = load_flowbox->data;
+        *reinterpret_cast<i32 *>(data->pad_0x04) = load_numgizmos;
+        data->gizmos = reinterpret_cast<GIZMO_s ***>(GizmoBufferAlloc(load_buff, load_endbuff, load_numgizmos * sizeof(GIZMO_s **)));
+        data->gizmo_count = 0;
+    }
+    NuStrCpy(load_gizmoname, "");
+    NuFParPushCom(parser, cfgtab_Gizmo);
+    while (NuFParGetLine(parser)) {
+        NuFParGetWord(parser);
+        if (NuStrICmp(parser->word_buf, "}") == 0) break;
+        NuFParInterpretWord(parser);
+    }
+    NuFParPopCom(parser);
+    if (load_gizmotype < 0 || NuStrLen(load_gizmoname) == 0) return;
+    const i32 name_length = NuStrLen(load_gizmoname);
+    const i32 prefix_length = NuStrLen(gizmotypes->types[load_gizmotype].prefix);
+    data->gizmos[data->gizmo_count] = reinterpret_cast<GIZMO_s **>(GizmoBufferAlloc(load_buff, load_endbuff, sizeof(FLOWGIZREF_s)));
+    FLOWGIZREF_s *ref = reinterpret_cast<FLOWGIZREF_s *>(data->gizmos[data->gizmo_count]);
+    ref->name = reinterpret_cast<char *>(GizmoBufferAlloc(load_buff, load_endbuff, name_length + prefix_length + 1));
+    NuStrCpy(ref->name, load_gizmoname);
+    if (load_gizmotype == giztimer_gizmotype_id) ref->gizmo = createGizTimer(NULL, load_t_time, load_t_randomTime, load_gizmoname);
+    else if (load_gizmotype == gizrandom_gizmotype_id) ref->gizmo = createGizRandom(NULL, load_r_noutputs, load_r_outputChance, load_gizmoname);
+    else if (load_gizmotype == gizspecial_gizmotype_id) {
+        ref->gizmo = createGizSpecial(NULL, load_gizmoname);
+        if (ref->gizmo != NULL) {
+            NuStrCpy(ref->name, gizmotypes->types[load_gizmotype].prefix);
+            NuStrNCat(ref->name, load_gizmoname, 32 - NuStrLen(gizmotypes->types[load_gizmotype].prefix));
+        }
+    } else ref->gizmo = GizmoFindByName(load_gizflow->gizmo_sys, load_gizmotype, load_gizmoname);
+    ++data->gizmo_count;
+    load_flowbox->state_flags = (load_flowbox->state_flags & 0x8f23) |
+        ((load_g_flags & 1) << 2) | ((load_g_flags & 2) << 2) | ((load_g_flags & 8) << 1) |
+        ((load_g_flags & 4) << 4) | (load_g_flags & 0x80) | ((load_g_flags & 0x10) << 8) |
+        (((load_g_flags ^ 0x20) & 0x20) << 9) | (((load_g_flags ^ 0x40) & 0x40) << 7);
+}
+
+void *LoadGizFlow(void *, GIZMOSYS_s *gizmo_sys, char *path, VARIPTR *buf, VARIPTR *buf_end) {
+    FLOWREMAP_s remaps[96];
+    numRemaps = 0;
+    remap = remaps;
+    load_buff = buf;
+    load_endbuff = buf_end;
+    load_nflowboxes = 0;
+    GIZFLOW_s *flow = NULL;
+    const NUFILE file = NuFileOpen(path, NUFILE_READ);
+    if (file != 0) {
+        NUFPAR *parser = NuFParOpen(file);
+        if (parser != NULL) {
+            NuFParPushCom(parser, cfgtab_GitCount);
+            while (NuFParGetLine(parser)) { NuFParGetWord(parser); NuFParInterpretWord(parser); }
+            NuFParClose(parser);
+        }
+        if (load_nflowboxes != 0 && (parser = NuFParOpen(file)) != NULL) {
+            flow = reinterpret_cast<GIZFLOW_s *>(GizmoBufferAlloc(load_buff, load_endbuff, sizeof(GIZFLOW_s)));
+            if (flow != NULL) {
+                flow->flowbox_count = load_nflowboxes;
+                flow->gizmo_sys = gizmo_sys;
+                load_flowbox = reinterpret_cast<FLOWBOX_s *>(GizmoBufferAlloc(load_buff, load_endbuff, load_nflowboxes * sizeof(FLOWBOX_s)));
+                flow->flowboxes = load_flowbox;
+                load_gizflow = flow;
+                NuFParPushCom(parser, cfgtab_Git);
+                while (NuFParGetLine(parser)) { NuFParGetWord(parser); NuFParInterpretWord(parser); }
+                flow->pointers_need_reset = 1;
+            }
+            NuFParClose(parser);
+        }
+        NuFileClose(file);
+    }
+    load_buff = load_endbuff = NULL;
+    load_gizflow = NULL;
+    load_flowbox = NULL;
+    return flow;
 }
 
 static __used__ i32 Loop_CountLoopingInputsEx(FLOWBOX_s *, FLOWBOX_s *, i32, u8) {

--- a/src/legoapi/gizmo/object/gizrandom.cpp
+++ b/src/legoapi/gizmo/object/gizrandom.cpp
@@ -3,6 +3,7 @@
 #include "legoapi/gizmos/trigger/gizrandom.h"
 #include "legoapi/legoapi_types.h"
 #include "legoapi/world/world.h"
+#include "legoapi/world/level.h"
 #include "nu2api/nu3d/nutex.h"
 #include "nu2api/nucore/nustring.h"
 
@@ -14,10 +15,10 @@ struct SHOPINPUT;
 void randyfloat() {
 }
 
-void createGizRandom(void *, i32 output_count, i32 *output_weights, char *name) {
+GIZMO_s *createGizRandom(void *, i32 output_count, i32 *output_weights, char *name) {
     WORLDINFO *world = WorldInfo_CurrentlyLoading();
-    if (world == NULL || world->giz_randoms == NULL || world->giz_randoms->count == world->giz_randoms->capacity) {
-        return;
+    if (world == NULL || world->giz_randoms->count == world->current_level->max_giz_randoms) {
+        return NULL;
     }
 
     GIZRANDOM *random = &world->giz_randoms->randoms[world->giz_randoms->count];
@@ -27,7 +28,7 @@ void createGizRandom(void *, i32 output_count, i32 *output_weights, char *name) 
     }
     NuStrNCpy(random->name, name, sizeof(random->name));
     ++world->giz_randoms->count;
-    AddGizmo(world->gizmo_sys, gizrandom_gizmotype_id, NULL, random);
+    return AddGizmo(world->gizmo_sys, gizrandom_gizmotype_id, NULL, random);
 }
 
 i32 RandomIDFromFlags(u32, u32, i32, APICHARACTERMODELLIST_s *, i32) {

--- a/src/legoapi/gizmo/object/gizspecial.cpp
+++ b/src/legoapi/gizmo/object/gizspecial.cpp
@@ -1,6 +1,9 @@
 #include "decomp.h"
 #include "legoapi/gizmos/trigger/gizspecial.h"
 #include "legoapi/legoapi_types.h"
+#include "legoapi/characters/motion/gameanim.h"
+#include "legoapi/world/world.h"
+#include "legoapi/world/level.h"
 #include "nu2api/nucore/nustring.h"
 #include "nu2api/nu3d/nuspecial.h"
 #include "nu2api/nu3d/nutex.h"
@@ -10,7 +13,30 @@ struct nuqthdr_s;
 struct nunativegscene_s;
 struct SHOPINPUT;
 
-void createGizSpecial(void *, char *) {
+GIZMO_s *createGizSpecial(void *, char *name) {
+    WORLDINFO *world = WorldInfo_CurrentlyLoading();
+    if (world != NULL && name != NULL) {
+        nuhspecial_s special;
+        char gizmo_name[32];
+        NuSpecialFind(world->current_gscn, &special, name, 0);
+        NuStrCpy(gizmo_name, "Spec_");
+        NuStrNCat(gizmo_name, name, 32 - NuStrLen("Spec_"));
+        if (NuSpecialExistsFn(&special)) {
+            GIZMO_s *gizmo = GizmoFindByName(world->gizmo_sys, gizspecial_gizmotype_id, gizmo_name);
+            if (gizmo != NULL) {
+                return gizmo;
+            }
+            if (world->giz_special_sys->count < world->current_level->max_giz_specials) {
+                GIZSPECIAL_s *entry = &world->giz_special_sys->specials[world->giz_special_sys->count];
+                GameAnimSet_AddObject(entry->anim_set, &special, 1.0f, 1e9f, 0);
+                ++world->giz_special_sys->count;
+                NuStrCpy(entry->name, "Spec_");
+                NuStrNCat(entry->name, name, 32 - NuStrLen("Spec_"));
+                return AddGizmo(world->gizmo_sys, gizspecial_gizmotype_id, NULL, entry);
+            }
+        }
+    }
+    return NULL;
 }
 
 char *GizSpecial_GetName(GIZSPECIAL_s *special) {

--- a/src/legoapi/gizmo/object/giztimers.cpp
+++ b/src/legoapi/gizmo/object/giztimers.cpp
@@ -1,5 +1,9 @@
 #include "decomp.h"
 #include "legoapi/legoapi_types.h"
+#include "legoapi/gizmos/trigger/giztimer.h"
+#include "legoapi/world/world.h"
+#include "legoapi/world/level.h"
+#include "nu2api/nucore/nustring.h"
 #include "nu2api/nu3d/nutex.h"
 
 struct AIROW_s;
@@ -7,5 +11,16 @@ struct nuqthdr_s;
 struct nunativegscene_s;
 struct SHOPINPUT;
 
-void createGizTimer(void *, float, i32, char *) {
+GIZMO_s *createGizTimer(void *, float time, i32 random_time, char *name) {
+    WORLDINFO *world = WorldInfo_CurrentlyLoading();
+    if (world == NULL || world->giz_timers == NULL ||
+        world->giz_timers_count == world->current_level->max_giz_timers) {
+        return NULL;
+    }
+    GIZTIMER *timer = &world->giz_timers[world->giz_timers_count];
+    timer->start_time = time;
+    timer->flags = (timer->flags & 0xfd) | ((random_time & 1) << 1);
+    NuStrNCpy(timer->name, name, 16);
+    ++world->giz_timers_count;
+    return AddGizmo(world->gizmo_sys, giztimer_gizmotype_id, NULL, timer);
 }

--- a/src/legoapi/gizmos/traps/gizforce.cpp
+++ b/src/legoapi/gizmos/traps/gizforce.cpp
@@ -16,6 +16,7 @@
 #include "nu2api/nu3d/nucamera.h"
 #include "nu2api/nu3d/nurndr.h"
 #include "nu2api/nucore/nustring.h"
+#include "nu2api/numath/nuvec.h"
 #include "nu2api/numusic/sfx.h"
 
 #include <string.h>
@@ -90,6 +91,11 @@ i32 GizmoBlowupGetNameTableId(char *name);
 i32 GizmoBlowupGetTypeFromNameTableId(WORLDINFO_s *world, i32 name_table_id);
 i32 MatrixReflection(NUMTX *matrix, i32 axis, f32 plane, f32 scale, NUMTX *result);
 void GameAnimSet_DrawReflection(GAMEANIMSET_s *set, i32 flags, f32 alpha, NUMTX *matrix);
+void GizmoBlowUpTypeBlowUp(WORLDINFO_s *world, i32 blowup_type, NUVEC *position);
+void AddPickups(i32 count, i32 pickup_type, i32 param3, i32 param4, NUVEC *position, NUVEC *direction, f32 speed,
+                i32 source, f32 scatter_height, f32 lifetime, GameObject_s *owner, i32 param12, i32 param13,
+                bool param14);
+i32 ReleaseHearts();
 void AddLevelSfxFromId(i32 sfx_id, i32 *sfx_ids, i32 *sfx_count, i32 max_sfx);
 void AddShoveObject(nuhspecial_s *special, i16 character_id);
 
@@ -199,6 +205,52 @@ static void GizForce_UpdateGroupState(GIZFORCE_s *force) {
     }
 }
 
+static void GizForce_ReleaseCompletion(WORLDINFO *world, GIZFORCE_s *force) {
+    GAMEANIMSET_s *anim_set = force->anim_set;
+    if ((anim_set->flags &
+         (GAMEANIMSET_FLAG_NO_VISIBILITY_TEST | GAMEANIMSET_FLAG_STOP_REQUESTED | GAMEANIMSET_FLAG_IN_SYSTEM_LIST)) !=
+            0 ||
+        anim_set->state != GAMEANIMSET_STATE_AT_END ||
+        (force->progress_flags & GIZFORCE_PROGRESS_GROUP_MEMBER) != 0 ||
+        (force->force_range > 0.0f &&
+         (force->runtime_flags & GIZFORCE_RUNTIME_FORCE_RANGE_COMPLETE) == 0) ||
+        ((force->config_flags & GIZFORCE_CONFIG_ALONG_SOCKET) != 0 &&
+         (force->runtime_flags & GIZFORCE_RUNTIME_ALONG_SOCKET_HIDDEN) == 0) ||
+        (anim_set->animated_object_count == 0 && force->force_range <= 0.0f &&
+         (force->config_flags & GIZFORCE_CONFIG_ALONG_SOCKET) == 0) ||
+        (force->runtime_flags & GIZFORCE_RUNTIME_COMPLETION_RELEASED) != 0) {
+        return;
+    }
+
+    if (force->blowup_type != -1) {
+        if ((force->config_flags & GIZFORCE_CONFIG_BLOWUP_AT_ANIM_OBJECTS) != 0) {
+            for (GAMEANIMOBJ_s *object = anim_set->objects; object != NULL; object = object->next) {
+                NUVEC *draw_position = NuSpecialGetDrawPos(&object->special);
+                if (draw_position != NULL) {
+                    GizmoBlowUpTypeBlowUp(world, force->blowup_type, draw_position);
+                }
+            }
+        } else {
+            GizmoBlowUpTypeBlowUp(world, force->blowup_type, &force->position);
+        }
+        GameAnimSet_SetVisibility(anim_set, 0);
+        force->state_flags |= GIZFORCE_STATE_DESTROYED_OR_THROWN;
+    }
+
+    if (force->pickup_count != 0 && (force->runtime_flags & GIZFORCE_RUNTIME_REWARD_RELEASED) == 0) {
+        NUVEC pickup_position;
+        NUVEC pickup_direction;
+        NuVecAdd(&pickup_position, &force->position, &force->pickup_offset);
+        NuVecRotateX(&pickup_direction, &v010, force->pickup_direction_x);
+        NuVecRotateY(&pickup_direction, &pickup_direction, force->pickup_direction_y);
+        AddPickups(static_cast<u16>(force->pickup_count), ReleaseHearts(), 0, 0, &pickup_position, &pickup_direction,
+                   2.0f, -1, force->pickup_scatter_height, 2000000.0f, NULL, 1, 0, true);
+        force->runtime_flags |= GIZFORCE_RUNTIME_REWARD_RELEASED;
+    }
+
+    force->runtime_flags |= GIZFORCE_RUNTIME_COMPLETION_RELEASED;
+}
+
 static void GizForces_Update(void *world_ptr, void *data, float) {
     WORLDINFO *world = static_cast<WORLDINFO *>(world_ptr);
     GIZFORCESYS_s *force_sys = static_cast<GIZFORCESYS_s *>(data);
@@ -270,19 +322,23 @@ static void GizForces_Update(void *world_ptr, void *data, float) {
             if (GizForce_AnimComplete(force) != 0) {
                 if ((force->config_flags & GIZFORCE_CONFIG_WAIT_FOR_FORCE_RANGE) != 0 || force->field_0x48 > 0.0f) {
                     force->field_0x48 -= FRAMETIME;
-                    if (force->field_0x48 < 0.0f) {
+                    if (force->field_0x48 <= 0.0f) {
                         force->field_0x48 = 0.0f;
+                        if ((force->config_flags & GIZFORCE_CONFIG_ALONG_SOCKET) != 0 &&
+                            (force->runtime_flags & GIZFORCE_RUNTIME_ALONG_SOCKET_HIDDEN) != 0) {
+                            GameAnimSet_SetVisibility(force->anim_set, 1);
+                            force->runtime_flags &= static_cast<u8>(~GIZFORCE_RUNTIME_ALONG_SOCKET_HIDDEN);
+                        }
+                        GizForce_PlayBackwards(force);
+                        force->runtime_flags &= static_cast<u8>(~GIZFORCE_RUNTIME_FORCE_RANGE_COMPLETE);
                     }
-                }
-                if (force->field_0x48 == 0.0f) {
-                    GizForce_PlayBackwards(force);
-                    force->runtime_flags &= static_cast<u8>(~GIZFORCE_RUNTIME_FORCE_RANGE_COMPLETE);
                 }
             } else {
                 GizForce_PlayBackwards(force);
             }
         }
 
+        GizForce_ReleaseCompletion(world, force);
         GizForce_UpdateGroupState(force);
         force->radius = 1.0f;
         force->position = force->file_position;

--- a/src/legoapi/items/base/collection.cpp
+++ b/src/legoapi/items/base/collection.cpp
@@ -10,6 +10,11 @@
 #include "nu2api/nufile/nufpar.h"
 
 #include <string.h>
+#include <stdlib.h>
+#include "legoapi/characters/motion.h"
+#include "legoapi/items/objects/gameobjects.h"
+#include "nu2api/numath/nutrig.h"
+#include "nu2api/numath/nufloat.h"
 struct GIZMOPICKUP_s;
 struct PART_s;
 struct starfighter_s;
@@ -218,7 +223,99 @@ LAB_004eb920:
     goto LAB_004eb886;
 }
 
-void Collection_Draw(COLLECTION_s *, float, float, float, APICHARACTERMODELLIST_s *, float, i32) {
+f32 COLLECTION_DX = 0.15f;
+f32 COLLECTION_DY = -0.2f;
+f32 COLLECTION_ICONSIZE = 0.16f;
+i32 LEGOOBJ_ICON_FRAME_NEUTRAL = -1;
+i32 LEGOOBJ_ICON_FRAME_BLUE = -1;
+i32 LEGOOBJ_ICON_FRAME_GREEN = -1;
+nuhspecial_s *collection_draw_hspecial;
+i32 (*collection_draw_IsValidFn)(COLLECTION_s *, i32);
+void (*Collection_GetSelectingPlayerIDsFn)(i16 *);
+void DrawCharIcon(i32, f32, f32, f32, f32, i32, f32, f32, i32, nuhspecial_s *);
+extern FadeSystem FadeSys;
+
+void Collection_Draw(COLLECTION_s *collection, float x, float y, float scale, APICHARACTERMODELLIST_s *models, float alpha, i32 hide_selected) {
+    nuhspecial_s *special = collection_draw_hspecial;
+    i32 (*valid)(COLLECTION_s *, i32) = collection_draw_IsValidFn;
+    collection_draw_hspecial = NULL;
+    collection_draw_IsValidFn = NULL;
+    if (collection->list == NULL || FadeSys.fade > 0.0f) return;
+    const u32 count = collection->count_y;
+    const u32 columns = collection->count_x;
+    if (count == 0 || columns == 0) return;
+    f32 dx = COLLECTION_DX * scale;
+    f32 size = COLLECTION_ICONSIZE * scale;
+    const u32 rows = count / columns + (count % columns != 0);
+    if (Game_OptionsSave != NULL && Game_OptionsSave->field11_0xb != 0) {
+        dx *= 0.75f;
+        size *= 0.875f;
+    }
+    i32 selected_x[2] = {-1, -1};
+    i32 selected_y[2] = {-1, -1};
+    if (models != NULL && Collection_GetSelectingPlayerIDsFn != NULL) {
+        i16 ids[2] = {-1, -1};
+        Collection_GetSelectingPlayerIDsFn(ids);
+        if (ids[0] != -1 || ids[1] != -1) {
+            i32 found = 0;
+            for (u32 row = 0; row < rows; ++row) for (u32 col = 0; col < columns; ++col) {
+                const u32 index = row * columns + col;
+                if (found != 2 && index < count && (collection->list[index].id == ids[0] || collection->list[index].id == ids[1])) {
+                    selected_x[found] = col;
+                    selected_y[found++] = row;
+                }
+            }
+        }
+    }
+    const f32 dy = COLLECTION_DY * scale;
+    collection->field_14 = dy;
+    if (alpha > 1.0f) alpha = 1.0f;
+    f32 py = y - static_cast<i32>(rows - 1) * dy * 0.5f;
+    for (u32 row = 0; row < rows; ++row) {
+        f32 px = x - static_cast<i32>(columns - 1) * dx * 0.5f;
+        for (u32 col = 0; col < columns; ++col, px += dx) {
+            const u32 index = row * columns + col;
+            if (index >= count) continue;
+            COLLECTID *entry = &collection->list[index];
+            i32 id = entry->id;
+            *reinterpret_cast<f32 *>(reinterpret_cast<u8 *>(entry) + 0x14) = px;
+            *reinterpret_cast<f32 *>(reinterpret_cast<u8 *>(entry) + 0x18) = py;
+            if (alpha <= 0.0f) continue;
+            i32 frame = LEGOOBJ_ICON_FRAME_NEUTRAL;
+            f32 opacity = 1.0f;
+            i32 model_index;
+            if (models != NULL && InModelList(models, id, &model_index) != 0) {
+                if (hide_selected != 0) continue;
+                opacity = 0.25f;
+                if (model_index == 0 || model_index == 1) {
+                    frame = model_index == 0 ? LEGOOBJ_ICON_FRAME_BLUE : LEGOOBJ_ICON_FRAME_GREEN;
+                    opacity = NuTrigTable[(static_cast<i32>(GlobalTimer.time_elapsed_mod_seconds * 65536.0f) >> 1) & 0x7fff] * 0.125f + 0.375f;
+                }
+            }
+            const i32 unlocked = valid != NULL ? valid(collection, index) : Collection_Got(id);
+            if (unlocked == 0) { opacity *= 0.25f; id = -1; }
+            opacity *= alpha;
+            if (opacity <= 0.0f) continue;
+            u32 neighbours = 0;
+            for (i32 player = 0; player < 2; ++player) {
+                if (selected_x[player] == -1 || selected_y[player] == -1) continue;
+                const i32 ax = abs(static_cast<i32>(col) - selected_x[player]);
+                const i32 ay = abs(static_cast<i32>(row) - selected_y[player]);
+                if ((ax == 0 && ay == 1) || (ax == 1 && ay == 0)) neighbours |= 1;
+                else if (ax == 1 && ay == 1) neighbours |= 2;
+                else if ((ax == 0 && ay == 2) || (ax == 2 && ay == 0)) neighbours |= 4;
+            }
+            if ((neighbours & 1) != 0) opacity *= 0.333f;
+            else if ((neighbours & 2) != 0) opacity *= 0.5f;
+            else if ((neighbours & 4) != 0) opacity *= 0.666f;
+            if (special == NULL) DrawCharIcon(id, px, py, 0.002f, size, frame, opacity, opacity, 1, NULL);
+            else {
+                drawcharicon_hspecial_spin = static_cast<i32>((NuFmod(GameTimer.time_elapsed, 3.0f) / 3.0f) * 65536.0f) + index * 0x1555;
+                DrawCharIcon(-1, px, py, 0.002f, size, frame, opacity, opacity, 1, unlocked != 0 ? special : NULL);
+            }
+        }
+        py += dy;
+    }
 }
 
 void Collection_GetPos(COLLECTION_s *collection, i32 id, float *x, float *y) {
@@ -385,10 +482,27 @@ void PartStop_Coin(PART_s *) {
 void ShipDropCoins(starfighter_s *) {
 }
 
-void AddToCollection(i32) {
+i32 AddToCollection(i32 id) {
+    if (id > 0 && id < CHARCOUNT && InCollectList_Index(id, NULL, 0) != -1 && Collection_Got(id) == 0) {
+        if (Game_CharacterSave != NULL) Game_CharacterSave[id] |= 3;
+        return 1;
+    }
+    return 0;
 }
 
+void (*Game_AllGoldBricksFn)();
+void (*Game_100PercentFn)();
+
 void AddToGoldBricks() {
+    STATUSCOLLECT_s *save = reinterpret_cast<STATUSCOLLECT_s *>(Game_CompletionSave);
+    const i32 points = GOLDBRICKPOINTS;
+    if (save != NULL && save->gold_bricks < points) {
+        ++save->gold_bricks;
+        if (save->gold_bricks == points && (save->flags & 2) == 0) {
+            if (Game_AllGoldBricksFn != NULL) Game_AllGoldBricksFn();
+            reinterpret_cast<STATUSCOLLECT_s *>(Game_CompletionSave)->flags |= 2;
+        }
+    }
 }
 
 void Pup_CollectCoin(WORLDINFO_s *world, GIZMOPICKUP_s *pickup, i32 type, GameObject_s *object, i32 arg) {
@@ -409,7 +523,22 @@ void UpdateCoinPacket(COINPACKET_s *, i32, i32) {
 void TotalLevelCoinTally(WORLDINFO_s *, u32 *, u32 *, u32 *, u32 *, u32 *, u32 *, u32 *) {
 }
 
-void AddToCompletionPoints(u32) {
+void AddToCompletionPoints(u32 points) {
+    STATUSCOLLECT_s *save = reinterpret_cast<STATUSCOLLECT_s *>(Game_CompletionSave);
+    const i32 maximum = COMPLETIONPOINTS;
+    if (save != NULL && save->completion_points < maximum) {
+        save->completion_points += points;
+        if (save->completion_points >= maximum) {
+            save->completion_points = maximum;
+            if ((save->flags & 1) == 0) {
+                if (Game_100PercentFn != NULL) {
+                    Game_100PercentFn();
+                    save = reinterpret_cast<STATUSCOLLECT_s *>(Game_CompletionSave);
+                }
+                save->flags |= 1;
+            }
+        }
+    }
 }
 
 COLLECTION_s *GetFreePlayCollection(i32 area) {

--- a/src/legoapi/items/collect/minikits.cpp
+++ b/src/legoapi/items/collect/minikits.cpp
@@ -4,6 +4,12 @@
 #include "legoapi/legoapi_types.h"
 #include "legoapi/world/area.h"
 #include "nu2api/nu3d/nutex.h"
+#include "legoapi/menus/core/text.h"
+#include "legoapi/characters/core/character.h"
+#include "legoapi/render/core/render.h"
+#include "nu2api/numath/nutrig.h"
+#include <math.h>
+#include <stdio.h>
 
 struct AIROW_s;
 struct nuqthdr_s;
@@ -41,19 +47,213 @@ void MiniKitDetector(nuvec_s *) {
 void CharMiniKit_Draw(i32, numtx_s *, i32, float, float) {
 }
 
-void MiniKit_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+extern i32 currentminikit, newminikitcount;
+f32 slideseek;
+f32 pop_timer;
+f32 jibberlen = 0.1f;
+f32 slidetime = 0.25f;
+void NextStatusStage(STATUSPACKET_s *);
+void SetDrawGoldBrick(STATUSPACKET_s *, i32);
+void IncreaseScore(u32 *, u64, i32);
+void NewStatusRumbleBuzz(i32, f32, f32, i32);
+extern "C" void PlaySfx(char *, nuvec_s *);
+i32 FindGameMsgsWithID(i32, i32, i32, GAMEMESSAGE_s *);
+void AddStatusMiniKitParts();
+void DrawStatusMiniKit(f32, f32, f32, f32, f32, i32, STATUSPACKET_s *, f32);
+void DrawMiniKitCount(f32, f32, i32, i32);
+f32 getFinishedStatusAlpha(STATUSPACKET_s *);
+extern f32 STATUS_TITLE_Y;
+extern i16 tMINIKIT;
+
+void MiniKit_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 current) {
+    char text[60];
+    if (current == 0) {
+        if (stage->field_0x12 == 0) return;
+        const f32 alpha = getFinishedStatusAlpha(packet);
+        i32 angle = 0x2000;
+        if (GameTimer.time_elapsed_mod_seconds <= 0.25f) {
+            angle = (static_cast<i32>(GameTimer.time_elapsed_mod_seconds * 32768.0f + 16384.0f) >> 1) & 0x7fff;
+        }
+        if (Game.area_save[packet->area->index].field_0x5[0] == 0) {
+            const f32 size = ((1.0f - fabsf(NuTrigTable[angle])) + 1.0f) * 1.2f;
+            Text3DEx("?", -0.6f, -0.6f, 1.1f, size, size, size, 0, 255, 255, 255, static_cast<i32>(alpha * 128.0f));
+        } else if (alpha > 0.0f) {
+            DrawStatusMiniKit(-0.6f, -0.5f, 1.1f, NuTrigTable[(static_cast<i32>(alpha * 16384.0f) >> 1) & 0x7fff] * 0.15f,
+                              1.0f, Game.area_save[packet->area->index].field_0x5[0], packet, 0.0f);
+        }
+        if (packet->minikit_max == Game.area_save[packet->area->index].field_0x5[0]) {
+            Text3DEx("$", -0.6f, -0.7f, 1.0f, 0.8f, 0.8f, 0.8f, 0, 255, 0, 127, static_cast<i32>(alpha * 128.0f));
+        } else {
+            sprintf(text, "%i/%i", Game.area_save[packet->area->index].field_0x5[0], packet->minikit_max);
+            Text3DEx(text, -0.6f, -0.8f, 1.0f, 0.5f, 0.5f, 0.5f, 0, 255, 0, 127, static_cast<i32>(alpha * 128.0f));
+        }
+        return;
+    }
+    f32 title_alpha;
+    switch (stage->field_0x14) {
+    case 0:
+        title_alpha = 0.0f;
+        break;
+    case 1: {
+        title_alpha = stage->field_0x18;
+        i32 angle = 0x6000;
+        if (title_alpha < 1.0f) angle = (static_cast<i32>(title_alpha * 32768.0f + 16384.0f) >> 1) & 0x7fff;
+        const f32 blend = 1.0f - (NuTrigTable[angle] + 1.0f) * 0.5f;
+        if (title_alpha <= stage->field_0x1c) DrawStatusMiniKit(0.0f, blend * -1.4f + 1.4f, 1.1f, 0.333f, 0.0f, currentminikit, packet, 0.0f);
+        else DrawStatusMiniKit(0.0f, 0.0f, 1.1f, 0.333f, 0.0f, currentminikit, packet, 0.0f);
+        const i32 count = packet->new_minikits < 1 ? Game.area_save[packet->area->index].field_0x5[0] : currentminikit < 0 ? 0 : currentminikit;
+        DrawMiniKitCount(blend, 1.0f, count, packet->minikit_max);
+        break;
+    }
+    case 2: {
+        const f32 duration = stage->field_0x1c - 0.25f;
+        f32 size;
+        if (stage->field_0x18 < duration) {
+            i32 angle = 0;
+            if (duration != 0.0f && stage->field_0x18 != 0.0f) angle = (static_cast<i32>((stage->field_0x18 / duration) * 16384.0f + 49152.0f + 16384.0f) >> 1) & 0x7fff;
+            size = NuTrigTable[angle] * 0.333f;
+        } else size = 0.333f;
+        DrawStatusMiniKit(0.0f, 0.0f, 1.1f, 0.333f, size, currentminikit + 1, packet, 0.0f);
+        const i32 count = packet->new_minikits < 1 ? Game.area_save[packet->area->index].field_0x5[0] : currentminikit < 0 ? 0 : currentminikit;
+        DrawMiniKitCount(1.0f, 1.0f, count, packet->minikit_max);
+        title_alpha = 1.0f;
+        break;
+    }
+    case 3: {
+        f32 blend = 0.0f;
+        if (stage->field_0x1c - jibberlen < stage->field_0x18) blend = (stage->field_0x18 - (stage->field_0x1c - jibberlen)) / jibberlen;
+        DrawStatusMiniKit(0.0f, 0.0f, 1.1f, 0.333f, 0.333f, currentminikit + 1, packet, blend);
+        i32 count = packet->new_minikits < 1 ? Game.area_save[packet->area->index].field_0x5[0] : currentminikit;
+        if (blend >= 0.5f) ++count;
+        if (count < 0) count = 0;
+        const f32 size = (1.0f - fabsf(NuTrigTable[(static_cast<i32>(blend * 32768.0f + 16384.0f) >> 1) & 0x7fff])) * 0.25f + 1.0f;
+        DrawMiniKitCount(1.0f, size, count, packet->minikit_max);
+        title_alpha = 1.0f;
+        break;
+    }
+    case 4: {
+        title_alpha = 1.0f - stage->field_0x18;
+        f32 progress = 0.0f;
+        if (stage->field_0x1c != 0.0f && stage->field_0x18 != 0.0f) progress = stage->field_0x18 / stage->field_0x1c;
+        const f32 blend = 1.0f - (NuTrigTable[(static_cast<i32>(progress * 32768.0f + 16384.0f) >> 1) & 0x7fff] + 1.0f) * 0.5f;
+        DrawStatusMiniKit(blend * -0.6f + 0.0f, blend * -0.5f + 0.0f, 1.1f, blend * -0.183f + 0.333f, 1.0f,
+                          Game.area_save[packet->area->index].field_0x5[0], packet, 0.0f);
+        const f32 off = stage->field_0x18 < 1.0f ? 1.0f - stage->field_0x18 : 0.0f;
+        DrawMiniKitCount(1.0f - (NuTrigTable[(static_cast<i32>(off * 32768.0f + 16384.0f) >> 1) & 0x7fff] + 1.0f) * 0.5f,
+                        1.0f, Game.area_save[packet->area->index].field_0x5[0], packet->minikit_max);
+        break;
+    }
+    case 6: {
+        title_alpha = 1.0f - stage->field_0x18;
+        i32 angle = 0x2000;
+        if (stage->field_0x18 < 1.0f) angle = (static_cast<i32>(title_alpha * 32768.0f + 16384.0f) >> 1) & 0x7fff;
+        if (stage->field_0x18 < stage->field_0x1c) {
+            DrawMiniKitCount(1.0f - (NuTrigTable[angle] + 1.0f) * 0.5f, 1.0f, Game.area_save[packet->area->index].field_0x5[0], packet->minikit_max);
+            DrawStatusMiniKit(0.0f, 0.0f, 1.1f, 0.333f, 1.0f, Game.area_save[packet->area->index].field_0x5[0], packet, 0.0f);
+        }
+        break;
+    }
+    default:
+        title_alpha = 1.0f;
+        break;
+    }
+    title_alpha = title_alpha < 0.0f ? 0.0f : title_alpha > 1.0f ? 1.0f : title_alpha;
+    Text3DEx(TTab[tMINIKIT], 0.0f, STATUS_TITLE_Y, 1.0f, 0.5f, 0.5f, 0.5f, 0, 255, 255, 255, static_cast<i32>(title_alpha * 128.0f));
 }
 
-void MiniKit_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void MiniKit_LSW_Skip(STATUS_STAGE_s *stage, STATUSPACKET_s *packet) {
+    currentminikit += newminikitcount;
+    if ((packet->field_0xb0 & 0x10) != 0 && (stage->field_0x14 != 6 || stage->field_0x18 < stage->field_0x1c)) IncreaseScore(packet->score, 50000, 0);
+    NextStatusStage(packet);
 }
 
-void UpdateNewMiniKits(STATUSPACKET_s *, STATUS_STAGE_s *) {
+i32 UpdateNewMiniKits(STATUSPACKET_s *, STATUS_STAGE_s *stage) {
+    if (stage->field_0x18 > stage->field_0x1c) {
+        stage->field_0x18 = 0.0f;
+        ++currentminikit;
+        pop_timer = 0.5f;
+        slideseek = 1.0f;
+        return 1;
+    }
+    if ((stage->field_0x1c - jibberlen) - slidetime < stage->field_0x18 && stage->field_0x18 <= stage->field_0x1c - jibberlen) {
+        slideseek = ((stage->field_0x1c - stage->field_0x18) - jibberlen) / slidetime;
+    }
+    return 0;
 }
 
 void CollectAllMiniKits(AREASAVE_s *) {
 }
 
-void MiniKit_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void MiniKit_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    switch (stage->field_0x14) {
+        case 0:
+            newminikitcount = packet->new_minikits;
+            currentminikit = Game.area_save[packet->area->index].field_0x5[0];
+            if (newminikitcount > 0) currentminikit -= newminikitcount;
+            stage->field_0x18 = 0.0f; stage->field_0x1c = 1.0f; stage->field_0x14 = 1;
+            break;
+        case 1:
+            stage->field_0x18 += elapsed;
+            if (stage->field_0x18 >= stage->field_0x1c) {
+                stage->field_0x18 = 0.0f;
+                if (newminikitcount == 0) {
+                    PlaySfx(const_cast<char *>("TrueJedi_NOT"), NULL);
+                    stage->field_0x1c = 1.0f; stage->field_0x14 = 4;
+                } else {
+                    stage->field_0x14 = 2; stage->field_0x1c = 0.5f; slideseek = 1.0f;
+                }
+            }
+            break;
+        case 2:
+            stage->field_0x18 += elapsed;
+            if (stage->field_0x18 >= stage->field_0x1c) {
+                stage->field_0x18 = 0.0f; stage->field_0x1c = 0.4f; stage->field_0x14 = 3;
+                PlaySfx(const_cast<char *>("Jp_Ana_Jump"), NULL);
+            }
+            break;
+        case 3:
+            if (newminikitcount < 1) {
+                stage->field_0x18 = 0.0f; stage->field_0x1c = 3.0f; stage->field_0x14 = 4;
+            } else {
+                const f32 previous = stage->field_0x18;
+                stage->field_0x18 += elapsed;
+                if (previous < stage->field_0x1c - jibberlen && stage->field_0x18 >= stage->field_0x1c - jibberlen) {
+                    NewStatusRumbleBuzz(-1, 0.0f, 0.1f, 0);
+                    PlaySfx(const_cast<char *>("MK-Panel"), NULL);
+                }
+                if (UpdateNewMiniKits(packet, stage) == 1) {
+                    stage->field_0x18 = 0.0f;
+                    if (currentminikit < packet->minikit_count) {
+                        stage->field_0x1c = 0.5f; stage->field_0x14 = 2;
+                        return;
+                    }
+                    stage->field_0x1c = 1.0f; stage->field_0x14 = 4;
+                } else if (stage->field_0x14 != 4) return;
+            }
+            if ((packet->field_0xb0 & 0x10) == 0) PlaySfx(const_cast<char *>("TrueJedi_NOT"), NULL);
+            else { stage->field_0x14 = 6; stage->field_0x1c = 1.0f; }
+            break;
+        case 4:
+            stage->field_0x18 += elapsed;
+            if (stage->field_0x18 >= stage->field_0x1c) NextStatusStage(packet);
+            break;
+        case 6: {
+            SetDrawGoldBrick(packet, packet->current_gold_brick);
+            const f32 previous = stage->field_0x18;
+            stage->field_0x18 += elapsed;
+            if (stage->field_0x18 < stage->field_0x1c) {
+                if (static_cast<u32>(GameTimer.update_count) % 6 < 3 && (GameTimer.update_count - 1U) % 6 > 2) NewStatusRumbleBuzz(-1, 0.0f, 0.0f, 2);
+            } else if (previous < stage->field_0x1c) {
+                AddStatusMiniKitParts();
+                NewStatusRumbleBuzz(-1, 1.0f, 0.1f, 0);
+                PlaySfx(const_cast<char *>("Explode1"), NULL);
+            } else if (FindGameMsgsWithID(1, 0, -1, NULL) == 0) {
+                PlaySfx(const_cast<char *>("Shop_BuyCheat"), NULL);
+                NextStatusStage(packet);
+            }
+            break;
+        }
+    }
 }
 
 void MiniKit_GameMsg_End(GAMEMESSAGE_s *) {
@@ -64,10 +264,65 @@ void ResetMinikitCounter() {
     minikitCounter_A = 0;
 }
 
-void AllMiniKits_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+extern i16 id_SLAVE1, tALLMINIKITSBUILT;
+extern i32 STATUS_R, STATUS_G, STATUS_B;
+
+void AllMiniKits_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 current) {
+    char text[60];
+    if (current == 0) {
+        if (stage->field_0x12 == 0) return;
+        const f32 alpha = getFinishedStatusAlpha(packet);
+        const i32 opacity = static_cast<i32>(alpha * 128.0f);
+        i32 angle = 0x2000;
+        if (GameTimer.time_elapsed_mod_seconds <= 0.25f) angle = (static_cast<i32>(GameTimer.time_elapsed_mod_seconds * 32768.0f + 16384.0f) >> 1) & 0x7fff;
+        if (Game.area_save[packet->area->index].field_0x5[0] == 0) {
+            const f32 size = ((1.0f - fabsf(NuTrigTable[angle])) + 1.0f) * 1.2f;
+            Text3DEx("?", -0.6f, -0.6f, 1.1f, size, size, size, 0, 255, 255, 255, opacity);
+        } else {
+            DrawStatusMiniKit(-0.6f, -0.5f, 1.1f, NuTrigTable[(static_cast<i32>(alpha * 16384.0f) >> 1) & 0x7fff] * 0.15f,
+                              1.0f, Game.area_save[packet->area->index].field_0x5[0], packet, 0.0f);
+        }
+        if (Game.area_save[packet->area->index].field_0x5[0] == packet->minikit_max) {
+            Text3DEx("$", -0.6f, -0.7f, 1.0f, 0.8f, 0.8f, 0.8f, 0, 255, 0, 127, opacity);
+        } else {
+            sprintf(text, "%i/%i", Game.area_save[packet->area->index].field_0x5[0], packet->minikit_max);
+            Text3DEx(text, -0.6f, -0.8f, 1.0f, 0.5f, 0.5f, 0.5f, 0, 255, 0, 127, opacity);
+        }
+        return;
+    }
+    if (stage->field_0x14 < 1) return;
+    const f32 time = stage->field_0x18;
+    f32 title_alpha;
+    f32 icon_alpha = 0.0f;
+    f32 y = 0.225f;
+    if (time < 0.5f) title_alpha = time + time;
+    else if (time < 3.5f) title_alpha = 1.0f;
+    else if (time < 4.0f) {
+        icon_alpha = (time - 3.5f) + (time - 3.5f);
+        title_alpha = 1.0f - icon_alpha;
+        y = (1.0f - NuTrigTable[(static_cast<i32>(icon_alpha * 16384.0f) >> 1) & 0x7fff]) * -0.5f + 0.225f;
+    } else if (time < 6.0f) {
+        title_alpha = 0.0f;
+        icon_alpha = 1.0f;
+        y = (1.0f - NuTrigTable[0x2000]) * -0.5f + 0.225f;
+    } else if (time < 6.5f) {
+        title_alpha = 0.0f;
+        icon_alpha = 1.0f - ((time - 6.0f) + (time - 6.0f));
+        if (icon_alpha <= 0.0f) return;
+    } else title_alpha = 0.0f;
+    if (icon_alpha > 0.0f) {
+        DrawCharIcon(id_SLAVE1, 0.0f, y, 0.0f, 0.4f, 0xa7, icon_alpha, icon_alpha, 1, NULL);
+        SmartTextEx(TTab[CDataList[id_SLAVE1].name_id], 0.0f, -0.1f, 1.0f, 0.6f, 0.6f, 0.6f,
+                    0, STATUS_R, STATUS_G, STATUS_B, 1.7f, 1, NULL, 0, static_cast<i32>(icon_alpha * 128.0f));
+    }
+    if (title_alpha > 0.0f) {
+        Text3DEx(TTab[tALLMINIKITSBUILT], 0.0f, 0.225f, 1.0f, 0.7f, 0.7f, 0.7f, 0,
+                 STATUS_R, STATUS_G, STATUS_B, static_cast<i32>(title_alpha * 128.0f));
+    }
 }
 
-void AllMiniKits_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void AllMiniKits_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *packet) {
+    NextStatusStage(packet);
 }
 
 void SpecialMiniKits_Draw(WORLDINFO_s *) {
@@ -103,7 +358,18 @@ void SpecialMiniKits_Reset(WORLDINFO_s *world) {
     }
 }
 
-void AllMiniKits_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void AllMiniKits_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x18 = 0.0f; stage->field_0x1c = 6.5f; stage->field_0x14 = 1;
+    } else if (stage->field_0x14 == 1) {
+        const f32 previous = stage->field_0x18;
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) NextStatusStage(packet);
+        else if (previous < 0.5f && stage->field_0x18 >= 0.5f) {
+            PlaySfx(const_cast<char *>("StatusAward"), NULL);
+            NewStatusRumbleBuzz(-1, 0.6f, 0.0f, 0);
+        } else if (previous < 4.0f && stage->field_0x18 >= 4.0f) PlaySfx(const_cast<char *>("Char_Icon_App"), NULL);
+    }
 }
 
 void CharacterMiniKits_Dump(WORLDINFO_s *) {

--- a/src/legoapi/items/objects/gameobjects.cpp
+++ b/src/legoapi/items/objects/gameobjects.cpp
@@ -1681,10 +1681,10 @@ void GameLoadCharacterModels(APICHARACTERMODELLIST_s *list, i32 append, VARIPTR 
 }
 
 i32 Game_100PercentComplete() {
-    if (StatusCollectList.ptr == NULL) {
+    if (Game_CompletionSave == NULL) {
         return 0;
     }
-    return StatusCollectList.ptr->flags & 1;
+    return reinterpret_cast<STATUSCOLLECT_s *>(Game_CompletionSave)->flags & 1;
 }
 
 void Game_WorldInfo_InitMenu(WORLDINFO_s *world, i32 *menu_id, i32 *) {
@@ -2608,6 +2608,7 @@ void UpdateGameObjects(WORLDINFO_s *world) {
         if (object->move_override != NULL) {
             object->move_override(object);
         } else {
+            Player_ToggleCharacter(object, 0, 1);
             MovePlayer(object);
         }
     }

--- a/src/legoapi/legoapi_types.h
+++ b/src/legoapi/legoapi_types.h
@@ -1607,7 +1607,15 @@ DECOMP_ASSERT(sizeof(PULSESYS_s) == 0x8, "PULSESYS_s size");
 DECOMP_ASSERT(offsetof(PULSESYS_s, pulse_count) == 0x4, "PULSESYS pulse count offset");
 struct PartHeader;
 struct PropertyMenuList {};
-struct REGISTERSTATUSPACKET_s {};
+struct REGISTERSTATUSPACKET_s {
+    STATUSPACKET_LSW_s *lsw_packet;
+    i32 (*init_callback)(WORLDINFO_s *, STATUSPACKET_s *);
+    i32 (*finish_callback)(WORLDINFO_s *, STATUSPACKET_s *, i32);
+    void (*reset_callback)(STATUSPACKET_s *);
+    void (*draw_background_callback)(STATUSPACKET_s *);
+    f32 stage_delay;
+};
+DECOMP_ASSERT(sizeof(REGISTERSTATUSPACKET_s) == 0x18, "REGISTERSTATUSPACKET_s size");
 struct RGBA {};
 struct SCENEPROGRESS_s {};
 struct SHADERSEMANTIC_enum {};
@@ -1621,11 +1629,14 @@ enum STATUS_FLAGS {
 // model ids at 0x9c/0x9e, per-player bytes at 0xa4/0xa5, flags at 0xb1/0xb2).
 struct STATUSPACKET_s {
     STATUSPACKET_LSW_s *lsw_packet; // 0x00
-    i32 field_0x04;
-    i32 field_0x08;
+    i32 (*init_callback)(WORLDINFO_s *, STATUSPACKET_s *); // 0x04
+    i32 (*finish_callback)(WORLDINFO_s *, STATUSPACKET_s *, i32); // 0x08
     void (*reset_callback)(STATUSPACKET_s *);           // 0x0c
     void (*draw_background_callback)(STATUSPACKET_s *); // 0x10
-    undefined field_0x14[0x24 - 0x14];
+    AREADATA_s *area; // 0x14
+    EPISODEDATA *episode; // 0x18
+    u32 *score; // 0x1c
+    struct MISSIONDATA_s *mission; // 0x20
     f32 player0_rumble_amount;   // 0x24
     f32 player0_rumble_time;     // 0x28
     f32 player0_rumble_duration; // 0x2c
@@ -1637,24 +1648,57 @@ struct STATUSPACKET_s {
     f32 player1_rumble_duration; // 0x40
     f32 player1_buzz_amount;     // 0x44
     u8 player1_rumble_priority;  // 0x48
-    undefined field_0x49[0x68 - 0x49];
+    u8 field_0x49[3];
+    f32 area_time; // 0x4c
+    f32 collected_score; // 0x50
+    f32 true_hero_target; // 0x54
+    f32 true_hero_percent; // 0x58
+    f32 previous_best_time; // 0x5c
+    f32 new_best_time; // 0x60
+    f32 elapsed_time; // 0x64
     f32 field_0x68;
-    undefined field_0x6c[0x9c - 0x6c];
+    u32 previous_best_score; // 0x6c
+    u32 new_best_score; // 0x70
+    u32 original_score; // 0x74
+    u32 reward_score; // 0x78
+    u32 time_reward_score; // 0x7c
+    u32 final_reward_score; // 0x80
+    u32 coins_remaining[2]; // 0x84
+    u32 coins_collected[2]; // 0x8c
+    i32 new_minikits; // 0x94
+    u32 field_0x98;
     u16 player0_model; // 0x9c
     u16 player1_model; // 0x9e
-    undefined field_0xa0[0xa4 - 0xa0];
+    i16 area_id; // 0xa0
+    i8 episode_id; // 0xa2
+    u8 field_0xa3;
     u8 player0_active; // 0xa4
     u8 player1_active; // 0xa5
-    undefined field_0xa6[0xb0 - 0xa6];
+    u8 challenge_state; // 0xa6
+    u8 mission_state; // 0xa7
+    f32 superstory_time; // 0xa8
+    u32 superstory_score; // 0xac
     u8 field_0xb0;
     u8 mode_flags;   // 0xb1
     u8 status_flags; // 0xb2
-    undefined field_0xb3[0xb5 - 0xb3];
+    u8 minikit_count; // 0xb3
+    u8 minikit_max; // 0xb4
     u8 stage_count;        // 0xb5
     i8 current_gold_brick; // 0xb6
-    undefined field_0xb7[0xc6 - 0xb7];
+    u8 save_state; // 0xb7
+    u8 prompt_choice; // 0xb8
+    u8 newly_completed; // 0xb9
+    u8 previous_completion; // 0xba
+    u8 previous_gold_bricks; // 0xbb
+    u8 displayed_gold_bricks; // 0xbc
+    u8 field_0xbd;
+    i8 field_0xbe;
+    u8 field_0xbf[7];
     i8 stage_types[0xee - 0xc6];             // 0xc6
-    u8 gold_brick_enabled[0x11c - 0xee];     // 0xee
+    u8 gold_brick_enabled[40]; // 0xee
+    i16 next_area; // 0x116
+    i8 chapter; // 0x118
+    u8 field_0x119[3];
     struct STATUS_STAGE_s *previous_stage_2; // 0x11c
     struct STATUS_STAGE_s *previous_stage;   // 0x120
     struct STATUS_STAGE_s *stage;            // 0x124
@@ -2869,6 +2913,8 @@ enum GIZFORCE_CONFIG_FLAGS : u32 {
     GIZFORCE_CONFIG_WAIT_FOR_FORCE_RANGE = 0x00000002,
     GIZFORCE_CONFIG_DRAW_REFLECTION = 0x00000004,
     GIZFORCE_CONFIG_RESET_STATE_ON_ACTIVATE = 0x00000008,
+    GIZFORCE_CONFIG_JEDI_BADDIE_ONLY = 0x00000010,
+    GIZFORCE_CONFIG_BLOWUP_AT_ANIM_OBJECTS = 0x00000020,
     GIZFORCE_CONFIG_ALONG_SOCKET = 0x00000040,
     GIZFORCE_CONFIG_HIT_TEST_TYPE_0 = 0x00000100,
     GIZFORCE_CONFIG_HIT_TEST_TYPE_1 = 0x00000200,
@@ -2955,17 +3001,40 @@ struct GIZFORCE_s {
     i16 start_sfx_id;      // 0x86
     i16 loop_sfx_id;       // 0x88
     i16 stop_sfx_id;       // 0x8a
-    i16 blowup_type;       // 0x8c
-    i16 debris_type;       // 0x8e
-    i16 hit_points;        // 0x90
-    i16 score;             // 0x92
-    NUVEC effect_position; // 0x94
-    f32 activation_radius; // 0xa0
+    i16 blowup_type; // 0x8c
+    union {
+        i16 debris_type;
+        u16 pickup_count; // 0x8e
+    };
+    union {
+        i16 hit_points;
+        u16 pickup_direction_x; // 0x90
+    };
+    union {
+        i16 score;
+        u16 pickup_direction_y; // 0x92
+    };
+    union {
+        NUVEC effect_position;
+        NUVEC pickup_offset; // 0x94
+    };
+    union {
+        f32 activation_radius;
+        f32 pickup_scatter_height; // 0xa0
+    };
     u32 field_0xa4;
-    u8 progress_flags; // 0xa8
-    u8 runtime_flags;  // 0xa9, GIZFORCE_RUNTIME_FLAGS
-    u8 field_0xaa;
-    u8 field_0xab;
+    union {
+        struct {
+            u8 progress_flags; // 0xa8, GIZFORCE_PROGRESS_FLAGS
+            u8 runtime_flags;  // 0xa9, GIZFORCE_RUNTIME_FLAGS
+            union {
+                u8 field_0xaa;
+                u8 state_flags; // GIZFORCE_STATE_FLAGS
+            };
+            u8 field_0xab;
+        };
+        u32 packed_state;
+    };
     void ClearMechObjectInterface();
     void GetMechObjectInterface();
 };
@@ -3796,7 +3865,9 @@ struct PART_s {
     f32 gravity;
     u8 pad_0ec[0x108 - 0xec];
     u32 flags;
-    u8 pad_10c[0x144 - 0x10c];
+    u8 pad_10c[0x13e - 0x10c];
+    i16 type_id; // 0x13e
+    u8 pad_140[0x144 - 0x140];
     u8 active;
     u8 pad_145[3];
     nuhspecial_s special;

--- a/src/legoapi/menus/core/gamemessages.cpp
+++ b/src/legoapi/menus/core/gamemessages.cpp
@@ -147,7 +147,7 @@ GAMEMESSAGE_s *AddGameMsg(ADDGAMEMSG *message) {
         if (length <= 0) {
             return NULL;
         }
-        if ((message->flags & 0x20) != 0) {
+        if ((message->flags & 0x2000) != 0) {
             slot->text = message->text;
         } else {
             for (; text_index < length && text_index <= 0x76; ++text_index) {
@@ -470,16 +470,6 @@ void UpdateGameMessages() {
             callback(reinterpret_cast<GAMEMESSAGE_s *>(message));
         }
     }
-}
-
-static i32 GoldBrickMessageCount;
-
-void AddGoldBrickMessage(STATUSPACKET_s *packet, i16 brick) {
-    if (GoldBrickMessageCount <= 15) {
-        *reinterpret_cast<i16 *>(reinterpret_cast<unsigned char *>(packet) + 0x12c + GoldBrickMessageCount * 2) = brick;
-        ++GoldBrickMessageCount;
-    }
-    AddToGoldBricks();
 }
 
 void TransformGameMessages(nuvec_s *camera_position, nuvec_s *camera_scale, nuvec_s *camera_direction) {

--- a/src/legoapi/menus/core/text.cpp
+++ b/src/legoapi/menus/core/text.cpp
@@ -49,7 +49,7 @@ extern "C" void NuRndrClear(u32 flags, u32 colour, f32 alpha);
 extern "C" void Text3DStringEncode(char *src, u16 *dst);
 void Text3DStringEncodeFont(unsigned char *src, u16 *dst, void *font);
 extern "C" void TextDecode(char *source, unsigned char *dest);
-extern "C" void Text3DEx(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32 z_scale, u8 alignment, u8 red,
+extern "C" void Text3DEx(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32 z_scale, u32 alignment, u8 red,
                          u8 green, u8 blue, i32 alpha);
 extern "C" void Text3DEx2(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32 z_scale, u8 alignment, u8 red,
                           u8 green, u8 blue, i32 alpha);
@@ -805,9 +805,11 @@ extern "C" {
     }
     void SplitText(void) {
     }
-    void Text3D(void) {
+    void Text3D(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32 z_scale, u32 alignment, u8 red,
+                u8 green, u8 blue) {
+        Text3DEx(text, x, y, z, x_scale, y_scale, z_scale, alignment, red, green, blue, 128);
     }
-    void Text3DEx(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32, u8 alignment, u8 red, u8 green,
+    void Text3DEx(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32, u32 alignment, u8 red, u8 green,
                   u8 blue, i32 alpha) {
         VUFNT *font = SmartTextFont != nullptr ? SmartTextFont : QFont2D;
         if (font == nullptr || text == nullptr || text[0] == '\0' || MenuStopDraw != 0 || x < -2.0f || x > 2.0f ||

--- a/src/legoapi/menus/core/text.h
+++ b/src/legoapi/menus/core/text.h
@@ -34,7 +34,9 @@ extern "C" {
                          u32 alpha);
     void MenuText3DEx(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32 z_scale, u8 alignment, u8 red,
                       u8 green, u8 blue, i32 alpha);
-    void Text3DEx(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32 z_scale, u8 alignment, u8 red,
+    void Text3D(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32 z_scale, u32 alignment, u8 red,
+                u8 green, u8 blue);
+    void Text3DEx(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32 z_scale, u32 alignment, u8 red,
                   u8 green, u8 blue, i32 alpha);
     void Text3DEx2(char *text, f32 x, f32 y, f32 z, f32 x_scale, f32 y_scale, f32 z_scale, u8 alignment, u8 red,
                    u8 green, u8 blue, i32 alpha);

--- a/src/legoapi/menus/screens/gamestatus_lsw.cpp
+++ b/src/legoapi/menus/screens/gamestatus_lsw.cpp
@@ -1,7 +1,9 @@
 #include <string.h>
+#include <stdio.h>
 
 #include "decomp.h"
 #include "globals.h"
+#include "gameframework/saveload.h"
 #include "legoapi/legoapi_types.h"
 #include "legoapi/characters/motion.h"
 #include "legoapi/core/input/qrand.h"
@@ -10,6 +12,16 @@
 #include "legoapi/world/world.h"
 #include "nu2api/nu3d/nutex.h"
 #include "nu2api/numath/nutrig.h"
+#include "legoapi/core/input/gamepads.h"
+#include "legoapi/menus/core/text.h"
+#include "gameapi/gui/apimenu.h"
+#include "MechInputTouch/MechInputTouch_types.h"
+#include "legoapi/render/core/render.h"
+#include "legoapi/world/levels/episode.h"
+#include "legoapi/world/mission.h"
+#include "legoapi/characters/core/players.h"
+#include "legoapi/props/doors/door.h"
+#include "nu2api/numath/nufloat.h"
 
 struct AIROW_s;
 struct nuqthdr_s;
@@ -25,6 +37,7 @@ extern f32 cointotaltime;
 extern i32 screendump;
 extern i32 newgamecam;
 extern STATUSPACKET_s StatusPacket;
+extern AREADATA *NEGOTIATIONS_ADATA;
 
 i32 GetMenuID();
 extern "C" i32 MenuInMemoryCard();
@@ -32,6 +45,41 @@ void ResetRumble(RUMBLEPACKET *packet);
 void ReCalculateCompletionPoints();
 void StatusStage_Reset(STATUS_STAGE_s *stage);
 void GameCam_Blend(GAMECAMERA_s *camera, f32 duration, f32 curve, i32 mode);
+void IncreaseScore(u32 *, u64, i32);
+extern "C" void PlaySfx(char *, nuvec_s *);
+void GameAudio_PlaySfx(i32, nuvec_s *, i32, i32);
+void FinishStatusPacket(i32);
+extern "C" void BackupMenu();
+void Text_FillInExtendedSaveInfo();
+void DrawStatusBG_LSW(STATUSPACKET_s *);
+i32 InitStatusScreen_LSW(WORLDINFO_s *, STATUSPACKET_s *);
+i32 FinishStatusPacket_LSW(WORLDINFO_s *, STATUSPACKET_s *, i32);
+void ResetStatusPacket_LSW(STATUSPACKET_s *);
+void RegisterStatusScreen(STATUS_STAGE_s *, i32 *, REGISTERSTATUSPACKET_s *);
+void EndOfDemo(i32);
+static i32 gamedemo_option;
+static i32 goldbrickmsgcount;
+void AddToGoldBricks();
+
+i32 AddGoldBrickMessage(STATUSPACKET_s *packet, i16 brick) {
+    if (goldbrickmsgcount < 16) {
+        reinterpret_cast<i16 *>(packet->field_0x12c)[goldbrickmsgcount] = brick;
+        ++goldbrickmsgcount;
+    }
+    AddToGoldBricks();
+    return 1;
+}
+extern f32 DROPINALPHA;
+extern f32 PANEL_SCOREX;
+extern f32 PANEL_SCORESCALE;
+extern i16 tCOINTOTAL;
+extern i16 tSELECT;
+extern i16 tSELECTING;
+void Text_MakeScore(u32, char *);
+void DrawPlayerIconPrompts(i32, i32, f32, i32, i32, i32, i32, i32, i32, f32, i32, i32, i32, i32);
+void Status_DrawPromptMenu(STATUSPACKET_s *, i32, f32);
+f32 getFinishedStatusAlpha(STATUSPACKET_s *);
+f32 STATUS_TITLE_Y = 0.5f;
 
 namespace {
     enum PANEL_BLOCKING_MENU {
@@ -69,6 +117,95 @@ i32 draw_player_icons;
 i32 status_prompt;
 static i32 DrawGoldBrick_Stage;
 static i32 DrawGoldBrick_Phase;
+void RedBrick_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void RedBrick_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void RedBrick_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void CollectCharcters_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void CollectCharcters_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void CollectCharcters_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void CollectCharactersOff_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void CollectCharactersOff_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void CollectCharactersOff_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void Coins_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void Coins_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void Coins_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void TrueHero_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void TrueHero_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void TrueHero_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void MiniKit_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void MiniKit_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void MiniKit_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void AllMiniKits_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void AllMiniKits_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void AllMiniKits_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void GoldBrick_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void GoldBrick_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void GoldBrick_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void LevelComplete_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void LevelComplete_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void LevelComplete_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void BonusTime_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void BonusTime_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void BonusTime_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void ChallangeCash_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void ChallangeCash_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void ChallangeCash_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void SuperStoryTime_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void SuperStoryTime_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void SuperStoryTime_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void SuperStoryScore_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void SuperStoryScore_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void SuperStoryScore_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void BonusComplete_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void BonusComplete_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void BonusComplete_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void BonusWin_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void BonusWin_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void BonusWin_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *);
+void Prompt_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32);
+void Prompt_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void Exit_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void Save_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+void Fade_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, f32);
+
+STATUSPACKET_LSW_s StatusPacket_LSW;
+STATUS_STAGE_s StatusStages_LSW[] = {
+    {RedBrick_LSW_Draw, RedBrick_LSW_Update, RedBrick_LSW_Skip, 18, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {CollectCharcters_Draw, CollectCharcters_Update, CollectCharcters_Skip, 35, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {CollectCharactersOff_Draw, CollectCharactersOff_Update, CollectCharactersOff_Skip, 36, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {Coins_LSW_Draw, Coins_LSW_Update, Coins_LSW_Skip, 3, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {TrueHero_LSW_Draw, TrueHero_LSW_Update, TrueHero_LSW_Skip, 1, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {TrueHero_LSW_Draw, TrueHero_LSW_Update, TrueHero_LSW_Skip, 2, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {MiniKit_LSW_Draw, MiniKit_LSW_Update, MiniKit_LSW_Skip, 4, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {AllMiniKits_LSW_Draw, AllMiniKits_LSW_Update, AllMiniKits_LSW_Skip, 17, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {GoldBrick_LSW_Draw, GoldBrick_LSW_Update, GoldBrick_LSW_Skip, 19, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 13, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 8, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 28, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 29, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 30, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 31, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 32, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 33, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 34, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 14, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 23, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {BonusTime_LSW_Draw, BonusTime_LSW_Update, BonusTime_LSW_Skip, 24, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {ChallangeCash_Draw, ChallangeCash_Update, ChallangeCash_Skip, 25, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {LevelComplete_LSW_Draw, LevelComplete_LSW_Update, LevelComplete_LSW_Skip, 26, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {BonusTime_LSW_Draw, BonusTime_LSW_Update, BonusTime_LSW_Skip, 27, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {SuperStoryTime_LSW_Draw, SuperStoryTime_LSW_Update, SuperStoryTime_LSW_Skip, 15, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {SuperStoryScore_LSW_Draw, SuperStoryScore_LSW_Update, SuperStoryScore_LSW_Skip, 16, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {BonusComplete_LSW_Draw, BonusComplete_LSW_Update, BonusComplete_LSW_Skip, 22, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {BonusWin_LSW_Draw, BonusWin_LSW_Update, BonusWin_LSW_Skip, 20, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {BonusTime_LSW_Draw, BonusTime_LSW_Update, BonusTime_LSW_Skip, 21, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {Prompt_LSW_Draw, Prompt_LSW_Update, NULL, 9, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {NULL, Exit_LSW_Update, NULL, 10, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {NULL, Save_LSW_Update, NULL, 11, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {NULL, Fade_LSW_Update, NULL, 12, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+    {NULL, NULL, NULL, -1, 0xffff, 0, 0, 0, 0.0f, 0.0f},
+};
+
 
 void NewGameMode() {
     NewMode = 1;
@@ -168,7 +305,21 @@ void NextStatusStage(STATUSPACKET_s *packet) {
     }
 }
 
-void Prompt_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+void Prompt_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 active) {
+    if (active != 0) {
+        if (stage->field_0x18 >= 0.5f) {
+            Status_DrawPromptMenu(packet, 1, 1.0f);
+            DrawPlayerIconPrompts(packet->player0_active, tSELECT, 1.0f, -1, -1, -1, tSELECTING,
+                                 packet->player1_active, tSELECT, 1.0f, -1, -1, -1, tSELECTING);
+        } else {
+            f32 alpha = NuTrigTable[(static_cast<i32>((stage->field_0x18 + stage->field_0x18) * 16384.0f) >> 1) & 0x7fff];
+            if (stage->field_0x14 == 1) {
+                alpha = 1.0f - alpha;
+            }
+            Status_DrawPromptMenu(packet, 0, alpha);
+            draw_player_icons = 1;
+        }
+    }
 }
 
 void ResetIconWibble() {
@@ -182,10 +333,418 @@ void ResetIconWibble() {
     hub_icontime[3] = 0.0f;
 }
 
-void Save_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void Save_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (packet->save_state == 3) {
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) {
+            if ((packet->mode_flags & 4) == 0 && packet->prompt_choice == 0 &&
+                (packet->field_0xb0 & 0x40) == 0 && packet->challenge_state == 0 && packet->mission_state == 0) {
+                packet->mode_flags |= 0x10;
+            }
+            NextStatusStage(packet);
+        }
+    } else if (packet->save_state == 0) {
+        packet->save_state = 1;
+        Text_FillInExtendedSaveInfo();
+        if (TriggerAutoSave() == 0) {
+            packet->save_state = 2;
+            NewMenu(1000, -1, -1);
+        }
+    } else if ((packet->save_state == 2 ? MenuInMemoryCard() : memcard_autosaveinprogress) == 0) {
+        packet->save_state = 3;
+    }
 }
 
-void InitStatusScreen(WORLDINFO_s *) {
+extern i32 from_save_and_exit;
+extern TIMER BonusTimer;
+extern i16 id_SLAVE1;
+extern i16 tSUPERSTORYCOMPLETE, tNEWBESTTIME, tLEVELCOMPLETE, tMISSIONCOMPLETE;
+extern i16 tCHALLENGECOMPLETE, tTRUEHERO, tMINIKIT;
+extern "C" void NuIOS_RecordFlurryEvent(char *);
+extern "C" void NuStrCpy(char *, const char *);
+void AddToCompletionPoints(u32);
+void AddToCollection(i32);
+i32 AllMiniKitsDone(AREASAVE_s *);
+i32 Mission_CurrentState(MISSIONSYS *);
+i32 newCharactersCollected(STATUSPACKET_s *);
+void StatusPacketReset(STATUSPACKET_s *);
+i32 newminikitcount;
+i32 currentminikit;
+static u32 collect_suit_bits;
+
+struct NEWMINIPIECE_s {
+    char name[8];
+    i16 level;
+    u8 pad[2];
+};
+DECOMP_ASSERT(sizeof(NEWMINIPIECE_s) == 12, "new minikit piece ABI");
+NEWMINIPIECE_s NewMiniPiece[10];
+
+void InitStatusScreen(WORLDINFO_s *world) {
+    STATUSPACKET_s &p = StatusPacket;
+    char event[72];
+    if (p.lsw_packet == NULL) {
+        return;
+    }
+    for (i32 i = 0; StatusStages[i].type != -1; ++i) {
+        StatusStage_Reset(&StatusStages[i]);
+    }
+    StatusPacketReset(&p);
+    icon_y = STATSPOSY;
+    newminikitcount = 0;
+    currentminikit = 0;
+    p.field_0xb0 &= 0xfe;
+    ResetRumble(reinterpret_cast<RUMBLEPACKET *>(&p.player0_rumble_amount));
+    ResetRumble(reinterpret_cast<RUMBLEPACKET *>(&p.player1_rumble_amount));
+    CoinTotalScale = 1.0f;
+    goldbrickmsgcount = 0;
+    if (netclient == 0) {
+        if (Player[0] == NULL) {
+            p.player0_model = 0xffff;
+        } else {
+            p.player0_model = Player[0]->id;
+            p.player0_active = Player[0]->apiobj.flags_low >> 7;
+            p.coins_remaining[0] = Player[0]->coinpacket == NULL ? 0 : Player[0]->coinpacket->coins;
+            ++p.status_flags;
+        }
+        if (Player[1] == NULL) {
+            p.player1_model = 0xffff;
+        } else {
+            p.player1_model = Player[1]->id;
+            p.player1_active = Player[1]->apiobj.flags_low >> 7;
+            p.coins_remaining[1] = Player[1]->coinpacket == NULL ? 0 : Player[1]->coinpacket->coins;
+            ++p.status_flags;
+        }
+    }
+    if (p.status_flags == 0) {
+        goldbrickmsgcount = 0;
+        CoinTotalScale = 1.0f;
+        return;
+    }
+    p.stage_count = 0;
+    p.field_0xb0 = (p.field_0xb0 & 0xbf) | ((FreePlay & 1) << 6);
+    p.mode_flags = (p.mode_flags & 0xe3) | ((SuperStory & 1) << 2) | ((from_save_and_exit & 1) << 3);
+    p.mission = Mission_Active(NULL);
+    p.mission_state = p.mission == NULL ? 0 : Mission_CurrentState(NULL);
+    if (from_save_and_exit != 0) {
+        from_save_and_exit = 0;
+        level_already_loaded = -1;
+    }
+    p.next_area = -1;
+    p.field_0xbe = -1;
+    p.newly_completed = 0;
+    p.field_0xbd = 0;
+    p.challenge_state = ChallengeMode;
+    const i32 area = static_cast<i8>(world->level_sub_id);
+    p.field_0xb0 &= 0x77;
+    p.score = &Game.coins;
+    p.previous_completion = Game.completion;
+    p.area_id = area;
+    p.previous_gold_bricks = Game.field_0x7c26[0];
+    p.displayed_gold_bricks = Game.field_0x7c26[0];
+    p.mode_flags &= 0xfc;
+    i32 episode = -1;
+    if (area == -1) {
+        p.area = NULL;
+        p.episode = NULL;
+        p.chapter = -1;
+    } else {
+        p.area = ADataList + area;
+        p.episode_id = p.area->episode_index;
+        episode = p.episode_id;
+        if (episode != -1) {
+            p.episode = EDataList + episode;
+        }
+        p.chapter = p.area->area_index;
+        if ((p.area->flags & 1) != 0) p.field_0xb0 |= 0x80;
+        if ((p.area->flags & 4) != 0) p.mode_flags |= 1;
+        if ((p.area->flags & 0x100) != 0) p.mode_flags |= 2;
+    }
+    if (p.init_callback(world, &p) != 0) {
+        return;
+    }
+    if ((p.mode_flags & 4) != 0) {
+        if (NewLData == STATUS_LDATA || WORLD->current_level == STATUS_LDATA) {
+            EPISODESAVE_s &save = Game.episode_save[episode];
+            p.previous_best_time = save.superstory_time_limit;
+            p.previous_best_score = save.superstory_score_target;
+            p.superstory_time = SuperStoryTimer[0];
+            p.superstory_score = SuperStoryScore;
+            i32 gold = 0;
+            if (episode == -1) {
+                p.new_best_score = 0;
+                p.new_best_time = 0.0f;
+                p.time_reward_score = *p.score;
+            } else {
+                p.new_best_time = p.superstory_time;
+                if (p.previous_best_time <= p.superstory_time) p.new_best_time = 0.0f;
+                else save.superstory_time_limit = p.superstory_time;
+                p.new_best_score = p.superstory_score;
+                if (p.previous_best_score < p.superstory_score) save.superstory_score_target = p.superstory_score;
+                else p.new_best_score = 0;
+                if ((save.flags & 0xff) == 0) {
+                    save.flags = (save.flags & 0xffffff00) | 1;
+                    AddToCompletionPoints(POINTS_PER_SUPERSTORY);
+                    if (GOLDBRICKFORSUPERSTORY != 0) gold = AddGoldBrickMessage(&p, tSUPERSTORYCOMPLETE);
+                }
+                p.time_reward_score = *p.score;
+                if (p.new_best_time != 0.0f) {
+                    u64 reward = static_cast<i64>(static_cast<i32>(p.previous_best_time - p.new_best_time) * 100);
+                    if (reward < 100) reward = 100;
+                    IncreaseScore(&p.time_reward_score, reward, 0);
+                }
+            }
+            p.final_reward_score = p.time_reward_score;
+            IncreaseScore(&p.final_reward_score, static_cast<u64>(p.superstory_score), 0);
+            AddStatusStage(&p, 14, gold);
+            AddStatusStage(&p, 15, 0);
+            AddStatusStage(&p, 16, 0);
+            if (p.previous_gold_bricks < Game.field_0x7c26[0]) AddStatusStage(&p, 19, 0);
+            if (netclient == 0 && (p.new_best_time != 0.0f || p.new_best_score != 0 || p.superstory_score != 0)) {
+                AddStatusStage(&p, 11, 0);
+            }
+            hub_from_superstory = static_cast<i8>(p.area->episode_index);
+        }
+        AddStatusStage(&p, 10, 0);
+        p.current_gold_brick = -1;
+        p.stage_types[p.stage_count] = -1;
+        p.next_stage = FindStatusStage(p.stage_types[0]);
+        NextStatusStage(&p);
+        if (episode != -1 && p.chapter < EDataList[episode].regular_areas) {
+            p.next_area = EDataList[episode].area_ids[p.chapter + 1];
+            if (p.next_area != -1 && (ADataList[p.next_area].flags & 2) != 0) hub_from_superstory = episode;
+        }
+        return;
+    }
+    if ((p.mode_flags & 1) != 0 && area != -1) {
+        p.field_0xb0 = (p.field_0xb0 & 0xdf) | ((BonusWinner & 1) << 5);
+        p.previous_best_time = Game.area_save[area].challenge_trial_time;
+        p.elapsed_time = BonusTimer.time_elapsed;
+        i32 gold = 0;
+        if (p.previous_best_time <= 0.0f || p.elapsed_time < p.previous_best_time) {
+            if (WORLD->area->challenge_trial_time != 0 && WORLD->area->challenge_trial_time <= p.previous_best_time) {
+                AddToCompletionPoints(POINTS_PER_TIMETRIAL);
+                gold = AddGoldBrickMessage(&p, tNEWBESTTIME);
+            }
+            p.new_best_time = p.elapsed_time;
+            Game.area_save[area].challenge_trial_time = p.elapsed_time;
+        }
+        if ((p.mode_flags & 2) == 0) {
+            AddStatusStage(&p, 20, 0);
+            if (p.elapsed_time < p.previous_best_time) AddStatusStage(&p, 3, 0);
+        } else {
+            if (Game.area_save[p.area_id].area_complete == 0) {
+                Game.area_save[p.area_id].area_complete = 1;
+                AddToCompletionPoints(POINTS_PER_SUPERBONUSCOMPLETE);
+                p.newly_completed = 1;
+                if (GOLDBRICKFORSUPERBONUS != 0) gold = AddGoldBrickMessage(&p, tLEVELCOMPLETE);
+            }
+            AddStatusStage(&p, 22, gold);
+            gold = 0;
+        }
+        AddStatusStage(&p, 21, gold);
+        if (p.previous_gold_bricks < Game.field_0x7c26[0]) AddStatusStage(&p, 19, 0);
+        AddStatusStage(&p, 9, 0);
+        AddStatusStage(&p, 10, 0);
+        if (netclient == 0) AddStatusStage(&p, 11, 0);
+        AddStatusStage(&p, 12, 0);
+        p.current_gold_brick = -1;
+        p.stage_types[p.stage_count] = -1;
+        p.next_stage = FindStatusStage(p.stage_types[0]);
+        NextStatusStage(&p);
+        draw_player_icons = 1;
+        return;
+    }
+    if (p.mission_state != 0) {
+        p.newly_completed = 0;
+        p.original_score = *p.score;
+        p.elapsed_time = MissionSys->timer.time_elapsed;
+        p.reward_score = p.original_score;
+        i32 gold = 0;
+        if (p.mission_state == 2) {
+            const i32 mission = static_cast<i8>(MissionSys->mission->count);
+            if (Game_MissionSave == NULL || reinterpret_cast<u8 *>(Game_MissionSave)[0x50 + mission] == 0) {
+                if (Game_MissionSave != NULL) reinterpret_cast<u8 *>(Game_MissionSave)[0x50 + mission] = 1;
+                AddToCompletionPoints(POINTS_PER_MISSION);
+                gold = AddGoldBrickMessage(&p, tMISSIONCOMPLETE);
+                sprintf(event, "bounty_mission_%i_complete", mission + 1);
+                NuIOS_RecordFlurryEvent(event);
+            }
+            u64 reward = static_cast<i64>(static_cast<i32>(static_cast<u16>(p.mission->time) - p.elapsed_time) * 150);
+            if (reward < 150) reward = 150;
+            IncreaseScore(&p.reward_score, reward, 0);
+            if (Game_MissionSave != NULL) {
+                f32 &best = reinterpret_cast<f32 *>(Game_MissionSave)[mission];
+                if (best == 0.0f || p.elapsed_time < best) best = p.elapsed_time;
+            }
+        }
+        AddStatusStage(&p, 26, gold);
+        if (p.previous_gold_bricks < Game.field_0x7c26[0]) AddStatusStage(&p, 19, 0);
+        AddStatusStage(&p, 9, 0);
+        AddStatusStage(&p, 10, 0);
+        goto challenge_finish;
+    }
+    if (p.challenge_state != 0) {
+        p.elapsed_time = ChallengeTimer.time_elapsed;
+        p.original_score = *p.score;
+        p.reward_score = p.original_score;
+        if (p.challenge_state == 2) {
+            i32 gold = 0;
+            if (Game.area_save[p.area_id].field_0x5[2] == 0) {
+                AddToCompletionPoints(POINTS_PER_CHALLENGE);
+                if (GOLDBRICKFORCHALLENGE != 0) gold = AddGoldBrickMessage(&p, tCHALLENGECOMPLETE);
+                Game.area_save[p.area_id].field_0x5[2] = 1;
+                if (p.episode_id != -1 && p.chapter != -1) {
+                    sprintf(event, "challenge_ep%i_ch%i_complete", p.episode_id + 1, p.chapter + 1);
+                    NuIOS_RecordFlurryEvent(event);
+                }
+            }
+            u64 reward = static_cast<i64>(static_cast<i32>(ADataList[p.area_id].challenge_trial_time - p.elapsed_time) * 500);
+            if (reward < 500) reward = 500;
+            IncreaseScore(&p.reward_score, reward, 0);
+            AddStatusStage(&p, 23, 0);
+            if (p.challenge_state == 2 && gold != 0) AddStatusStage(&p, 25, 0);
+        } else AddStatusStage(&p, 23, 0);
+        if (p.previous_gold_bricks < Game.field_0x7c26[0]) AddStatusStage(&p, 19, 0);
+        AddStatusStage(&p, 9, 0);
+        AddStatusStage(&p, 10, 0);
+challenge_finish:
+        if (netclient == 0) AddStatusStage(&p, 11, 0);
+        AddStatusStage(&p, 12, 0);
+        p.current_gold_brick = -1;
+        p.stage_types[p.stage_count] = -1;
+        p.next_stage = FindStatusStage(p.stage_types[0]);
+        NextStatusStage(&p);
+        draw_player_icons = 1;
+        cointotal_i_obj[0] = cointotal_i_obj[1] = 0xc3;
+        return;
+    }
+    if (area != -1) {
+        if (BuildUpDone != 0) p.field_0xb0 |= 4;
+        p.minikit_count = Game.area_save[area].field_0x5[0] + AreaGlobals.values.field_0x10;
+        p.minikit_max = (p.area->flags & 0x10) != 0 ? 10 : 0;
+        if (p.minikit_count > p.minikit_max) p.minikit_count = p.minikit_max;
+        p.true_hero_target = static_cast<u32>((p.field_0xb0 & 0x40) != 0 ? p.area->field38_0x90 : p.area->field37_0x8c);
+    }
+    p.area_time = AreaTimer.time_elapsed;
+    const u64 total = static_cast<u64>(p.coins_remaining[0]) + p.coins_remaining[1];
+    p.collected_score = total > 4000000000ULL ? 4000000000.0f : static_cast<f32>(static_cast<u32>(total));
+    p.newly_completed = 0;
+    if ((p.field_0xb0 & 4) != 0) p.true_hero_percent = 100.0f;
+    else if (p.collected_score * 100.0f == 0.0f || p.true_hero_target == 0.0f) p.true_hero_percent = 0.0f;
+    else {
+        p.true_hero_percent = p.collected_score * 100.0f / p.true_hero_target;
+        if (p.true_hero_percent > 99.0f) p.true_hero_percent = 99.0f;
+    }
+    p.coins_collected[0] = p.coins_remaining[0];
+    p.coins_collected[1] = p.coins_remaining[1];
+    draw_player_icons = 0;
+    if (area != -1) {
+        if ((p.field_0xb0 & 0x40) == 0 && p.episode != NULL && p.chapter < p.episode->regular_areas) {
+            p.next_area = p.episode->area_ids[p.chapter + 1];
+            if (p.chapter < p.episode->regular_areas - 1) p.field_0xb0 |= 8;
+        }
+        for (i32 i = 0; i < AreaGlobals.values.field_0x10; ++i) {
+            if (Game.area_save[area].field_0x5[0] < 10) ++Game.area_save[area].field_0x5[0];
+            u8 *save = Game.level_save + NewMiniPiece[i].level * 0x54;
+            if (save[0x50] < 10) {
+                NuStrCpy(reinterpret_cast<char *>(save + save[0x50] * 8), NewMiniPiece[i].name);
+                ++save[0x50];
+            }
+        }
+        i32 gold = 0;
+        i32 completed_episode = 0;
+        if ((p.field_0xb0 & 0x40) == 0 && Game.area_save[area].area_complete == 0 && (p.area->flags & 0x26) == 0) {
+            Game.area_save[area].area_complete = 1;
+            p.newly_completed = 1;
+            AddToCompletionPoints(POINTS_PER_STORY);
+            if ((p.mode_flags & 1) == 0 && (p.area->flags & 0x800) == 0) gold = AddGoldBrickMessage(&p, tLEVELCOMPLETE);
+            if (p.episode != NULL && Episode_IsComplete(p.episode, NULL) != 0) completed_episode = static_cast<i8>(p.area->episode_index);
+            if (p.episode_id != -1 && p.chapter != -1) {
+                sprintf(event, "story_ep%i_ch%i_complete", p.episode_id + 1, p.chapter + 1);
+                NuIOS_RecordFlurryEvent(event);
+            }
+            if (p.area == NEGOTIATIONS_ADATA) {
+                Game.area_save[EDataList[1].area_ids[0]].complete = 1;
+                Game.area_save[EDataList[2].area_ids[0]].complete = 1;
+                Game.area_save[EDataList[3].area_ids[0]].complete = 1;
+                Game.area_save[EDataList[4].area_ids[0]].complete = 1;
+                Game.area_save[EDataList[5].area_ids[0]].complete = 1;
+            }
+            if ((p.field_0xb0 & 8) != 0) Game.area_save[p.next_area].complete = 1;
+            else if (p.episode != NULL) {
+                const i32 bonus = Episode_FindAreaFromFlags(p.episode, 5, 4);
+                hub_startoutsidebonusdoor_area = Episode_FindAreaFromFlags(p.episode, 5, 5);
+                if (bonus != -1) Game.area_save[bonus].complete = 1;
+                if (hub_startoutsidebonusdoor_area != -1) Game.area_save[hub_startoutsidebonusdoor_area].complete = 1;
+            }
+        }
+        if (p.newly_completed != 0) AddStatusStage(&p, 13, gold);
+        if (completed_episode != 0) AddStatusStage(&p, completed_episode + 29, 0);
+    }
+    if (p.area != NULL && static_cast<i8>(p.area->cheat) != -1 && Game.area_save[area].field_0x5[1] == 0 && AreaGlobals.values.field_0x08 != 0) {
+        AddToCompletionPoints(POINTS_PER_REDBRICK);
+        Game.area_save[area].field_0x5[1] = 1;
+        AddStatusStage(&p, 18, 0);
+        if (p.episode_id != -1 && p.chapter != -1) {
+            sprintf(event, "redbrick_ep%i_ch%i_awarded", p.episode_id + 1, p.chapter + 1);
+            NuIOS_RecordFlurryEvent(event);
+        }
+    }
+    if (p.newly_completed != 0 && newCharactersCollected(&p) > 0) {
+        AddStatusStage(&p, 35, 0);
+        AddStatusStage(&p, 36, 0);
+        RememberPlayerIDs(1, static_cast<i16>(p.player0_model), static_cast<i16>(p.player1_model));
+    }
+    if (area != -1 && ((p.area->flags & 0x136) == 0x10 || (p.area->flags & 0x4000) != 0)) {
+        AREASAVE_s &save = Game.area_save[area];
+        if (BOTHTRUEJEDIGOLDBRICKS != 0) {
+            u8 &complete = (p.field_0xb0 & 0x40) != 0 ? save.freeplay_buildup_complete : save.story_buildup_complete;
+            if (complete == 0) {
+                if ((p.field_0xb0 & 4) != 0) {
+                    complete = 1;
+                    AddToCompletionPoints(POINTS_PER_TRUEJEDI);
+                    AddStatusStage(&p, 1, AddGoldBrickMessage(&p, tTRUEHERO));
+                } else if (p.collected_score > 0.0f) AddStatusStage(&p, 2, 0);
+            }
+        } else if (save.story_buildup_complete == 0 && save.freeplay_buildup_complete == 0) {
+            if ((p.field_0xb0 & 4) != 0) {
+                save.story_buildup_complete = save.freeplay_buildup_complete = 1;
+                AddToCompletionPoints(POINTS_PER_TRUEJEDI);
+                AddStatusStage(&p, 1, AddGoldBrickMessage(&p, tTRUEHERO));
+                if (p.episode_id == -1 || p.chapter == -1) sprintf(event, "truejedi_%s_awarded", p.area->file);
+                else sprintf(event, "truejedi_ep%i_ch%i_awarded", p.episode_id + 1, p.chapter + 1);
+                NuIOS_RecordFlurryEvent(event);
+            } else if (p.collected_score > 0.0f && (p.mode_flags & 8) == 0) AddStatusStage(&p, 2, 0);
+        }
+    }
+    if (p.collected_score > 0.0f) AddStatusStage(&p, 3, 0);
+    if (p.minikit_max != 0 && (p.area->flags & 0x36) == 0x10 && Game.area_save[area].minikit_count == 0 && AreaGlobals.values.field_0x10 > 0) {
+        p.new_minikits = AreaGlobals.values.field_0x10;
+        i32 gold = 0;
+        if (p.minikit_max <= Game.area_save[area].field_0x5[0]) {
+            Game.area_save[area].minikit_count = 1;
+            p.field_0xb0 |= 0x10;
+            AddToCompletionPoints(POINTS_PER_MINIKIT);
+            gold = AddGoldBrickMessage(&p, tMINIKIT);
+        }
+        if (from_save_and_exit == 0 || p.new_minikits != 0) AddStatusStage(&p, 4, gold);
+        if ((p.field_0xb0 & 0x10) != 0 && AllMiniKitsDone(Game.area_save) != 0) {
+            AddToCollection(id_SLAVE1);
+            AddStatusStage(&p, 17, 0);
+        }
+    }
+    if (p.previous_gold_bricks < Game.field_0x7c26[0]) AddStatusStage(&p, 19, 0);
+    if ((p.mode_flags & 8) == 0) AddStatusStage(&p, 9, 0);
+    AddStatusStage(&p, 10, 0);
+    if (netclient == 0) AddStatusStage(&p, 11, 0);
+    AddStatusStage(&p, 12, 0);
+    p.current_gold_brick = -1;
+    p.stage_types[p.stage_count] = -1;
+    p.next_stage = FindStatusStage(p.stage_types[0]);
+    NextStatusStage(&p);
+    collect_suit_bits = Game.initial_store_pack_flags;
+    Game.initial_store_pack_flags = areaSuitBits;
 }
 
 void SetDrawGoldBrick(STATUSPACKET_s *packet, i32) {
@@ -257,19 +816,96 @@ f32 StatusIconsOnOff(f32 progress) {
 void UpdateIconWibble() {
 }
 
-void Prompt_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void Prompt_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        if (stage->field_0x18 == 0.0f) {
+            NewMenu(0x400, 0, -1);
+        }
+        stage->field_0x18 += elapsed;
+        const i32 menu_level = GameMenuLevel;
+        if (stage->field_0x18 >= 0.5f) {
+            for (i32 player = 0; player < 2; ++player) {
+                if ((player == 0 ? packet->player0_active : packet->player1_active) == 0) {
+                    continue;
+                }
+                bool selected = false;
+                if (menu_level > 0 && GameMenu[menu_level].queued_item != -1) {
+                    status_prompt = GameMenu[menu_level].queued_item;
+                    GameMenu[menu_level].queued_item = -1;
+                    selected = true;
+                }
+                const u32 buttons = GamePad[player].buttons_pressed;
+                if ((buttons & GAMEPAD_MENUSELECT) != 0) {
+                    selected = true;
+                }
+                bool moved = false;
+                if ((buttons & GAMEPAD_MENUSELECT) == 0 &&
+                    (((packet->field_0xb0 & 0x48) == 8 &&
+                      (packet->next_area == -1 || (packet->area->flags & 2) != 0 ||
+                       Game.area_save[packet->next_area].complete != 0)) ||
+                     (packet->mode_flags & 1) != 0 || packet->challenge_state != 0 || packet->mission_state != 0)) {
+                    const u32 navigation = buttons | GamePad[player].left_directions;
+                    if (status_prompt < 1) {
+                        if ((navigation & GAMEPAD_DDOWN) != 0) {
+                            GameAudio_PlaySfx(0x2f, NULL, 0, 0);
+                            ++status_prompt;
+                            moved = true;
+                        }
+                    } else if ((navigation & GAMEPAD_DUP) != 0) {
+                        GameAudio_PlaySfx(0x2f, NULL, 0, 0);
+                        --status_prompt;
+                        moved = true;
+                    }
+                }
+                if (selected) {
+                    packet->prompt_choice =
+                        (packet->field_0xb0 & 8) != 0 && packet->next_area != -1 &&
+                        (packet->area->flags & 2) == 0 && Game.area_save[packet->next_area].complete == 0
+                            ? 1 : static_cast<u8>(status_prompt);
+                    GameAudio_PlaySfx(0x30, NULL, 0, 0);
+                    stage->field_0x14 = 1;
+                    stage->field_0x18 = 0.0f;
+                    stage->field_0x1c = 0.5f;
+                    return;
+                }
+                if (moved) {
+                    return;
+                }
+            }
+        }
+    } else if (stage->field_0x14 == 1) {
+        if (stage->field_0x18 == 0.0f) {
+            BackupMenu();
+        }
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 > stage->field_0x1c) {
+            NextStatusStage(packet);
+        }
+    }
 }
 
-void RedBrick_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+extern i32 STATUS_R, STATUS_G, STATUS_B;
+extern i16 tUNLOCKED;
+i32 DrawPanel3DObjectNoAlpha(f32, f32, f32, f32, f32, f32, u16, u16, u16, nuhspecial_s *, i32);
+void RedBrick_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 active) {
+    if (active == 0 || stage->field_0x14 <= 0) return;
+    f32 blend = 1.0f;
+    if (stage->field_0x18 < 1.0f) blend = NuTrigTable[(static_cast<i32>(stage->field_0x18 * 16384.0f) >> 1) & 0x7fff];
+    else if (stage->field_0x18 >= stage->field_0x1c - 1.0f) blend = NuTrigTable[(static_cast<i32>((1.0f - (stage->field_0x18 - (stage->field_0x1c - 1.0f))) * 16384.0f) >> 1) & 0x7fff];
+    SmartTextEx(TTab[tUNLOCKED], 0.0f, 0.05f, 1.0f, 0.7f, 0.7f, 0.7f, 0, STATUS_R, STATUS_G, STATUS_B, 1.7f, 1, NULL, 0, static_cast<i32>(blend * 128.0f));
+    const u32 angle = NuFmod(GlobalTimer.time_elapsed, 4.0f) * 0.25f * 65536.0f;
+    DrawPanel3DObjectNoAlpha(0.0f, blend - 1.5f, 1.0f, 1.0f, 1.0f, 1.0f, static_cast<i32>(NuTrigTable[angle & 0x7fff] * 1820.0f), angle, 0, reinterpret_cast<nuhspecial_s *>(&WORLD->lev_objs[0xd2]), 2);
+    SmartTextEx(TTab[*Cheat[static_cast<i8>(packet->area->cheat)].text_id], 0.0f, 1.5f - blend, 1.0f, 0.7f, 0.7f, 0.7f, 0, 255, 255, 255, 1.7f, 1, NULL, 0, 128);
 }
 
-void RedBrick_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void RedBrick_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *packet) {
+    NextStatusStage(packet);
 }
 
 void StatusPacketReset(STATUSPACKET_s *packet) {
     const STATUSPACKET_LSW_s *lsw_packet = packet->lsw_packet;
-    const i32 field_0x04 = packet->field_0x04;
-    const i32 field_0x08 = packet->field_0x08;
+    auto init_callback = packet->init_callback;
+    auto finish_callback = packet->finish_callback;
     void (*reset_callback)(STATUSPACKET_s *) = packet->reset_callback;
     void (*draw_background_callback)(STATUSPACKET_s *) = packet->draw_background_callback;
     const f32 field_0x68 = packet->field_0x68;
@@ -279,8 +915,8 @@ void StatusPacketReset(STATUSPACKET_s *packet) {
 
     packet->reset_callback = reset_callback;
     packet->lsw_packet = const_cast<STATUSPACKET_LSW_s *>(lsw_packet);
-    packet->field_0x04 = field_0x04;
-    packet->field_0x08 = field_0x08;
+    packet->init_callback = init_callback;
+    packet->finish_callback = finish_callback;
     packet->draw_background_callback = draw_background_callback;
     packet->field_0x68 = field_0x68;
 }
@@ -294,10 +930,69 @@ void StatusStage_Reset(STATUS_STAGE_s *stage) {
     }
 }
 
-void TrueHero_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+void DrawBuildUpBar(f32, f32, i32, i32, f32, f32, f32, u16);
+extern i16 tTRUEJEDI, tSTORY, tFREEPLAY;
+extern "C" void NuStrCat(char *, const char *);
+
+void TrueHero_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 active) {
+    if (active == 0) return;
+    char text[252];
+    f32 alpha = 1.0f;
+    const f32 time = stage->field_0x18;
+    switch (stage->field_0x14) {
+        case 0: alpha = 0.0f; break;
+        case 1: {
+            alpha = time;
+            const f32 ratio = stage->field_0x1c != 0.0f && time != 0.0f ? time / stage->field_0x1c : 0.0f;
+            const f32 blend = 1.0f - (NuTrigTable[(static_cast<i32>(ratio * 32768.0f + 16384.0f) >> 1) & 0x7fff] + 1.0f) * 0.5f;
+            DrawBuildUpBar(0.0f, (0.7f - STATSPOS2Y) * NuTrigTable[(static_cast<i32>(blend * 16384.0f) >> 1) & 0x7fff] + STATSPOS2Y,
+                           0, 100, 1.0f, blend * 0.75f + 1.0f, 1.0f, 0);
+            break;
+        }
+        case 2: {
+            const f32 blend = 1.0f - (NuTrigTable[(static_cast<i32>((time <= 1.0f ? time : 1.0f) * 32768.0f + 16384.0f) >> 1) & 0x7fff] + 1.0f) * 0.5f;
+            DrawBuildUpBar(0.0f, 0.7f, packet->true_hero_percent, 100, 1.0f, 1.75f, 1.0f, 0);
+            sprintf(text, "%i%%", static_cast<i32>(packet->true_hero_percent));
+            Text3DEx(text, 0.0f, 0.3f, 1.0f, 0.8f, 0.8f, 0.8f, 0, 255, 191, 0, static_cast<i32>(blend * 128.0f) & 255);
+            break;
+        }
+        case 3: {
+            const f32 blend = 1.0f - (NuTrigTable[time < 1.0f ? ((static_cast<i32>(time * 32768.0f + 16384.0f) >> 1) & 0x7fff) : 0x6000] + 1.0f) * 0.5f;
+            if (blend < 1.0f) {
+                const i32 opacity = static_cast<i32>((1.0f - blend) * 64.0f) & 255;
+                f32 scale = (blend * 0.5f + 1.0f) * 0.8f;
+                Text3DEx(const_cast<char *>("100%"), 0.0f, 0.3f, 1.0f, scale, scale, scale, 0, 255, 191, 0, opacity);
+                scale = (1.0f - blend * 0.5f) * 0.8f;
+                Text3DEx(const_cast<char *>("100%"), 0.0f, 0.3f, 1.0f, scale, scale, scale, 0, 255, 191, 0, opacity);
+            }
+            DrawBuildUpBar(0.0f, 0.7f, packet->true_hero_percent, 100, 1.0f, 1.75f, 1.0f, 0);
+            break;
+        }
+        case 6: {
+            alpha = 1.0f - time;
+            if (stage->type == 2 && alpha > 0.0f) {
+                sprintf(text, "%i%%", static_cast<i32>(packet->true_hero_percent));
+                Text3DEx(text, 0.0f, 0.3f, 1.0f, 0.8f, 0.8f, 0.8f, 0, 255, 191, 0, static_cast<i32>(alpha * 128.0f) & 255);
+            }
+            const f32 ratio = stage->field_0x18 < 1.0f ? 1.0f - stage->field_0x18 : 0.0f;
+            const f32 blend = 1.0f - (NuTrigTable[(static_cast<i32>(ratio * 32768.0f + 16384.0f) >> 1) & 0x7fff] + 1.0f) * 0.5f;
+            DrawBuildUpBar(0.0f, (0.7f - STATSPOS2Y) * NuTrigTable[(static_cast<i32>(blend * 16384.0f) >> 1) & 0x7fff] + STATSPOS2Y,
+                           packet->true_hero_percent, 100, 1.0f, blend * 0.75f + 1.0f, 1.0f, 0);
+            break;
+        }
+    }
+    if (alpha < 0.0f) alpha = 0.0f;
+    else if (alpha > 1.0f) alpha = 1.0f;
+    NuStrCpy(text, TTab[tTRUEJEDI]);
+    if (BOTHTRUEJEDIGOLDBRICKS != 0) {
+        NuStrCat(text, " ");
+        NuStrCat(text, TTab[(packet->field_0xb0 & 0x40) != 0 ? tFREEPLAY : tSTORY]);
+    }
+    Text3DEx(text, 0.0f, STATUS_TITLE_Y, 1.0f, 0.5f, 0.5f, 0.5f, 0, 255, 255, 255, static_cast<i32>(alpha * 128.0f) & 255);
 }
 
-void TrueHero_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void TrueHero_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *packet) {
+    NextStatusStage(packet);
 }
 
 i32 UpdateAchievements(STATUSPACKET_s *) {
@@ -305,25 +1000,265 @@ i32 UpdateAchievements(STATUSPACKET_s *) {
 }
 
 void UpdateStatusScreen(WORLDINFO_s *) {
+    const f32 elapsed = FRAMETIME;
+    CoinTotalScale = SeekLinearF(CoinTotalScale, 1.0f, FRAMETIME * 3.0f);
+    DrawGoldBrick_Phase = -1;
+    DrawGoldBrick_Stage = -1;
+    if (GAMEDEMO != 0) {
+        if (GAMEDEMO == 2) {
+            if (GameTimer.time_elapsed >= 8.0f) {
+                EndOfDemo(0);
+            }
+            return;
+        }
+        if (GAMEDEMO != 1 || FadeSys.fade != 0.0f || NewLData != NULL) {
+            return;
+        }
+        for (i32 player = 0; player < 2; ++player) {
+            if ((player == 0 ? StatusPacket.player0_active : StatusPacket.player1_active) == 0) {
+                continue;
+            }
+            if ((GamePad[player].buttons_pressed & GAMEPAD_MENUSELECT) != 0) {
+                GameAudio_PlaySfx(0x30, NULL, 0, 0);
+                if (gamedemo_option == 0) {
+                    new_level_from_menu = 1;
+                    NewLData = HUB_LDATA;
+                    GAMEDEMO = 2;
+                } else if (gamedemo_option == 1) {
+                    EndOfDemo(0);
+                }
+                return;
+            }
+            const u32 navigation = GamePad[player].buttons_pressed | GamePad[player].left_directions;
+            if ((navigation & GAMEPAD_DUP) != 0) {
+                if (gamedemo_option > 0) {
+                    --gamedemo_option;
+                    GameAudio_PlaySfx(0x2f, NULL, 0, 0);
+                }
+                return;
+            }
+            if ((navigation & GAMEPAD_DDOWN) != 0) {
+                if (gamedemo_option < 1) {
+                    ++gamedemo_option;
+                    GameAudio_PlaySfx(0x2f, NULL, 0, 0);
+                }
+                return;
+            }
+        }
+        return;
+    }
+    if (StatusPacket.status_flags == 0) {
+        return;
+    }
+    if ((StatusPacket.field_0xb0 & 2) == 0) {
+        bool skip = MechInputTouchMenuController::AnyTouchesThisFrame > 0;
+        if (skip) {
+            MechInputTouchMenuController::AnyTouchesThisFrame = 0;
+        } else {
+            const u32 button = Text_Language == 0 ? GAMEPAD_MENUSELECT : GAMEPAD_JUMP;
+            skip = (StatusPacket.player0_active != 0 && (GamePad[0].buttons_pressed & button) != 0) ||
+                   (StatusPacket.player1_active != 0 && (GamePad[1].buttons_pressed & button) != 0);
+        }
+        if (skip) {
+            if (StatusPacket.stage == NULL) {
+                return;
+            }
+            if (StatusPacket.stage->skip_callback != NULL) {
+                StatusPacket.stage->skip_callback(StatusPacket.stage, &StatusPacket);
+            }
+        }
+    }
+    if (StatusPacket.stage != NULL && StatusPacket.stage->update_callback != NULL) {
+        StatusPacket.stage->update_callback(StatusPacket.stage, &StatusPacket, elapsed);
+    }
+    if (StatusPacket.status_flags == 0 && GameTimer.time_elapsed >= 5.0f) {
+        FinishStatusPacket(0);
+    }
 }
 
-void RedBrick_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void RedBrick_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x18 = 0.0f;
+        stage->field_0x1c = 5.0f;
+        stage->field_0x14 = 1;
+    } else if (stage->field_0x14 == 1) {
+        const f32 previous = stage->field_0x18;
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) NextStatusStage(packet);
+        else if (previous < 0.75f && stage->field_0x18 >= 0.75f) {
+            PlaySfx(const_cast<char *>("TrueJedi_100pc"), NULL);
+            NewStatusRumbleBuzz(-1, 0.6f, 0.0f, 0);
+        }
+    }
 }
 
-void TrueHero_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+f32 nextsoundpercent;
+void TrueHero_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    static f32 spdelay;
+    switch (stage->field_0x14) {
+        case 0:
+            stage->field_0x14 = 1;
+            stage->field_0x18 = 0.0f;
+            stage->field_0x1c = 1.0f;
+            break;
+        case 1:
+            stage->field_0x18 += elapsed;
+            if (stage->field_0x18 >= stage->field_0x1c) {
+                stage->field_0x14 = 2;
+                stage->field_0x18 = 0.0f;
+                stage->field_0x1c = 3.0f;
+                nextsoundpercent = 5.0f;
+                packet->true_hero_percent = 0.0f;
+            }
+            break;
+        case 2: {
+            SetDrawGoldBrick(packet, packet->current_gold_brick);
+            f32 percent = 100.0f;
+            if ((packet->field_0xb0 & 4) == 0) {
+                const f32 ratio = packet->collected_score * 100.0f / packet->true_hero_target;
+                percent = ratio <= 99.0f ? ratio : 99.0f;
+            }
+            stage->field_0x18 += elapsed;
+            packet->true_hero_percent += (100.0f / stage->field_0x1c) * elapsed;
+            if (packet->true_hero_percent > percent) packet->true_hero_percent = percent;
+            else if (packet->true_hero_percent >= nextsoundpercent) {
+                PlaySfx(const_cast<char *>("Status_GoldBarDec"), NULL);
+                nextsoundpercent += 10.0f;
+            }
+            if (stage->field_0x18 > stage->field_0x1c) {
+                stage->field_0x18 = 0.0f;
+                stage->field_0x1c = 1.0f;
+                if (stage->type == 2) {
+                    stage->field_0x14 = 6;
+                    PlaySfx(const_cast<char *>("TrueJedi_NOT"), NULL);
+                } else {
+                    stage->field_0x14 = 3;
+                    PlaySfx(const_cast<char *>("TrueJedi_100pc"), NULL);
+                }
+            }
+            break;
+        }
+        case 3:
+            stage->field_0x18 += elapsed;
+            if (stage->field_0x18 >= stage->field_0x1c) {
+                stage->field_0x18 = 0.0f;
+                stage->field_0x1c = 1.0f;
+                stage->field_0x14 = 6;
+                spdelay = 0.0f;
+            }
+            break;
+        case 6:
+            stage->field_0x18 += elapsed;
+            if (stage->field_0x18 >= stage->field_0x1c) NextStatusStage(packet);
+            break;
+    }
 }
 
-void InitStatusScreen_LSW(WORLDINFO_s *, STATUSPACKET_s *) {
+i32 InitStatusScreen_LSW(WORLDINFO_s *, STATUSPACKET_s *) {
+    return 0;
 }
 
-void RegisterStatusScreen(STATUS_STAGE_s *, i32 *, REGISTERSTATUSPACKET_s *) {
+void RegisterStatusScreen(STATUS_STAGE_s *stages, i32 *, REGISTERSTATUSPACKET_s *registration) {
+    StatusStages = stages;
+    StatusPacket.init_callback = registration->init_callback;
+    StatusPacket.finish_callback = registration->finish_callback;
+    StatusPacket.reset_callback = registration->reset_callback;
+    StatusPacket.draw_background_callback = registration->draw_background_callback;
+    StatusPacket.lsw_packet = registration->lsw_packet;
+    StatusPacket.field_0x68 = registration->stage_delay;
 }
 
 void ResetStatusPacket_LSW(STATUSPACKET_s *packet) {
     packet->lsw_packet->field_0x00 = 0;
 }
 
-void Status_DrawPromptMenu(STATUSPACKET_s *, i32, float) {
+extern i16 tMAP, tRESTART, tFINISHSTORY, tCONTINUESTORY, tFINALCHAPTERLOCKED, tNEXTCHAPTERLOCKED;
+extern f32 text3d_width, text3d_height;
+extern "C" {
+    extern u8 MENUENTRYR, MENUENTRYG, MENUENTRYB;
+    extern u8 MENUNORMALR, MENUNORMALG, MENUNORMALB;
+    extern u8 MENUFLASH0R, MENUFLASH0G, MENUFLASH0B;
+    extern u8 MENUFLASH1R, MENUFLASH1G, MENUFLASH1B;
+}
+void Hint_SetHintFromId(i32, i32, i32);
+void Hint_SetComplete(i32);
+void Hint_Draw(i32);
+
+void Status_DrawPromptMenu(STATUSPACKET_s *packet, i32 selected, float alpha) {
+    i32 labels[2];
+    labels[1] = -1;
+    MENU_s *menu = &GameMenu[GameMenuLevel];
+    bool locked = false;
+    if ((packet->mode_flags & 1) != 0 || packet->challenge_state != 0 || packet->mission_state != 0) {
+        labels[0] = tRESTART;
+        labels[1] = tMAP;
+    } else if ((packet->field_0xb0 & 0x40) != 0 ||
+               (packet->area_id != -1 && ADataList[packet->area_id].episode_index == 0xff)) {
+        labels[0] = tMAP;
+    } else {
+        labels[0] = tFINISHSTORY;
+        if ((packet->field_0xb0 & 8) != 0) {
+            if (packet->next_area != -1 && (ADataList[packet->next_area].flags & 2) == 0 &&
+                Game.area_save[packet->next_area].complete == 0) {
+                labels[0] = tMAP;
+                const i16 text = ADataList[packet->next_area].area_index == 5 ? tFINALCHAPTERLOCKED : tNEXTCHAPTERLOCKED;
+                SmartTextEx(TTab[text], 0.0f, 0.325f, 1.0f, 0.5f, 0.5f, 0.5f, 0, 255, 63, 0, 1.7f, 1,
+                            NULL, 0, static_cast<i32>(alpha * 128.0f));
+                locked = true;
+            } else {
+                if (packet->next_area == -1 || (ADataList[packet->next_area].flags & 2) == 0) {
+                    labels[0] = tCONTINUESTORY;
+                }
+                labels[1] = tMAP;
+            }
+        } else if (packet->next_area == -1 || (ADataList[packet->next_area].flags & 2) == 0) {
+            labels[0] = tCONTINUESTORY;
+        }
+    }
+    const i32 count = labels[1] == -1 ? 1 : 2;
+    f32 y = count == 1 ? 0.125f : 0.1f;
+    if (!locked && count == 2 && packet->newly_completed != 0 && packet->area != NULL &&
+        packet->area == NEGOTIATIONS_ADATA) {
+        Hint_SetHintFromId(0x26c, 0, 1);
+        Hint_SetComplete(0x26c);
+        Hint_Draw(-1);
+        y = 0.48999998f;
+    }
+    if ((packet->mode_flags & 1) != 0) {
+        y += 0.075f;
+    }
+    for (i32 i = 0; i < count; ++i) {
+        u32 red, green, blue;
+        if (selected != 0 && status_prompt == i && TestForController()) {
+            if (menu_pulsate > 0.0f) {
+                const f32 inverse = 1.0f - menu_pulsate;
+                red = MENUFLASH0R * menu_pulsate + MENUFLASH1R * inverse;
+                green = MENUFLASH0G * menu_pulsate + MENUFLASH1G * inverse;
+                blue = MENUFLASH0B * menu_pulsate + MENUFLASH1B * inverse;
+            } else if (menu_flash == 0) {
+                red = MENUFLASH1R; green = MENUFLASH1G; blue = MENUFLASH1B;
+            } else {
+                red = MENUFLASH0R; green = MENUFLASH0G; blue = MENUFLASH0B;
+            }
+        } else if (menu_pulse > 0.0f) {
+            const f32 inverse = 1.0f - menu_pulse;
+            red = MENUFLASH0R * menu_pulse + MENUNORMALR * inverse;
+            green = MENUFLASH0G * menu_pulse + MENUNORMALG * inverse;
+            blue = MENUFLASH0B * menu_pulse + MENUNORMALB * inverse;
+        } else {
+            red = MENUENTRYR; green = MENUENTRYG; blue = MENUENTRYB;
+        }
+        smarttextex_drawmessagebox = 1;
+        SmartTextEx(TTab[labels[i]], 0.0f, y, 1.0f, 0.7f, 0.7f, 0.7f, 0, red, green, blue, 1.7f, 1,
+                    NULL, 0, static_cast<i32>(alpha * 128.0f) & 0xff);
+        menu->item_x[i] = 0.0f;
+        menu->item_y[i] = y;
+        menu->item_width[i] = text3d_width;
+        menu->item_height[i] = text3d_height;
+        menu->item_column[i] = 0;
+        menu->item_row[i] = i;
+        y -= 0.2f;
+    }
 }
 
 f32 getFinishedStatusAlpha(STATUSPACKET_s *packet) {
@@ -349,35 +1284,271 @@ f32 getFinishedStatusAlpha(STATUSPACKET_s *packet) {
 void SuperStoryTime_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
 }
 
-void SuperStoryTime_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void SuperStoryTime_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *packet) {
+    *packet->score = packet->time_reward_score;
+    NextStatusStage(packet);
 }
 
 void LSW_registerStatusScreen() {
+    REGISTERSTATUSPACKET_s registration = {
+        &StatusPacket_LSW, InitStatusScreen_LSW, FinishStatusPacket_LSW,
+        ResetStatusPacket_LSW, DrawStatusBG_LSW, 0.5f,
+    };
+    RegisterStatusScreen(StatusStages_LSW, NULL, &registration);
 }
 
 void SuperStoryScore_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
 }
 
-void SuperStoryScore_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void SuperStoryScore_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *packet) {
+    *packet->score = packet->final_reward_score;
+    NextStatusStage(packet);
 }
 
-void SuperStoryTime_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void SuperStoryTime_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x14 = 1;
+        stage->field_0x18 = 0.0f;
+        stage->field_0x1c = 5.0f;
+        packet->original_score = *packet->score;
+    } else if (stage->field_0x14 == 1) {
+        const f32 previous = stage->field_0x18;
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) {
+            *packet->score = packet->time_reward_score;
+            NextStatusStage(packet);
+        } else if (previous < 0.5f && stage->field_0x18 >= 0.5f) {
+            if (packet->new_best_time == 0.0f) GameAudio_PlaySfx(0x32, NULL, 0, 0);
+            else PlaySfx(const_cast<char *>("StatusAward"), NULL);
+            NewStatusRumbleBuzz(-1, 0.6f, 0.0f, 0);
+        }
+        if (packet->new_best_time != 0.0f) {
+            if (previous < 4.0f && stage->field_0x18 >= 4.0f) {
+                CoinTotalScale = 1.5f;
+                NewStatusRumbleBuzz(-1, 0.0f, 0.1f, 0);
+                PlaySfx(const_cast<char *>("Shop_BuyCheat"), NULL);
+            }
+            if (stage->field_0x18 >= 4.5f) *packet->score = packet->time_reward_score;
+            else if (stage->field_0x18 >= 0.5f && stage->field_0x18 < 4.0f) {
+                const f32 blend = NuTrigTable[(static_cast<i32>(((stage->field_0x18 - 0.5f) / 3.5f) * 16384.0f) >> 1) & 0x7fff];
+                const u32 difference = packet->time_reward_score - packet->original_score;
+                *packet->score = packet->original_score;
+                IncreaseScore(packet->score, static_cast<i64>(static_cast<i32>(static_cast<f32>(difference) * blend)), 0);
+                if (static_cast<i32>(previous / 0.2f) != static_cast<i32>(stage->field_0x18 / 0.2f)) PlaySfx(const_cast<char *>("PickupCoin"), NULL);
+            }
+        }
+    }
 }
 
-void SuperStoryScore_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void SuperStoryScore_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x14 = 1;
+        stage->field_0x18 = 0.0f;
+        stage->field_0x1c = 5.0f;
+        packet->original_score = *packet->score;
+    } else if (stage->field_0x14 == 1) {
+        const f32 previous = stage->field_0x18;
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) {
+            *packet->score = packet->final_reward_score;
+            NextStatusStage(packet);
+        } else if (previous < 0.5f && stage->field_0x18 >= 0.5f) {
+            if (packet->new_best_score == 0) GameAudio_PlaySfx(0x32, NULL, 0, 0);
+            else PlaySfx(const_cast<char *>("StatusAward"), NULL);
+            NewStatusRumbleBuzz(-1, 0.6f, 0.0f, 0);
+        }
+        if (packet->final_reward_score != packet->original_score) {
+            if (previous < 4.0f && stage->field_0x18 >= 4.0f) {
+                CoinTotalScale = 1.5f;
+                NewStatusRumbleBuzz(-1, 0.0f, 0.1f, 0);
+                PlaySfx(const_cast<char *>("Shop_BuyCheat"), NULL);
+            }
+            if (stage->field_0x18 >= 4.0f) *packet->score = packet->final_reward_score;
+            else if (stage->field_0x18 >= 0.5f && stage->field_0x18 < 4.0f) {
+                const f32 blend = 1.0f - NuTrigTable[(static_cast<i32>(((stage->field_0x18 - 0.5f) / 3.5f) * 16384.0f + 16384.0f) >> 1) & 0x7fff];
+                const u32 difference = packet->final_reward_score - packet->original_score;
+                *packet->score = packet->original_score;
+                IncreaseScore(packet->score, static_cast<i64>(static_cast<i32>(static_cast<f32>(difference) * blend)), 0);
+                if (static_cast<i32>(previous / 0.2f) != static_cast<i32>(stage->field_0x18 / 0.2f)) PlaySfx(const_cast<char *>("PickupCoin"), NULL);
+            }
+        }
+    }
 }
 
-void Coins_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+void Coins_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 active) {
+    if (active == 0) {
+        if (stage->field_0x12 != 0) {
+            const f32 alpha = getFinishedStatusAlpha(packet);
+            CoinTotal_Draw(*packet->score, StatusIconsOnOff(alpha), CoinTotalScale, 1, 1.0f, 255, 191, 0);
+        }
+        return;
+    }
+    f32 alpha = 1.0f;
+    f32 coin_y = STATSPOS2Y;
+    f32 total_y = STATSPOS2Y;
+    f32 scale = 2.0f;
+    switch (stage->field_0x14) {
+    case 0:
+        alpha = 0.0f;
+        break;
+    case 1: {
+        alpha = stage->field_0x18;
+        f32 ratio = stage->field_0x18 / stage->field_0x1c;
+        const f32 blend = 1.0f - (NuTrigTable[(static_cast<i32>(ratio * 32768.0f + 16384.0f) >> 1) & 0x7fff] + 1.0f) * 0.5f;
+        if (stage->field_0x1c == 0.0f || stage->field_0x18 == 0.0f) {
+            ratio = 0.0f;
+        }
+        icon_y = StatusIconsOnOff(ratio);
+        total_y = (0.3f - STATSPOS2Y) * blend + STATSPOS2Y;
+        coin_y = (STATSPOSY - STATSPOS2Y) * blend + STATSPOS2Y;
+        break;
+    }
+    case 2:
+        total_y = 0.3f;
+        coin_y = STATSPOSY;
+        break;
+    case 3: {
+        alpha = 1.0f - stage->field_0x18;
+        const f32 blend = 1.0f - (NuTrigTable[(static_cast<i32>((1.0f - stage->field_0x18 / stage->field_0x1c) * 32768.0f + 16384.0f) >> 1) & 0x7fff] + 1.0f) * 0.5f;
+        total_y = (0.3f - STATSPOSY) * blend + STATSPOSY;
+        scale = (2.0f - CoinTotalScale) * blend + CoinTotalScale;
+        coin_y = STATSPOS2Y + (STATSPOSY - STATSPOS2Y) * blend;
+        break;
+    }
+    }
+    if (stage->field_0x14 >= 1) {
+        const f32 player_alpha = packet->player0_active == 0 ? DROPINALPHA : 1.0f;
+        const u32 coins = packet->coins_remaining[0];
+        const i32 object_index = coins < 100 ? 0xb3 : coins < 1000 ? 0xbb : 0xc3;
+        if (WORLD->lev_objs[object_index].active != 0) {
+            DrawPanel3DObject(-PANEL_COINX, coin_y, 1.0f, PANEL_COINSCALE_END, PANEL_COINSCALE_END,
+                              PANEL_COINSCALE_END, 0, 0, 0, &WORLD->lev_objs[object_index].special, 0, player_alpha);
+        }
+        char text[256];
+        Text_MakeScore(packet->coins_remaining[0], text);
+        Text3DEx(text, -PANEL_SCOREX, coin_y, 1.0f, PANEL_SCORESCALE, PANEL_SCORESCALE, PANEL_SCORESCALE,
+                 2, 255, 191, 0, static_cast<u8>(player_alpha * 128.0f));
+        CoinTotal_Draw(*packet->score, total_y, scale, 1, 1.0f, 255, 191, 0);
+    }
+    alpha = alpha < 0.0f ? 0.0f : alpha > 1.0f ? 1.0f : alpha;
+    Text3DEx(TTab[tCOINTOTAL], 0.0f, STATUS_TITLE_Y, 1.0f, 0.5f, 0.5f, 0.5f, 0,
+             255, 255, 255, static_cast<u8>(alpha * 128.0f));
 }
-void Coins_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void Coins_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *packet) {
+    icon_y = StatusIconsOnOff(1.0f);
+    IncreaseScore(packet->score, static_cast<u64>(packet->coins_remaining[0] + packet->coins_remaining[1]), 0);
+    packet->coins_remaining[0] = 0;
+    packet->coins_remaining[1] = 0;
+    NextStatusStage(packet);
 }
-void Coins_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void Coins_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    switch (stage->field_0x14) {
+    case 0:
+        stage->field_0x14 = 1;
+        stage->field_0x18 = 0.0f;
+        stage->field_0x1c = 1.0f;
+        draw_player_icons = 1;
+        break;
+    case 1:
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) {
+            stage->field_0x14 = 2;
+        }
+        break;
+    case 2: {
+        i32 finished = 0;
+        for (i32 player = 0; player < 2; ++player) {
+            u32 remaining = packet->coins_remaining[player];
+            if (remaining != 0) {
+                u32 rate = 35;
+                for (u32 threshold = 100; threshold <= remaining; threshold *= 10) {
+                    rate *= 10;
+                }
+                u32 amount = static_cast<u32>(static_cast<f32>(rate) * elapsed);
+                if (amount > remaining) {
+                    amount = remaining;
+                } else if (amount == 0) {
+                    amount = 1;
+                }
+                packet->coins_remaining[player] -= amount;
+                IncreaseScore(packet->score, static_cast<u64>(amount), 0);
+            }
+            finished += packet->coins_remaining[player] == 0;
+        }
+        PlaySfx("PickupCoin", 0);
+        if (finished == 2) {
+            stage->field_0x14 = 3;
+            stage->field_0x18 = 0.0f;
+            stage->field_0x1c = 1.0f;
+            if (packet->coins_collected[0] + packet->coins_collected[1] == 0) {
+                GameAudio_PlaySfx(0x32, NULL, 0, 0);
+            } else {
+                PlaySfx("Shop_BuyCheat", 0);
+            }
+        }
+        break;
+    }
+    case 3:
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) {
+            NextStatusStage(packet);
+        }
+        break;
+    }
 }
-void BonusWin_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+extern i16 tWINNER;
+void DrawBonusScore(f32, i32, i32, f32, i32 *);
+void DrawBonusTime(STATUSPACKET_s *, f32, i32);
+
+void BonusWin_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 current) {
+    if (current == 0) {
+        if (stage->field_0x12 != 0) {
+            const f32 alpha = getFinishedStatusAlpha(packet);
+            if (packet->stage->type != 25) {
+                DrawBonusScore(STATSPOSY, StatusPacket.player0_active, StatusPacket.player1_active, alpha, BonusScore);
+            }
+        }
+    } else if (stage->field_0x14 == 0) {
+        iconalphaoverride = 0.0f;
+    } else {
+        const f32 time = stage->field_0x18;
+        if (stage->field_0x1c - 0.1f <= time) {
+            iconalphaoverride = 0.0f;
+        } else if (time < stage->field_0x1c - 0.6f) {
+            iconalphaoverride = time < 0.5f ? time + time : 1.0f;
+        } else {
+            const f32 fade = time - (stage->field_0x1c - 0.6f);
+            iconalphaoverride = 1.0f - (fade + fade);
+        }
+        if (time < 2.0f && NuFmod(time, 0.2f) >= 0.1f) {
+            const i32 winner = (packet->field_0xb0 & 0x20) != 0;
+            SmartTextEx(TTab[tWINNER], winner ? 0.675f : -0.675f, STATSPOSY, 1.0f,
+                        0.7f, 0.7f, 0.7f, winner ? 8 : 2, 0, 255, 0, 0.35f, 1, NULL, 0,
+                        static_cast<i32>(iconalphaoverride * 128.0f));
+        }
+        DrawBonusScore(STATSPOSY, StatusPacket.player0_active, StatusPacket.player1_active, iconalphaoverride, BonusScore);
+    }
 }
 void BonusWin_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
 }
-void BonusTime_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+void BonusTime_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 current) {
+    if (current == 0) {
+        if (stage->field_0x12 != 0) {
+            DrawBonusTime(packet, 1.0f, static_cast<i32>(getFinishedStatusAlpha(packet) * 128.0f));
+        }
+    } else if (stage->field_0x14 > 0) {
+        f32 alpha = stage->field_0x18;
+        f32 time;
+        if (alpha >= 0.5f) {
+            time = alpha < 3.0f ? 0.0f : alpha - 3.0f;
+            alpha = 1.0f;
+        } else {
+            alpha += alpha;
+            time = 0.0f;
+        }
+        DrawBonusTime(packet, 1.0f - (NuTrigTable[(static_cast<i32>(time * 32768.0f + 16384.0f) >> 1) & 0x7fff] + 1.0f) * 0.5f,
+                      static_cast<i32>(alpha * 128.0f));
+    }
 }
 void BonusTime_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
 }
@@ -385,15 +1556,78 @@ void ChallangeCash_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
 }
 void ChallangeCash_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
 }
-void BonusWin_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void BonusWin_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x14 = 1; stage->field_0x18 = 0.0f; stage->field_0x1c = 4.0f;
+        draw_player_icons = 1;
+    } else if (stage->field_0x14 == 1) {
+        const f32 previous = stage->field_0x18;
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) NextStatusStage(packet);
+        else if (previous < stage->field_0x1c * 0.5f && stage->field_0x18 >= stage->field_0x1c * 0.5f) {
+            PlaySfx(const_cast<char *>("TrueJedi_100pc"), NULL);
+            NewStatusRumbleBuzz(-1, 0.6f, 0.0f, 0);
+            ++BonusScore[(packet->field_0xb0 >> 5) & 1];
+        }
+    }
 }
-void BonusTime_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void BonusTime_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x18 = 0.0f; stage->field_0x1c = 4.0f; stage->field_0x14 = 1;
+    } else if (stage->field_0x14 == 1) {
+        SetDrawGoldBrick(packet, packet->current_gold_brick);
+        const f32 previous = stage->field_0x18;
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) NextStatusStage(packet);
+        else if (previous < 0.5f && stage->field_0x18 >= 0.5f) {
+            if (packet->new_best_time == 0.0f) GameAudio_PlaySfx(0x32, NULL, 0, 0);
+            else PlaySfx(const_cast<char *>("StatusAward"), NULL);
+            NewStatusRumbleBuzz(-1, 0.6f, 0.0f, 0);
+        }
+    }
 }
 void ChallangeCash_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
 }
-void BonusComplete_LSW_Draw(STATUS_STAGE_s *, STATUSPACKET_s *, i32) {
+void BonusComplete_LSW_Draw(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, i32 current) {
+    if (current == 0) return;
+    if (stage->field_0x14 > 0 && packet->newly_completed != 0) {
+        const f32 time = stage->field_0x18;
+        f32 alpha;
+        if (time < 0.5f) alpha = time + time;
+        else if (time >= 3.5f) alpha = 1.0f - ((time - 3.5f) + (time - 3.5f));
+        else alpha = 1.0f;
+        if (alpha > 0.0f) {
+            SmartTextEx(TTab[tLEVELCOMPLETE], 0.0f, 0.1f, 1.0f, 0.7f, 0.7f, 0.7f, 0,
+                        STATUS_R, STATUS_G, STATUS_B, 1.7f, 1, NULL, 0, static_cast<i32>(alpha * 128.0f));
+        }
+    }
+    if (stage->field_0x14 == 0) {
+        iconalphaoverride = 0.0f;
+    } else if (packet->newly_completed == 0) {
+        iconalphaoverride = stage->field_0x18 / stage->field_0x1c;
+    } else if (stage->field_0x18 < stage->field_0x1c - 0.5f) {
+        iconalphaoverride = 0.0f;
+    } else {
+        const f32 time = stage->field_0x18 - (stage->field_0x1c - 0.5f);
+        iconalphaoverride = time + time;
+    }
 }
-void BonusComplete_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *) {
+void BonusComplete_LSW_Skip(STATUS_STAGE_s *, STATUSPACKET_s *packet) {
+    NextStatusStage(packet);
 }
-void BonusComplete_LSW_Update(STATUS_STAGE_s *, STATUSPACKET_s *, float) {
+void BonusComplete_LSW_Update(STATUS_STAGE_s *stage, STATUSPACKET_s *packet, float elapsed) {
+    if (stage->field_0x14 == 0) {
+        stage->field_0x18 = 0.0f; stage->field_0x14 = 1;
+        stage->field_0x1c = packet->newly_completed == 0 ? 0.5f : 4.0f;
+        draw_player_icons = 1;
+    } else if (stage->field_0x14 == 1) {
+        SetDrawGoldBrick(packet, packet->current_gold_brick);
+        const f32 previous = stage->field_0x18;
+        stage->field_0x18 += elapsed;
+        if (stage->field_0x18 >= stage->field_0x1c) NextStatusStage(packet);
+        else if (packet->newly_completed != 0 && previous < 0.5f && stage->field_0x18 >= 0.5f) {
+            PlaySfx(const_cast<char *>("StatusAward"), NULL);
+            NewStatusRumbleBuzz(-1, 0.6f, 0.0f, 0);
+        }
+    }
 }

--- a/src/legoapi/misc/legoapi_misc.cpp
+++ b/src/legoapi/misc/legoapi_misc.cpp
@@ -118,7 +118,8 @@ COLLECTID *CollectIDUnlocked(i32 id) {
         case 4:
             return AllMiniKitsDone(Game_AreaSave) != 0 ? entry : NULL;
         case 6:
-            if (StatusCollectList.ptr == NULL || StatusCollectList.ptr->gold_bricks < entry->field6_0xa) {
+            if (Game_CompletionSave == NULL ||
+                reinterpret_cast<STATUSCOLLECT_s *>(Game_CompletionSave)->gold_bricks < entry->field6_0xa) {
                 return NULL;
             }
             return entry;

--- a/src/legoapi/render/core/render.cpp
+++ b/src/legoapi/render/core/render.cpp
@@ -1257,7 +1257,33 @@ void DrawAlphaGrid(i32, i32, NuBloomParameters *) {
 void DrawArrow_Now(_vum_s *, float, i32, i32) {
 }
 
-void DrawBonusTime(STATUSPACKET_s *, float, i32) {
+extern i16 tNONEWBESTTIME, tNEWBESTTIME;
+void Text_MakeTime(f32, i32, i32, i32, char *);
+
+void DrawBonusTime(STATUSPACKET_s *packet, float position, i32 alpha) {
+    const f32 y = -0.5f * position;
+    char *title;
+    i32 red, green;
+    if (packet->new_best_time != 0.0f) {
+        title = TTab[tNEWBESTTIME];
+        red = 0;
+        green = 255;
+    } else {
+        title = TTab[tNONEWBESTTIME];
+        red = 255;
+        green = 0;
+    }
+    SmartTextEx(title, 0.0f, 0.15f + y, 1.0f, 0.7f, 0.7f, 0.7f, 0,
+                red, green, 0, 1.7f, 1, NULL, 0, static_cast<u8>(alpha));
+    char time[256];
+    char previous[256];
+    Text_MakeTime(packet->new_best_time != 0.0f ? packet->new_best_time : packet->elapsed_time, 1, 1, 1, time);
+    Text3DEx(time, 0.0f, 0.0f + y, 1.0f, 0.7f, 0.7f, 0.7f, 0, 255, 255, 255, static_cast<u8>(alpha));
+    Text_MakeTime(packet->previous_best_time, 1, 1, 1, time);
+    NuStrCpy(previous, "(");
+    NuStrCat(previous, time);
+    NuStrCat(previous, ")");
+    Text3DEx(previous, 0.0f, y - 0.15f, 1.0f, 0.7f, 0.7f, 0.7f, 0, 255, 255, 255, static_cast<u8>(static_cast<u8>(alpha) >> 1));
 }
 
 void DrawCross_Now(_vuv_s *, float, i32, i32) {
@@ -1361,7 +1387,28 @@ void DrawBonusScore(float, i32, i32, float, i32 *) {
 void DrawBoxMtx_Now(_vum_s *, _vuv_s *, i32, i32) {
 }
 
-void DrawBuildUpBar(float, float, i32, i32, float, float, float, u16) {
+void DrawBuildUpBar(float x, float y, i32 amount, i32 maximum, float scale, float width, float alpha, u16 angle) {
+    const f32 progress = static_cast<f32>(amount * 10) / maximum;
+    const i32 full = progress;
+    const f32 fraction = NuFmod(progress, 1.0f);
+    const f32 phase = GlobalTimer.time_elapsed_mod_seconds * 10.0f;
+    const f32 size = scale * 0.085f * width;
+    const f32 step = width * 0.02975f * NuTrigTable[((angle + 0x4000) >> 1) & 0x7fff];
+    f32 px = x - step * 9.0f * 0.5f;
+    i32 shimmer = 0xb3 - static_cast<i32>(phase);
+    for (i32 i = 0; i < 10; ++i) {
+        i32 object;
+        if (amount == maximum) {
+            if (shimmer >= 0xb3) shimmer = 0xa9;
+            object = shimmer++;
+        } else if (i < full) object = 0xb2;
+        else if (i == full) object = fraction * 9.0f + 169.0f;
+        else object = 0xa9;
+        const f32 depth[10] = {1.009f, 1.008f, 1.007f, 1.006f, 1.005f, 1.004f, 1.003f, 1.002f, 1.001f, 1.0f};
+        DrawPanel3DObject(px, y, depth[i], size, size, size, 0, 0, 0,
+                          reinterpret_cast<nuhspecial_s *>(&WORLD->lev_objs[object]), 0, alpha);
+        px += step;
+    }
 }
 
 void DrawCodeMenu3D() {
@@ -1726,7 +1773,37 @@ void DrawGameMessages() {
 void DrawMeleeTargets(i16 *, char *, float *, i32) {
 }
 
-void DrawMiniKitCount(float, float, i32, i32) {
+f32 KITPOSX = -0.725f;
+f32 KITPOSY = -0.7f;
+f32 KITPOS2X = -1.275f;
+f32 KITPOS2Y = -1.3f;
+f32 PANEL_MINIKITSCALE = 0.25f;
+f32 PANEL_MINIKITY = 0.03f;
+f32 PANEL_MINIKITCOUNTSCALE = 0.5f;
+f32 PANEL_MINIKITCOUNTY = -0.1f;
+i32 LEGOOBJ_CHARKIT = -1;
+i32 LEGOOBJ_MINIKIT = -1;
+i32 DrawPanel3DObjectNoAlpha(f32, f32, f32, f32, f32, f32, u16, u16, u16, nuhspecial_s *, i32);
+extern "C" void Text3D(char *, f32, f32, f32, f32, f32, f32, u32, u8, u8, u8);
+
+void DrawMiniKitCount(float position, float scale, i32 count, i32 maximum) {
+    const i32 model = ChallengeMode != 0 ? LEGOOBJ_CHARKIT : LEGOOBJ_MINIKIT;
+    if (model == -1 || position <= 0.0f) return;
+    const f32 blend = NuTrigTable[(static_cast<i32>(position * 16384.0f) >> 1) & 0x7fff];
+    const f32 x = (KITPOSX - KITPOS2X) * blend + KITPOS2X;
+    const f32 y = (KITPOSY - KITPOS2Y) * blend + KITPOS2Y;
+    WORLDINFO_s *world = WorldInfo_CurrentlyActive();
+    if (world->lev_objs[model].active != 0) {
+        const u16 rotation = static_cast<u16>(static_cast<i32>(NuFmod(GameTimer.time_elapsed, 4.0f) * 0.25f * 65536.0f));
+        const u16 tilt = static_cast<u16>(static_cast<i32>(1820.0f * NuTrigTable[rotation & 0x7fff]));
+        const f32 size = scale * PANEL_MINIKITSCALE;
+        DrawPanel3DObjectNoAlpha(x, PANEL_MINIKITY + y, 1.0f, size, size, size, tilt, rotation, 0,
+                                 &world->lev_objs[model].special, 2);
+    }
+    char text[40];
+    sprintf(text, "%i/%i", count, maximum);
+    const f32 size = scale * PANEL_MINIKITCOUNTSCALE;
+    Text3D(text, x, y + PANEL_MINIKITCOUNTY, 1.0f, size, size, size, 0, 255, 0, 127);
 }
 
 void DrawStatusBG_LSW(STATUSPACKET_s *status) {
@@ -2377,7 +2454,13 @@ void DrawPanel() {
 
     if (editor_active == 0 && PANELOFF == 0 && WORLD != NULL && WORLD->current_level != NULL) {
         LEVELDATA *level = WORLD->current_level;
-        if ((level->flags & LEVEL_GAMEPLAY) != 0) {
+        // DrawPanel 0x141f08: status levels dispatch before the gameplay HUD.
+        if (level == STATUS_LDATA || (level->flags & LEVEL_STATUS) != 0) {
+            if (level->draw_status_fn != NULL) {
+                level->draw_status_fn(WORLD);
+            }
+            DrawGameMessages();
+        } else if ((level->flags & LEVEL_GAMEPLAY) != 0) {
             const f32 status_y =
                 NuTrigTable[(static_cast<i32>(statstime * static_cast<f32>(NUANG_90DEG)) >> 1) & 0x7fff] *
                     (STATSPOSY - STATSPOS2Y) +

--- a/src/legoapi/render/core/render.h
+++ b/src/legoapi/render/core/render.h
@@ -16,7 +16,7 @@ void Draw_AUTOSAVEWARNING(void);
 #ifdef __cplusplus
 extern "C" {
 #endif
-    void Text3DEx(char *, f32, f32, f32, f32, f32, f32, u8, u8, u8, u8, i32);
+    void Text3DEx(char *, f32, f32, f32, f32, f32, f32, u32, u8, u8, u8, i32);
 #ifdef __cplusplus
 }
 #endif

--- a/src/legoapi/world/levels/episodeIV.cpp
+++ b/src/legoapi/world/levels/episodeIV.cpp
@@ -134,7 +134,9 @@ void DeathStarRescueC_AlwaysUpdate(WORLDINFO_s *) {
 // Death Star escape (DeathStarEscape_A / B / C / D)
 // ===========================================================================
 
-void DeathStarShieldDown() {
+bool DeathStarShieldDown() {
+    // Shield-state behavior remains unreconstructed.
+    return false;
 }
 
 void DeathStarEscapeA_Init(WORLDINFO_s *) {

--- a/src/legoapi/world/levels/episodeVI.cpp
+++ b/src/legoapi/world/levels/episodeVI.cpp
@@ -117,7 +117,9 @@ void SarlaccPitC_Reset(WORLDINFO_s *) {
 void SarlaccPitC_Update(WORLDINFO_s *) {
 }
 
-void SarlaccPitDiscoActive(WORLDINFO_s *) {
+bool SarlaccPitDiscoActive(WORLDINFO_s *) {
+    // Disco-state behavior remains unreconstructed.
+    return false;
 }
 
 // ===========================================================================

--- a/src/legogame/game.cpp
+++ b/src/legogame/game.cpp
@@ -336,7 +336,6 @@ void InitGameBeforeConfig(void) {
     Game_CharacterSave = Game.character_save;
     Game_CompletionSave = &Game.completion;
     Game_MissionSave = &Game.mission_save;
-    StatusCollectList.ptr = reinterpret_cast<STATUSCOLLECT_s *>(&Game.completion);
 
     ResetSeeds();
     ResetTimer(&GlobalTimer, 0.0f);
@@ -605,8 +604,9 @@ void InitGameAfterConfig(void) {
     Hub_UsePlayerList = 1;
     //  BoltSys_Init((BOLTSYS *)BoltSys_LSW);
     GameAudio_Init(&GameAudio_LSW);
-    //  KITPOSX = 0;
-    //  KITPOS2X = 0;
+    extern f32 KITPOSX, KITPOS2X;
+    KITPOSX = 0;
+    KITPOS2X = 0;
     //  CONVERTOLDPICKUPS = 1;
     //  GrabScreenWhenFading = 1;
     //  troopers_gdeb._0_4_ = 0x83;
@@ -791,13 +791,15 @@ void InitGameAfterConfig(void) {
     //  LEGOMENU_RESTORE_NEWGAME = 0x1d;
     //  LEGOCAMMODE_DOORCUT = 4;
     //  LEGOCAMMODE_OBSTACLE = 2;
-    //  LEGOOBJ_ICON_FRAME_NEUTRAL = 0xa7;
-    //  LEGOOBJ_ICON_FRAME_GREEN = 0xa5;
-    //  LEGOOBJ_ICON_FRAME_BLUE = 0xa6;
+    extern i32 LEGOOBJ_ICON_FRAME_NEUTRAL, LEGOOBJ_ICON_FRAME_GREEN, LEGOOBJ_ICON_FRAME_BLUE;
+    LEGOOBJ_ICON_FRAME_NEUTRAL = 0xa7;
+    LEGOOBJ_ICON_FRAME_GREEN = 0xa5;
+    LEGOOBJ_ICON_FRAME_BLUE = 0xa6;
     //  LEGOOBJ_ICON_QUESTION = 0xa1;
     //  LEGOOBJ_ICON_WEIRDO = 0xa3;
-    //  LEGOOBJ_CHARKIT = 0xcf;
-    //  LEGOOBJ_MINIKIT = 0xce;
+    extern i32 LEGOOBJ_CHARKIT, LEGOOBJ_MINIKIT;
+    LEGOOBJ_CHARKIT = 0xcf;
+    LEGOOBJ_MINIKIT = 0xce;
     LEGOSPL_SPLIT = 5;
     LEGOSPL_START = 0;
     //  LEGOGDEB_SPLASH = 0xd;

--- a/src/nu2api/nu3d/nurndr_plain.cpp
+++ b/src/nu2api/nu3d/nurndr_plain.cpp
@@ -407,7 +407,7 @@ extern "C" __attribute__((optimize("O0"))) void NuGScnFixupTIDsPS(NUGSCN *scene)
 }
 extern "C" void NuGScnFromVideoMem(void) {
 }
-extern "C" void NuGScnGetSpecial(void) {
+extern "C" void NuGScnGetSpecial(nuhspecial_s *, NUGSCN *, i32) {
 }
 extern "C" void NuGScnNumSpecials(void) {
 }

--- a/src/nu2api/nusound/nusound_system.cpp
+++ b/src/nu2api/nusound/nusound_system.cpp
@@ -789,9 +789,7 @@ void NuSoundSystem::ReleaseDecoder(NuSoundDecoder *decoder) {
     // libTTapp.so 0x31aafb: invoke vtable slot 0 (the complete-object
     // destructor) without using the deleting-destructor slot; the scratch
     // allocator owns the storage release below.
-    typedef void (*CompleteDestructor)(void *);
-    CompleteDestructor *vtable = *(CompleteDestructor **)decoder;
-    vtable[0](decoder);
+    decoder->~NuSoundDecoder();
     FreeMemory(MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(decoder), 0);
 }
 
@@ -814,9 +812,7 @@ void NuSoundSystem::ReleaseEffect(NuSoundEffect *effect) {
     sAllocdMemory[static_cast<i32>(MemoryDiscipline::SCRATCH)] -= sizeof(NuEListNode<NuSoundEffect>);
 
     effect->Shutdown();
-    typedef void (*CompleteDestructor)(void *);
-    CompleteDestructor *vtable = *reinterpret_cast<CompleteDestructor **>(effect);
-    vtable[4](effect);
+    effect->~NuSoundEffect();
     FreeMemory(MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(effect), 0);
 }
 
@@ -843,9 +839,7 @@ void NuSoundSystem::OnExitSystemMenu() {
 void NuSoundSystem::ReleaseSample(NuSoundSample *sample) {
     this->decoder_list.Remove(reinterpret_cast<NuSoundDecoder *>(sample));
 
-    typedef void (*CompleteDestructor)(void *);
-    CompleteDestructor *vtable = *reinterpret_cast<CompleteDestructor **>(sample);
-    vtable[0](sample);
+    sample->~NuSoundSample();
     FreeMemory(MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(sample), 0);
 }
 
@@ -910,9 +904,7 @@ void NuSoundSystem::Shutdown() {
     NuSoundDecoder *entry = this->decoder_list.Front();
     while (entry != this->decoder_list.End()) {
         NuSoundDecoder *next = *reinterpret_cast<NuSoundDecoder **>(reinterpret_cast<u8 *>(entry) + 0x24);
-        typedef void (*CompleteDestructor)(void *);
-        CompleteDestructor *vtable = *reinterpret_cast<CompleteDestructor **>(entry);
-        vtable[0](entry);
+        entry->~NuSoundDecoder();
         FreeMemory(MemoryDiscipline::SCRATCH, reinterpret_cast<usize>(entry), 0);
         entry = next;
     }
@@ -1128,9 +1120,7 @@ void NuSoundSystem::ReleaseVoice(NuSoundVoice *voice) {
 
     // libTTapp.so 0x31b394: run the voice's complete destructor (vtable slot
     // 0, no free), then hand the block back through FreeMemory(SCRATCH).
-    typedef void (*CompleteDestructor)(void *);
-    CompleteDestructor *vtable = *(CompleteDestructor **)voice;
-    vtable[0](voice);
+    voice->~NuSoundVoice();
     NuSoundSystem::FreeMemory(NuSoundSystem::MemoryDiscipline::SCRATCH, (usize)voice, 0);
 
     NuSoundWeakPtrListNode::sPtrAccessLock.Unlock();

--- a/third_party/emscripten-sdl3-3.4.10.patch
+++ b/third_party/emscripten-sdl3-3.4.10.patch
@@ -15,7 +15,7 @@ index dce32b5..81391a0 100644
 +SUBDIR = f'SDL3-{VERSION}'
  
  variants = {'sdl3-mt': {'PTHREADS': 1}}
-@@ -29,7 +29,7 @@ def get(ports, settings, shared):
+@@ -29,11 +29,26 @@ def get(ports, settings, shared):
    diagnostics.warning('experimental', 'sdl3 port is still experimental')
  
    # get the port
@@ -24,3 +24,22 @@ index dce32b5..81391a0 100644
  
    def create(final):
      root_dir = ports.get_dir('sdl3', SUBDIR)
+ 
++    # The game mixes at 48 kHz. SDL's browser backend otherwise chooses the
++    # OS device rate (192 kHz on some hosts), resamples every mix, and turns
++    # its fixed 2048-frame ScriptProcessor buffer into a 10.7 ms deadline.
++    # Pin only the Web Audio context; native SDL and target code are unchanged.
++    audio_path = os.path.join(root_dir, 'src/audio/emscripten/SDL_emscriptenaudio.c')
++    with open(audio_path) as audio_file:
++      audio_source = audio_file.read()
++    for constructor in ('AudioContext', 'webkitAudioContext'):
++      original = f'new {constructor}()'
++      replacement = f'new {constructor}({{sampleRate: 48000}})'
++      assert original in audio_source or replacement in audio_source
++      audio_source = audio_source.replace(original, replacement)
++    with open(audio_path, 'w') as audio_file:
++      audio_file.write(audio_source)
++
+     # In addition copy our pre-generated SDL_build_config.h file.
+     sdl_build_config_h = os.path.join(os.path.dirname(__file__), 'sdl3/SDL_build_config.h')
+     shutil.copyfile(sdl_build_config_h, os.path.join(root_dir, 'include/SDL3/SDL_build_config.h'))

--- a/third_party/emsdk-cache-pkgconfig.patch
+++ b/third_party/emsdk-cache-pkgconfig.patch
@@ -20,10 +20,13 @@ index 3d2f995..463f067 100644
  """
  
  EMBUILDER_CONFIG_TEMPLATE = """
-@@ -91,6 +91,11 @@ def _emscripten_cache_repository_impl(repository_ctx):
+@@ -91,6 +91,14 @@ def _emscripten_cache_repository_impl(repository_ctx):
          root, script_ext = get_root_and_script_ext(repository_ctx)
          llvm_root = root.get_child("bin")
          cache = repository_ctx.path("cache")
++
++        # Rebuild the port cache when our WASM SDL backend patch changes.
++        repository_ctx.read(root.get_child("emscripten/tools/ports/sdl3.py"))
 +
 +        # Emscripten ports write pkg-config metadata but do not create this
 +        # directory when a secondary cache starts with port-only targets.


### PR DESCRIPTION
Preserve the pending gameplay, results-screen, ABI and host-audio work after the squash merge. Reconstruct the two-pass gizmo flow parser and its constructors from the original binary; flow reset/execution and results initialization remain unfinished. This is a buildable development checkpoint, not a claim of completed gameplay fixes.

Target, native and WASM builds pass, as do all four repository checks. Regenerate the matching report. Overall fuzzy matching rises from 25.23344% to 25.69756%, with 1257 exact functions and no lost exact matches. Partial functions still have regressions, including MenuText3DEx (82.578316% to 69.445786%) and incomplete results/flow functions; these require further matching work. Required checks ran manually; skip the optional whole-worktree formatting hook.