### PR TITLE
Restore carry state machine, thrown-object lifecycle, and plug helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # _saga_
 
-![Progress](https://img.shields.io/badge/matching-29.78%25-red)
+![Progress](https://img.shields.io/badge/matching-29.79%25-red)
 [![Bazel build](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml/badge.svg)](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml)
 [![Discord](https://img.shields.io/discord/1467775700894224555?color=%235865F2&logo=discord&logoColor=%23FFFFFF)](https://discord.gg/2HJuMtzA7q)
 [![status & wasm build](https://img.shields.io/badge/status%20%26%20wasm%20build-click%20here-orange?style=flat)](https://opensaga.dev/)
@@ -73,7 +73,7 @@ See https://ttdecomp.github.io/saga/
 | `legoapi/core` | 26.2% | 6.6% |
 | `legoapi/cutscenes` | 32.4% | 3.9% |
 | `legoapi/gizmo` | 31.4% | 7.3% |
-| `legoapi/gizmos` | 47.5% | 32.7% |
+| `legoapi/gizmos` | 47.6% | 32.5% |
 | `legoapi/items` | 26.9% | 5.8% |
 | `legoapi/menus` | 20.7% | 6.5% |
 | `legoapi/misc` | 22.4% | 4.2% |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # _saga_
 
-![Progress](https://img.shields.io/badge/matching-29.79%25-red)
+![Progress](https://img.shields.io/badge/matching-29.85%25-red)
 [![Bazel build](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml/badge.svg)](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml)
 [![Discord](https://img.shields.io/discord/1467775700894224555?color=%235865F2&logo=discord&logoColor=%23FFFFFF)](https://discord.gg/2HJuMtzA7q)
 [![status & wasm build](https://img.shields.io/badge/status%20%26%20wasm%20build-click%20here-orange?style=flat)](https://opensaga.dev/)
@@ -65,8 +65,8 @@ See https://ttdecomp.github.io/saga/
 | `gameframework` | 99.9% | 5.9% |
 | `gamelib` | 16.5% | 5.3% |
 | `java` | 96.0% | 0.0% |
-| `legoapi` | 27.7% | 9.1% |
-| `legoapi/actions` | 13.2% | 1.4% |
+| `legoapi` | 27.9% | 9.1% |
+| `legoapi/actions` | 15.7% | 1.3% |
 | `legoapi/ai` | 17.6% | 0.0% |
 | `legoapi/audio` | 54.1% | 10.2% |
 | `legoapi/characters` | 26.0% | 7.2% |
@@ -78,7 +78,7 @@ See https://ttdecomp.github.io/saga/
 | `legoapi/menus` | 20.7% | 6.5% |
 | `legoapi/misc` | 22.4% | 4.2% |
 | `legoapi/props` | 37.1% | 2.3% |
-| `legoapi/render` | 28.1% | 7.6% |
+| `legoapi/render` | 28.2% | 7.6% |
 | `legoapi/world` | 25.6% | 6.4% |
 | `legogame` | 62.6% | 8.8% |
 | `nu2api` | 43.4% | 19.5% |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # _saga_
 
-![Progress](https://img.shields.io/badge/matching-29.85%25-red)
+![Progress](https://img.shields.io/badge/matching-29.90%25-red)
 [![Bazel build](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml/badge.svg)](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml)
 [![Discord](https://img.shields.io/discord/1467775700894224555?color=%235865F2&logo=discord&logoColor=%23FFFFFF)](https://discord.gg/2HJuMtzA7q)
 [![status & wasm build](https://img.shields.io/badge/status%20%26%20wasm%20build-click%20here-orange?style=flat)](https://opensaga.dev/)
@@ -66,7 +66,7 @@ See https://ttdecomp.github.io/saga/
 | `gamelib` | 16.5% | 5.3% |
 | `java` | 96.0% | 0.0% |
 | `legoapi` | 27.9% | 9.1% |
-| `legoapi/actions` | 15.7% | 1.3% |
+| `legoapi/actions` | 17.4% | 1.3% |
 | `legoapi/ai` | 17.6% | 0.0% |
 | `legoapi/audio` | 54.1% | 10.2% |
 | `legoapi/characters` | 26.0% | 7.2% |

--- a/bazel/android_per_file_copts.bazelrc
+++ b/bazel/android_per_file_copts.bazelrc
@@ -304,3 +304,6 @@ build:target --per_file_copt=^src/gamelib/util/TouchHacks\.cpp$@-O2
 # rotation and unrolls setup loops; its game_deb initializer also matches -O3.
 # The unoptimized game API wrappers remain in game_debris_api.cpp.
 build:target --per_file_copt=^src/legoapi/render/fx/game_deb\.cpp$@-O3
+
+# Original carry module uses optimized private calls and matrix operations (0x4fab00 onward).
+build:target --per_file_copt=^src/legoapi/actions/movement/supercarry\.cpp$@-O3

--- a/matching.json
+++ b/matching.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "measures": {
-    "fuzzy_match_percent": 29.775238,
+    "fuzzy_match_percent": 29.778288,
     "total_code": "4722419",
     "matched_code": "59808",
     "matched_code_percent": 1.2664696,
@@ -78754,7 +78754,7 @@
           "address": 1982528,
           "offset": 1092560,
           "size": 226,
-          "match_percent": 8.235294
+          "match_percent": 72.07843
         },
         {
           "name": "_ZL14PowerUp_EndMsgP13GAMEMESSAGE_s",

--- a/matching.json
+++ b/matching.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "measures": {
-    "fuzzy_match_percent": 29.778288,
+    "fuzzy_match_percent": 29.786488,
     "total_code": "4722419",
     "matched_code": "59808",
     "matched_code_percent": 1.2664696,
@@ -57920,6 +57920,22 @@
           "match_percent": 75.08772
         },
         {
+          "name": "_Z16Plug_FindNearestP9PLUGSYS_sP7nuvec_sPfi",
+          "demangled_name": "Plug_FindNearest(PLUGSYS_s*, nuvec_s*, float*, int)",
+          "address": 5243120,
+          "offset": 4353152,
+          "size": 342,
+          "match_percent": 85.89888
+        },
+        {
+          "name": "_Z16Plug_MakeDrawMtxP6PLUG_sP7numtx_s",
+          "demangled_name": "Plug_MakeDrawMtx(PLUG_s*, numtx_s*)",
+          "address": 5243472,
+          "offset": 4353504,
+          "size": 115,
+          "match_percent": 99.965515
+        },
+        {
           "name": "_Z19Plugs_RegisterGizmoi",
           "demangled_name": "Plugs_RegisterGizmo(int)",
           "address": 5243600,
@@ -67051,24 +67067,7 @@
       "name": "legoapi/items/objects/plugs.cpp.o",
       "source": "src/legoapi/items/objects/plugs.cpp",
       "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/1/plugs.o",
-      "functions": [
-        {
-          "name": "_Z16Plug_FindNearestP9PLUGSYS_sP7nuvec_sPfi",
-          "demangled_name": "Plug_FindNearest(PLUGSYS_s*, nuvec_s*, float*, int)",
-          "address": 5243120,
-          "offset": 4353152,
-          "size": 342,
-          "match_percent": 3.820225
-        },
-        {
-          "name": "_Z16Plug_MakeDrawMtxP6PLUG_sP7numtx_s",
-          "demangled_name": "Plug_MakeDrawMtx(PLUG_s*, numtx_s*)",
-          "address": 5243472,
-          "offset": 4353504,
-          "size": 115,
-          "match_percent": 7.586207
-        }
-      ]
+      "functions": []
     },
     {
       "name": "legoapi/items/objects/things.cpp.o",

--- a/matching.json
+++ b/matching.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "measures": {
-    "fuzzy_match_percent": 29.852629,
+    "fuzzy_match_percent": 29.898443,
     "total_code": "4722419",
     "matched_code": "59808",
     "matched_code_percent": 1.2664696,
@@ -42002,7 +42002,7 @@
           "address": 5189200,
           "offset": 4299232,
           "size": 258,
-          "match_percent": 6.666666
+          "match_percent": 76.85714
         }
       ]
     },
@@ -42881,30 +42881,6 @@
           "match_percent": 13.214286
         },
         {
-          "name": "_Z19SuperCarry_PossibleP12GameObject_si",
-          "demangled_name": "SuperCarry_Possible(GameObject_s*, int)",
-          "address": 5225040,
-          "offset": 4335072,
-          "size": 130,
-          "match_percent": 5.789473
-        },
-        {
-          "name": "_Z16SuperCarry_StartP12GameObject_sP13GIZMOBLOWUP_si",
-          "demangled_name": "SuperCarry_Start(GameObject_s*, GIZMOBLOWUP_s*, int)",
-          "address": 5225184,
-          "offset": 4335216,
-          "size": 1204,
-          "match_percent": 1.659751
-        },
-        {
-          "name": "_Z19SuperCarry_MoveCodeP11WORLDINFO_sP12GameObject_s",
-          "demangled_name": "SuperCarry_MoveCode(WORLDINFO_s*, GameObject_s*)",
-          "address": 5226400,
-          "offset": 4336432,
-          "size": 4691,
-          "match_percent": 0.412371
-        },
-        {
           "name": "_Z23SuperCarry_SetTargetMomP12GameObject_sf",
           "demangled_name": "SuperCarry_SetTargetMom(GameObject_s*, float)",
           "address": 5231104,
@@ -42919,14 +42895,6 @@
           "offset": 4341456,
           "size": 390,
           "match_percent": 0.0
-        },
-        {
-          "name": "_Z18SuperCarry_ReleaseP12GameObject_s",
-          "demangled_name": "SuperCarry_Release(GameObject_s*)",
-          "address": 5231920,
-          "offset": 4341952,
-          "size": 75,
-          "match_percent": 12.222222
         }
       ]
     },
@@ -43417,6 +43385,38 @@
           "offset": 4332912,
           "size": 2147,
           "match_percent": 85.18673
+        },
+        {
+          "name": "_Z19SuperCarry_PossibleP12GameObject_si",
+          "demangled_name": "SuperCarry_Possible(GameObject_s*, int)",
+          "address": 5225040,
+          "offset": 4335072,
+          "size": 130,
+          "match_percent": 95.47369
+        },
+        {
+          "name": "_Z16SuperCarry_StartP12GameObject_sP13GIZMOBLOWUP_si",
+          "demangled_name": "SuperCarry_Start(GameObject_s*, GIZMOBLOWUP_s*, int)",
+          "address": 5225184,
+          "offset": 4335216,
+          "size": 1204,
+          "match_percent": 79.435684
+        },
+        {
+          "name": "_Z19SuperCarry_MoveCodeP11WORLDINFO_sP12GameObject_s",
+          "demangled_name": "SuperCarry_MoveCode(WORLDINFO_s*, GameObject_s*)",
+          "address": 5226400,
+          "offset": 4336432,
+          "size": 4691,
+          "match_percent": 18.825773
+        },
+        {
+          "name": "_Z18SuperCarry_ReleaseP12GameObject_s",
+          "demangled_name": "SuperCarry_Release(GameObject_s*)",
+          "address": 5231920,
+          "offset": 4341952,
+          "size": 75,
+          "match_percent": 99.94444
         }
       ]
     },

--- a/matching.json
+++ b/matching.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "measures": {
-    "fuzzy_match_percent": 29.786488,
+    "fuzzy_match_percent": 29.852629,
     "total_code": "4722419",
     "matched_code": "59808",
     "matched_code_percent": 1.2664696,
@@ -42881,30 +42881,6 @@
           "match_percent": 13.214286
         },
         {
-          "name": "_Z21SuperCarry_DrawObjectP12GameObject_s",
-          "demangled_name": "SuperCarry_DrawObject(GameObject_s*)",
-          "address": 5221776,
-          "offset": 4331808,
-          "size": 673,
-          "match_percent": 1.517241
-        },
-        {
-          "name": "_Z23SuperCarry_GetObjectPosP12GameObject_sP7nuvec_sS2_",
-          "demangled_name": "SuperCarry_GetObjectPos(GameObject_s*, nuvec_s*, nuvec_s*)",
-          "address": 5222464,
-          "offset": 4332496,
-          "size": 410,
-          "match_percent": 2.340425
-        },
-        {
-          "name": "_Z16SuperCarry_ThrowP12GameObject_si",
-          "demangled_name": "SuperCarry_Throw(GameObject_s*, int)",
-          "address": 5222880,
-          "offset": 4332912,
-          "size": 2147,
-          "match_percent": 0.982801
-        },
-        {
           "name": "_Z19SuperCarry_PossibleP12GameObject_si",
           "demangled_name": "SuperCarry_Possible(GameObject_s*, int)",
           "address": 5225040,
@@ -43386,6 +43362,61 @@
           "offset": 4315744,
           "size": 778,
           "match_percent": 2.052632
+        }
+      ]
+    },
+    {
+      "name": "legoapi/actions/movement/supercarry.cpp.o",
+      "source": "src/legoapi/actions/movement/supercarry.cpp",
+      "object": "bazel-out/x64_windows-fastbuild/bin/src/_objs/saga_target_legoapi/supercarry.o",
+      "functions": [
+        {
+          "name": "_ZL21SuperCarry_PartImpactP6PART_s",
+          "demangled_name": "SuperCarry_PartImpact(PART_s*)",
+          "address": 5221120,
+          "offset": 4331152,
+          "size": 184,
+          "match_percent": 87.585365
+        },
+        {
+          "name": "_ZL27SuperCarry_TurnBlowupBackOnP13GIZMOBLOWUP_sP7nuvec_sti",
+          "demangled_name": "SuperCarry_TurnBlowupBackOn(GIZMOBLOWUP_s*, nuvec_s*, unsigned short, int)",
+          "address": 5221312,
+          "offset": 4331344,
+          "size": 347,
+          "match_percent": 82.55238
+        },
+        {
+          "name": "_ZL19SuperCarry_PartKillP6PART_si",
+          "demangled_name": "SuperCarry_PartKill(PART_s*, int)",
+          "address": 5221664,
+          "offset": 4331696,
+          "size": 112,
+          "match_percent": 73.52
+        },
+        {
+          "name": "_Z21SuperCarry_DrawObjectP12GameObject_s",
+          "demangled_name": "SuperCarry_DrawObject(GameObject_s*)",
+          "address": 5221776,
+          "offset": 4331808,
+          "size": 673,
+          "match_percent": 72.71724
+        },
+        {
+          "name": "_Z23SuperCarry_GetObjectPosP12GameObject_sP7nuvec_sS2_",
+          "demangled_name": "SuperCarry_GetObjectPos(GameObject_s*, nuvec_s*, nuvec_s*)",
+          "address": 5222464,
+          "offset": 4332496,
+          "size": 410,
+          "match_percent": 90.21277
+        },
+        {
+          "name": "_Z16SuperCarry_ThrowP12GameObject_si",
+          "demangled_name": "SuperCarry_Throw(GameObject_s*, int)",
+          "address": 5222880,
+          "offset": 4332912,
+          "size": 2147,
+          "match_percent": 85.18673
         }
       ]
     },
@@ -79161,7 +79192,7 @@
           "address": 4317360,
           "offset": 3427392,
           "size": 2574,
-          "match_percent": 57.368706
+          "match_percent": 57.370502
         },
         {
           "name": "KillAllParts",
@@ -79530,30 +79561,6 @@
           "offset": 4098832,
           "size": 124,
           "match_percent": 99.90625
-        },
-        {
-          "name": "_ZL21SuperCarry_PartImpactP6PART_s",
-          "demangled_name": "SuperCarry_PartImpact(PART_s*)",
-          "address": 5221120,
-          "offset": 4331152,
-          "size": 184,
-          "match_percent": 10.243902
-        },
-        {
-          "name": "_ZL27SuperCarry_TurnBlowupBackOnP13GIZMOBLOWUP_sP7nuvec_sti",
-          "demangled_name": "SuperCarry_TurnBlowupBackOn(GIZMOBLOWUP_s*, nuvec_s*, unsigned short, int)",
-          "address": 5221312,
-          "offset": 4331344,
-          "size": 347,
-          "match_percent": 4.571429
-        },
-        {
-          "name": "_ZL19SuperCarry_PartKillP6PART_si",
-          "demangled_name": "SuperCarry_PartKill(PART_s*, int)",
-          "address": 5221664,
-          "offset": 4331696,
-          "size": 112,
-          "match_percent": 16.8
         }
       ]
     },
@@ -131127,7 +131134,7 @@
     }
   ],
   "summary": {
-    "bazel_units": 505,
+    "bazel_units": 506,
     "functions": 13454,
     "assigned_functions": 12199,
     "ambiguous_functions": 237,

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -20,6 +20,9 @@ struct CUSTOMISER;
 struct GIZAIMESSAGESYS_s;
 NetTransporter theNetwork;
 char *ASCII_DOWN = const_cast<char *>("\xc2\xa3");
+// Original defaults: LEGOASCII_DOWN is null; txt_UNKNOWN points to "?".
+char *LEGOASCII_DOWN = NULL;
+char *txt_UNKNOWN = const_cast<char *>("?");
 u8 PlayerRGB[2][3] = {{0, 127, 255}, {0, 255, 0}};
 
 // ----------------------------------------------------------------------

--- a/src/legoapi/actions/character/speederchase.cpp
+++ b/src/legoapi/actions/character/speederchase.cpp
@@ -207,7 +207,20 @@ void SpeederChaseA_Update(WORLDINFO_s *) {
 void KillParts_SpeederBike(ADDPART_s *, i32, i32, GameObject_s *) {
 }
 
-void ObjOpponentStillThere(GameObject_s *, GameObject_s *, float) {
+// Original 0x4f2e50, 258 bytes. The original returns an integer.
+i32 ObjOpponentStillThere(GameObject_s *object, GameObject_s *opponent, f32 gap) {
+    i32 result = 0;
+    if (object->force_target != NULL) {
+        NUVEC forward, difference;
+        NuVecRotateY(&forward, &v001, object->apiobj.field_0x276);
+        f32 distance = NuVecDistSqr(&opponent->apiobj.position, &object->apiobj.position, &difference);
+        f32 dot = forward.x * difference.x + forward.z * difference.z;
+        if (static_cast<i8>(object->context_flags) < 0 ? dot <= 0.0f : dot >= 0.0f) {
+            f32 radius = object->apiobj.field_0x1dc + opponent->apiobj.field_0x1dc + gap;
+            result = distance < radius * radius;
+        }
+    }
+    return result;
 }
 
 void PodSeekTuskanCutSound() {

--- a/src/legoapi/actions/movement/carrying.cpp
+++ b/src/legoapi/actions/movement/carrying.cpp
@@ -12,9 +12,6 @@ i16 LEGOACT_SUPERCARRY_WALK = -1;
 void SuperCarry_Start(GameObject_s *, GIZMOBLOWUP_s *, i32) {
 }
 
-void SuperCarry_Throw(GameObject_s *, i32) {
-}
-
 void SuperCarry_Release(GameObject_s *) {
 }
 
@@ -46,12 +43,6 @@ i32 SuperCarry_YRotation(GameObject_s *object, u16 input_angle) {
         object->apiobj.movement_facing_angle = object->apiobj.facing_angle;
     }
     return 1;
-}
-
-void SuperCarry_DrawObject(GameObject_s *) {
-}
-
-void SuperCarry_GetObjectPos(GameObject_s *, nuvec_s *, nuvec_s *) {
 }
 
 // Original 0x4fd200, 312 bytes.

--- a/src/legoapi/actions/movement/carrying.cpp
+++ b/src/legoapi/actions/movement/carrying.cpp
@@ -9,18 +9,6 @@
 
 i16 LEGOACT_SUPERCARRY_WALK = -1;
 
-void SuperCarry_Start(GameObject_s *, GIZMOBLOWUP_s *, i32) {
-}
-
-void SuperCarry_Release(GameObject_s *) {
-}
-
-void SuperCarry_MoveCode(WORLDINFO_s *, GameObject_s *) {
-}
-
-void SuperCarry_Possible(GameObject_s *, i32) {
-}
-
 // Original 0x4fd340, 390 bytes.
 i32 SuperCarry_YRotation(GameObject_s *object, u16 input_angle) {
     if (object->field_0x7a3 == 0) {

--- a/src/legoapi/actions/movement/supercarry.cpp
+++ b/src/legoapi/actions/movement/supercarry.cpp
@@ -27,6 +27,42 @@ f32 SUPERCARRY_OBJGRAVITY = -6.0f;
 i32 SuperCarry_AlignObject = 1;
 i32 SuperCarry_KeepObjectLevel = 1;
 
+#include "nu2api/numath/nuang.h"
+#include "nu2api/nu3d/nuspecial.h"
+i16 LEGOACT_SUPERCARRY_PICKUP = -1;
+i16 LEGOACT_SUPERCARRY_IDLE = -1;
+extern "C" f32 AnimDuration(i32, i32, f32, f32, i32);
+void GizmoBlowupBlowup(GIZMOBLOWUP_s *, i32, i32, i32, GameObject_s *, i32);
+u32 (*CanSuperCarryFn)(GameObject_s *) = NULL;
+i32 SuperCarry_Carrying(GameObject_s *);
+
+#include "legoapi/characters/motion/gameanim.h"
+#include "legoapi/characters/motion/animlist.h"
+#include "legoapi/core/input/gamepads.h"
+#include "legoapi/core/input/timer.h"
+#include "nu2api/numath/nufloat.h"
+extern i16 LEGOACT_SUPERCARRY_WALK;
+i16 LEGOACT_SUPERCARRY_THROW = -1;
+i16 LEGOACT_SUPERCARRY_PUTDOWN = -1;
+i16 LEGOACT_SUPERCARRY_BASH = -1;
+i16 LEGOACT_SUPERCARRY_JUMP = -1;
+i16 LEGOACT_SUPERCARRY_LAND = -1;
+i16 LEGOACT_SUPERCARRY_FALLLAND = -1;
+i32 SuperCarry_UseActionButton = 0;
+i32 SuperCarry_PutDownDrop = 1;
+f32 SUPERCARRY_JUMPSPEED = 1.4f;
+extern f32 PUNCHGAP;
+extern i32 objopponent_ignoreaiopponent;
+extern ADDGAMEMSG AddGameMsg_Default;
+extern char *LEGOASCII_DOWN;
+extern char *txt_UNKNOWN;
+extern u8 PlayerRGB[2][3];
+GAMEMESSAGE_s *AddGameMsg(ADDGAMEMSG *);
+i32 ObjOpponentStillThere(GameObject_s *, GameObject_s *, f32);
+i32 ObjHitObj(GameObject_s *, GameObject_s *, i32, u16, i32, i32);
+void NewRumble(nupad_s *, f32, i32);
+void NewBuzzFrames(nupad_s *, i32, i32);
+
 // Original 0x4fab00, 184 bytes.
 static __used__ void SuperCarry_PartImpact(PART_s *part) {
     f32 intensity = NuVecMag(&part->velocity);
@@ -227,5 +263,422 @@ void SuperCarry_Throw(GameObject_s *object, i32 mode) {
         part->force_flags = static_cast<u16>(ObjHitObj_Flags(object));
         part->carried_blowup = static_cast<GIZMOBLOWUP_s *>(object->field_0x788);
         part->rotation_y = object->carried_object_angle + object->apiobj.movement_facing_angle;
+    }
+}
+
+// Original 0x4fba50, 130 bytes. The original returns an integer.
+i32 SuperCarry_Possible(GameObject_s *object, i32 require_grounded) {
+    if (CanSuperCarryFn == NULL || CanSuperCarryFn(object) == 0)
+        return 0;
+    if (static_cast<i8>(object->apiobj.flags_low) >= 0)
+        return 0;
+    if (require_grounded != 0 && (object->apiobj.field_0x27d == 0 || ObjLandReady(object) == 0))
+        return 0;
+    return 1;
+}
+
+// Original 0x4fd530, 75 bytes.
+void SuperCarry_Release(GameObject_s *object) {
+    if (SuperCarry_Carrying(object) != 0) {
+        SuperCarry_Throw(object, 1);
+        object->character_context = -1;
+    }
+}
+
+// Original 0x4fbae0, 1204 bytes.
+void SuperCarry_Start(GameObject_s *object, GIZMOBLOWUP_s *blowup, i32 immediate) {
+    object->character_context = static_cast<i8>(LEGOCONTEXT_SUPERCARRY);
+    object->context_flags &= static_cast<u8>(~0x40);
+    object->action_movement_state = 0;
+    object->field_0x788 = blowup;
+    if (immediate == 0) {
+        if (LEGOACT_SUPERCARRY_PICKUP != -1 &&
+            object->apiobj.character_model->model_data_b[LEGOACT_SUPERCARRY_PICKUP] != NULL) {
+            object->context_animation = LEGOACT_SUPERCARRY_PICKUP;
+            object->field_0x7a3 = 0;
+            f32 duration = AnimDuration(object->id, LEGOACT_SUPERCARRY_PICKUP, 0.0f, 0.0f, 1);
+            if (duration <= 0.0f)
+                duration = 0.5f;
+            object->context_animation_timer = duration;
+            object->apiobj.movement_facing_angle =
+                NuAtan2D(blowup->mid_position.x - object->apiobj.collision_position.x,
+                         blowup->mid_position.z - object->apiobj.collision_position.z);
+        } else {
+            object->context_animation_timer = 0.0f;
+            object->context_animation = LEGOACT_SUPERCARRY_IDLE;
+            object->field_0x7a3 = 2;
+            GizmoBlowupBlowup(blowup, 0, 7, -1, NULL, 1);
+        }
+    } else {
+        object->context_animation_timer = 0.0f;
+        object->context_animation = LEGOACT_SUPERCARRY_IDLE;
+        object->field_0x7a3 = 2;
+    }
+    blowup = static_cast<GIZMOBLOWUP_s *>(object->field_0x788);
+    if (SuperCarry_AlignObject != 0) {
+        NUVEC minimum, maximum;
+        NuSpecialGetBounds(&blowup->type->special, &minimum, &maximum);
+        blowup = static_cast<GIZMOBLOWUP_s *>(object->field_0x788);
+        const u16 angle = NuAtan2D(blowup->transform.m20, blowup->transform.m22);
+        const i32 difference = RotDiff(object->apiobj.movement_facing_angle, angle);
+        const i32 magnitude = difference < 0 ? -difference : difference;
+        if (magnitude < 0x2000) {
+            object->carried_object_angle = 0;
+            object->carried_object_basis[0].x = 0.0f;
+            object->carried_object_basis[0].y = -minimum.y;
+            object->carried_object_basis[0].z = -minimum.z;
+        } else if (magnitude > 0x6000) {
+            object->carried_object_angle = 0x8000;
+            object->carried_object_basis[0].x = 0.0f;
+            object->carried_object_basis[0].y = -minimum.y;
+            object->carried_object_basis[0].z = maximum.z;
+        } else if (difference < 0) {
+            object->carried_object_angle = 0xc000;
+            object->carried_object_basis[0].x = 0.0f;
+            object->carried_object_basis[0].y = -minimum.y;
+            object->carried_object_basis[0].z = maximum.x;
+        } else {
+            object->carried_object_angle = 0x4000;
+            object->carried_object_basis[0].x = 0.0f;
+            object->carried_object_basis[0].y = -minimum.y;
+            object->carried_object_basis[0].z = -minimum.x;
+        }
+        object->carried_object_basis[1].x = 0.0f;
+        object->carried_object_basis[1].y = object->carried_object_basis[0].y + (maximum.y - minimum.y) * 0.5f;
+        object->carried_object_basis[1].z = object->carried_object_basis[0].z;
+        object->apiobj.movement_facing_angle = angle - object->carried_object_angle;
+    } else {
+        NUMTX matrix = blowup->transform;
+        NuMtxRotateY(&matrix, 0x8000 - object->apiobj.movement_facing_angle);
+        object->carried_object_basis[0] = *NUMTX_GET_ROW_VEC(&matrix, 0);
+        object->carried_object_basis[1] = *NUMTX_GET_ROW_VEC(&matrix, 1);
+        object->carried_object_basis[2] = *NUMTX_GET_ROW_VEC(&matrix, 2);
+    }
+    object->field_0x768 = 0.5f;
+}
+
+// Original 0x4fbfa0, 4691 bytes. Original carry state machine.
+void SuperCarry_MoveCode(WORLDINFO_s *world, GameObject_s *object) {
+    if (LEGOCONTEXT_SUPERCARRY == -1)
+        return;
+    if (object->character_context != LEGOCONTEXT_SUPERCARRY) {
+        if (!SuperCarry_Possible(object, 1))
+            return;
+        NUVEC forward;
+        NuVecRotateY(&forward, &v001, object->apiobj.movement_facing_angle);
+        if (world->gizmo_blowups == NULL)
+            return;
+        GIZMOBLOWUP_s *nearest = NULL;
+        f32 best = 100000.0f;
+        GIZMOBLOWUP_s *blowup = world->gizmo_blowups;
+        for (i32 i = 0; i < world->gizmo_blowup_count; ++i, ++blowup) {
+            if ((blowup->status_flags & 0x80c001) != 0x80c000 || (blowup->secondary_flags & 1) == 0)
+                continue;
+            if ((blowup->draw_flags & 0x20) != 0 && ShadowMode == 0)
+                continue;
+            if (blowup->platform_id != -1 && blowup->platform_id == object->field_0x1078)
+                continue;
+            NUVEC delta;
+            f32 distance = NuVecDistSqr(&blowup->mid_position, &object->apiobj.collision_position, &delta);
+            f32 radius = object->apiobj.field_0x1dc + blowup->target_scale + 0.2f;
+            if (distance < best && distance < radius * radius && delta.x * forward.x + delta.z * forward.z > 0.0f) {
+                nearest = blowup;
+                best = distance;
+            }
+        }
+        if (nearest == NULL)
+            return;
+        const i32 player = object->apiobj.field_0x27c;
+        if (static_cast<u8>(player) <= 1) {
+            ADDGAMEMSG message = AddGameMsg_Default;
+            message.text = LEGOASCII_DOWN != NULL ? LEGOASCII_DOWN : txt_UNKNOWN;
+            message.position = &nearest->mid_position;
+            message.flags = 0x87;
+            message.field_0x4f = 4;
+            message.scale = 2.0f;
+            if (Player[0] != NULL && (Player[0]->apiobj.flags_low & 0x80) != 0 && Player[1] != NULL &&
+                (Player[1]->apiobj.flags_low & 0x80) != 0)
+                message.field_0x4f = player == 0 ? 12 : 6;
+            message.red = PlayerRGB[player][0];
+            message.green = PlayerRGB[player][1];
+            message.blue = PlayerRGB[player][2];
+            const u16 angle =
+                static_cast<u16>(static_cast<i32>(NuFmod(GameTimer.time_elapsed_mod_seconds, 0.5f) * 2.0f * 65536.0f));
+            message.alpha = static_cast<u8>(static_cast<i32>(80.0f + 48.0f * NuTrigTable[angle >> 1]));
+            AddGameMsg(&message);
+        }
+        if ((object->pad_gamepad->buttons_held & GAMEPAD_SPECIAL) != 0)
+            SuperCarry_Start(object, nearest, 0);
+        return;
+    }
+    f32 *frame = NULL;
+    if (object->apiobj.character_model->model_data_b[object->context_animation] != NULL) {
+        frame = AnimPlaying(&object->apiobj.anim_packet, object->context_animation, 1, 0);
+        if (frame == NULL)
+            return;
+    }
+    switch (object->field_0x7a3) {
+        case 0: {
+            bool event = false;
+            if ((object->context_flags & 0x40) == 0) {
+                GIZMOBLOWUP_s *blowup = static_cast<GIZMOBLOWUP_s *>(object->field_0x788);
+                object->apiobj.movement_facing_angle =
+                    NuAtan2D(blowup->mid_position.x - object->apiobj.collision_position.x,
+                             blowup->mid_position.z - object->apiobj.collision_position.z);
+                if (frame != NULL) {
+                    f32 marker = AnimListFrame(object->apiobj.character_model, object->context_animation, 0);
+                    event = marker >= 1.0f && *frame >= marker;
+                }
+            }
+            object->context_animation_timer -= FRAMETIME;
+            if (object->context_animation_timer <= 0.0f) {
+                object->field_0x7a3 = 2;
+                object->context_animation = LEGOACT_SUPERCARRY_IDLE;
+                if ((object->context_flags & 0x40) == 0)
+                    event = true;
+            }
+            if (event) {
+                object->context_flags |= 0x40;
+                GizmoBlowupBlowup(static_cast<GIZMOBLOWUP_s *>(object->field_0x788), 0, 7, -1, NULL, 1);
+                NewBuzzFrames(object->pad_gamepad->pad, 1, 0);
+            }
+            return;
+        }
+        case 1: {
+            bool event = false;
+            if ((object->context_flags & 0x40) == 0) {
+                if (frame != NULL) {
+                    f32 marker = AnimListFrame(object->apiobj.character_model, object->context_animation, 0);
+                    event = marker >= 1.0f && *frame >= marker;
+                } else {
+                    event = SuperCarry_PutDownDrop != 0;
+                }
+            }
+            object->context_animation_timer -= FRAMETIME;
+            if (object->context_animation_timer <= 0.0f) {
+                object->character_context = -1;
+                if ((object->context_flags & 0x40) == 0)
+                    event = true;
+            }
+            if (event) {
+                object->context_flags |= 0x40;
+                NewBuzzFrames(object->pad_gamepad->pad, 1, 0);
+                GIZMOBLOWUP_s *blowup = static_cast<GIZMOBLOWUP_s *>(object->field_0x788);
+                if (SuperCarry_PutDownDrop != 0) {
+                    blowup->state_flags |= 0x80;
+                    blowup->visibility_flags |= 0x40;
+                    GizBlowup_Respawn(blowup);
+                    blowup->state_flags |= 1;
+                    f32 distance;
+                    PLUG *plug = Plug_FindNearest(WORLD->plug_sys, &object->carried_object_drop_position, &distance, 1);
+                    if (plug != NULL && distance < 0.5625f) {
+                        Plug_MakeDrawMtx(plug, &blowup->transform);
+                        plug->flags |= 4;
+                        blowup->state_flags &= static_cast<u8>(~0x80);
+                        blowup->field_0x9f |= 0x10;
+                    } else {
+                        SuperCarry_Throw(object, 2);
+                    }
+                } else {
+                    SuperCarry_TurnBlowupBackOn(blowup, &object->carried_object_drop_position,
+                                                object->carried_object_angle + object->apiobj.movement_facing_angle, 0);
+                }
+            }
+            return;
+        }
+        case 2:
+        case 3: {
+            object->context_animation_timer += FRAMETIME;
+            if (object->apiobj.field_0x27d != 0) {
+                bool throw_object = false, put_down = false;
+                if (SuperCarry_UseActionButton != 0) {
+                    if ((object->pad_gamepad->buttons_pressed & GAMEPAD_ACTION) != 0)
+                        throw_object = true;
+                    else
+                        put_down = (object->pad_gamepad->buttons_pressed & GAMEPAD_SPECIAL) != 0;
+                } else if ((object->pad_gamepad->buttons_pressed & GAMEPAD_SPECIAL) != 0) {
+                    throw_object = object->pad_gamepad->input_magnitude > 0.0f;
+                    put_down = !throw_object;
+                }
+                if (throw_object || put_down) {
+                    if ((throw_object || SuperCarry_UseActionButton == 0) && SuperCarry_Bash != 0 &&
+                        LEGOACT_SUPERCARRY_BASH != -1 &&
+                        object->apiobj.character_model->model_data_b[LEGOACT_SUPERCARRY_BASH] != NULL) {
+                        objopponent_ignoreaiopponent = 1;
+                        object->force_target = ObjOpponent(object, 1.0f, PUNCHGAP, 1, 0, 1);
+                        if (object->force_target == NULL) {
+                            objopponent_ignoreaiopponent = 1;
+                            object->force_target = ObjOpponent(object, 1.0f, PUNCHGAP, 1, 0, 2);
+                        }
+                        if (object->force_target != NULL) {
+                            object->field_0x7a3 = 5;
+                            object->context_animation = LEGOACT_SUPERCARRY_BASH;
+                            object->context_flags &= static_cast<u8>(~0x40);
+                            f32 duration = AnimDuration(object->id, object->context_animation, 0.0f, 0.0f, 1);
+                            object->context_animation_timer = duration <= 0.0f ? 0.5f : duration;
+                            return;
+                        }
+                    }
+                    if (throw_object) {
+                        if (LEGOACT_SUPERCARRY_THROW != -1 &&
+                            object->apiobj.character_model->model_data_b[LEGOACT_SUPERCARRY_THROW] != NULL) {
+                            object->field_0x7a3 = 4;
+                            object->context_animation = LEGOACT_SUPERCARRY_THROW;
+                            object->context_flags &= static_cast<u8>(~0x40);
+                            f32 duration = AnimDuration(object->id, object->context_animation, 0.0f, 0.0f, 1);
+                            object->context_animation_timer = duration <= 0.0f ? 0.5f : duration;
+                        } else {
+                            object->character_context = -1;
+                            object->field_0xe22 |= 0x80;
+                            NewRumble(object->pad_gamepad->pad, 0.6f, 0);
+                        }
+                        return;
+                    }
+                    GIZMOBLOWUP_s *blowup = static_cast<GIZMOBLOWUP_s *>(object->field_0x788);
+                    if (put_down && (blowup->secondary_flags & 4) != 0 && LEGOACT_SUPERCARRY_PUTDOWN != -1 &&
+                        object->apiobj.character_model->model_data_b[LEGOACT_SUPERCARRY_PUTDOWN] != NULL &&
+                        object->apiobj.field_0x218 != 2000000.0f &&
+                        object->apiobj.lower_position.y - object->apiobj.field_0x218 < 0.1f) {
+                        object->context_animation = LEGOACT_SUPERCARRY_PUTDOWN;
+                        object->field_0x7a3 = 1;
+                        object->context_flags &= static_cast<u8>(~0x40);
+                        f32 duration = AnimDuration(object->id, object->context_animation, 0.0f, 0.0f, 1);
+                        object->context_animation_timer = duration <= 0.0f ? 0.5f : duration;
+                        object->carried_object_drop_position.x = object->apiobj.lower_position.x;
+                        object->carried_object_drop_position.y = object->apiobj.field_0x218;
+                        object->carried_object_drop_position.z = object->apiobj.lower_position.z;
+                        NUVEC offset;
+                        NuVecRotateY(&offset, &object->carried_object_basis[0], object->apiobj.field_0x276);
+                        object->carried_object_drop_position.x += offset.x;
+                        object->carried_object_drop_position.z += offset.z;
+                        return;
+                    }
+                }
+            }
+            if (SuperCarry_Jump != 0 && LEGOACT_SUPERCARRY_JUMP != -1 &&
+                (object->pad_gamepad->buttons_pressed & GAMEPAD_JUMP) != 0 && object->apiobj.field_0x27d != 0) {
+                object->field_0x7a3 = 6;
+                object->context_animation = LEGOACT_SUPERCARRY_JUMP;
+                object->context_animation_timer = 0.0f;
+                object->apiobj.velocity.y = SUPERCARRY_JUMPSPEED;
+                f32 duration;
+                if (object->apiobj.character_model->model_data_b[LEGOACT_SUPERCARRY_JUMP] != NULL)
+                    duration = AnimDuration(object->id, LEGOACT_SUPERCARRY_JUMP, 0.0f, 0.0f, 0);
+                else
+                    duration = (-SUPERCARRY_JUMPSPEED / object->apiobj.character_data->game_character->gravity) * 2.0f;
+                object->apiobj.field_0x27d = 0;
+                object->field_0x105c = 0;
+                object->context_variant_flags &= 0x7f;
+                object->airborne_action_duration = duration + 0.1f;
+                object->jump_start_height = object->apiobj.collision_min.y;
+                ResetAnimPacket(&object->apiobj.anim_packet, -1);
+            }
+            goto idle_or_walk;
+        }
+        case 4: {
+            if (object->context_animation_timer <= 0.0f && (object->context_flags & 0x40) != 0) {
+                object->character_context = -1;
+                return;
+            }
+            bool event = false;
+            if (frame != NULL && (object->context_flags & 0x40) == 0) {
+                f32 marker = AnimListFrame(object->apiobj.character_model, object->context_animation, 0);
+                event = marker >= 1.0f && *frame >= marker;
+            }
+            object->context_animation_timer -= FRAMETIME;
+            if (object->context_animation_timer <= 0.0f) {
+                if ((object->context_flags & 0x40) == 0)
+                    event = true;
+                else
+                    object->character_context = -1;
+            }
+            if (!event)
+                return;
+            object->context_flags |= 0x40;
+            object->field_0xe22 |= 0x80;
+            NewRumble(object->pad_gamepad->pad, 0.6f, 0);
+            return;
+        }
+        case 5: {
+            if (object->context_animation_timer <= 0.0f && (object->context_flags & 0x40) != 0) {
+                object->character_context = -1;
+                return;
+            }
+            bool event = false;
+            if (frame != NULL && (object->context_flags & 0x40) == 0) {
+                f32 marker = AnimListFrame(object->apiobj.character_model, object->context_animation, 0);
+                event = marker >= 1.0f && *frame >= marker;
+            }
+            object->context_animation_timer -= FRAMETIME;
+            if (object->context_animation_timer <= 0.0f) {
+                if ((object->context_flags & 0x40) == 0)
+                    event = true;
+                else
+                    object->character_context = -1;
+            }
+            if (!event)
+                return;
+            object->context_flags |= 0x40;
+            if (ObjOpponentStillThere(object, object->force_target, PUNCHGAP)) {
+                ObjHitObj(object, object->force_target, 1, 0x2000, 0, 1);
+            } else if (object->character_context != -1 && object->context_animation_timer > 0.0f) {
+                object->context_flags &= static_cast<u8>(~0x40);
+            }
+            if ((object->context_flags & 0x40) != 0) {
+                NUVEC position;
+                SuperCarry_GetObjectPos(object, &position, NULL);
+                GIZMOBLOWUP_s *blowup = static_cast<GIZMOBLOWUP_s *>(object->field_0x788);
+                GizmoBlowUp_AddEffects(&position, blowup, 0, blowup->field_0xb8 > 0.0f ? 11 : 3, NULL);
+                NewRumble(object->pad_gamepad->pad, 0.6f, 0);
+                NewBuzzFrames(object->pad_gamepad->pad, 2, 0);
+            }
+            return;
+        }
+        case 6: {
+            object->context_animation_timer += FRAMETIME;
+            if (object->context_animation_timer >= object->airborne_action_duration)
+                object->context_variant_flags = static_cast<i8>(object->context_variant_flags | 0x80);
+            if (object->context_animation_timer < 0.1f || object->apiobj.field_0x27d == 0)
+                return;
+            if (object->context_variant_flags < 0) {
+                object->field_0x7a3 = 7;
+                if (LEGOACT_SUPERCARRY_FALLLAND != -1 &&
+                    object->apiobj.character_model->model_data_b[LEGOACT_SUPERCARRY_FALLLAND] != NULL) {
+                    object->context_animation = LEGOACT_SUPERCARRY_FALLLAND;
+                    goto landing;
+                }
+            } else if (object->pad_gamepad->input_magnitude != 0.0f) {
+                goto idle_or_walk;
+            }
+            object->field_0x7a3 = 7;
+            object->context_animation = LEGOACT_SUPERCARRY_LAND;
+            if (object->context_animation == -1)
+                goto idle_or_walk;
+        landing:
+            f32 duration = AnimDuration(object->id, object->context_animation, 0.0f, 0.0f, 1);
+            object->context_animation_timer = duration <= 0.0f ? 0.5f : duration;
+            ResetAnimPacket(&object->apiobj.anim_packet, -1);
+            object->apiobj.velocity.x = object->apiobj.velocity.z = 0.0f;
+            NewBuzzFrames(object->pad_gamepad->pad, object->context_animation == LEGOACT_SUPERCARRY_FALLLAND ? 2 : 1,
+                          0);
+            return;
+        }
+        case 7:
+            object->context_animation_timer -= FRAMETIME;
+            if (object->context_animation_timer <= 0.0f)
+                goto idle_or_walk;
+            if (object->context_variant_flags >= 0 && object->pad_gamepad->input_magnitude > 0.0f)
+                goto idle_or_walk;
+            return;
+        default:
+            return;
+    }
+idle_or_walk:
+    if (object->pad_gamepad->input_magnitude > 0.0f) {
+        object->field_0x7a3 = 3;
+        object->context_animation = LEGOACT_SUPERCARRY_WALK;
+    } else {
+        object->field_0x7a3 = 2;
+        object->context_animation = LEGOACT_SUPERCARRY_IDLE;
     }
 }

--- a/src/legoapi/actions/movement/supercarry.cpp
+++ b/src/legoapi/actions/movement/supercarry.cpp
@@ -1,0 +1,231 @@
+#include "globals.h"
+#include "legoapi/characters/core/character.h"
+#include "legoapi/characters/motion.h"
+#include "legoapi/world/world.h"
+#include "legoapi/gizmos/door/plugs.h"
+#include "nu2api/numath/numtx.h"
+#include "nu2api/numath/nuvec.h"
+#include "nu2api/numath/nutrig.h"
+#include "legoapi/core/input/qrand.h"
+void GameCam_Judder(GAMECAMERA_s *, f32, i32, NUVEC *);
+void GizBlowup_Respawn(GIZMOBLOWUP_s *);
+void GizmoBlowUp_AddEffects(NUVEC *, GIZMOBLOWUP_s *, i32, i32, GameObject_s *);
+void DrawObjectOnCharacter(WORLDINFO_s *, GameObject_s *, i32, nuhspecial_s *, i32, i32, NUMTX *, i32, u32, NUMTX *,
+                           NUVEC *, f32, f32);
+void QuatInterpolateRotationMatrix(NUMTX *, NUMTX *, NUMTX *, f32);
+extern i32 dco_locatorposonly;
+extern ADDPART_s Default_ADDPART;
+extern "C" PART_s *AddPart(ADDPART_s *);
+u16 ObjHitObj_Flags(GameObject_s *);
+f32 SUPERCARRY_THROWSPEED_XZ = 3.0f;
+f32 SUPERCARRY_RELEASESPEED_XZ = 2.0f;
+f32 SUPERCARRY_DROPSPEED_XZ = 0.2f;
+f32 SUPERCARRY_DROPSPEED_Y = 1.0f;
+f32 SUPERCARRY_THROWSPEED_Y = 3.0f;
+f32 SUPERCARRY_OBJGRAVITY = -6.0f;
+// Original defaults: 0x668d30 and 0x668d40, each a four-byte integer.
+i32 SuperCarry_AlignObject = 1;
+i32 SuperCarry_KeepObjectLevel = 1;
+
+// Original 0x4fab00, 184 bytes.
+static __used__ void SuperCarry_PartImpact(PART_s *part) {
+    f32 intensity = NuVecMag(&part->velocity);
+    if (intensity >= 4.0f)
+        intensity = 1.0f;
+    else
+        intensity *= 0.25f;
+    if (intensity > 0.0f) {
+        const i32 axis = qrand() > 0x7fff ? 2 : 0;
+        GameCam_Judder(NULL, intensity * 0.3f, axis, &part->position);
+    }
+}
+
+// Original 0x4fabc0, 347 bytes. The original returns an integer.
+static __used__ i32 SuperCarry_TurnBlowupBackOn(GIZMOBLOWUP_s *blowup, NUVEC *position, u16 angle, i32 keep_matrix) {
+    blowup->state_flags |= 0x80;
+    blowup->visibility_flags |= 0x40;
+    GizBlowup_Respawn(blowup);
+    blowup->state_flags |= 1;
+    f32 distance;
+    PLUG *plug = Plug_FindNearest(WORLD->plug_sys, position, &distance, 1);
+    if (plug != NULL && distance < 0.5625f) {
+        Plug_MakeDrawMtx(plug, &blowup->transform);
+        plug->flags |= PLUG_FLAG_PLUGGED;
+        blowup->state_flags &= static_cast<u8>(~0x80);
+        blowup->field_0x9f |= 0x10;
+        return 1;
+    }
+    if (keep_matrix == 0) {
+        if (SuperCarry_AlignObject != 0)
+            NuMtxSetRotationY(&blowup->transform, angle);
+        else
+            blowup->transform = numtx_identity;
+        NuMtxTranslate(&blowup->transform, position);
+    }
+    return 0;
+}
+
+// Original 0x4fad20, 112 bytes.
+static __used__ void SuperCarry_PartKill(PART_s *part, i32) {
+    GIZMOBLOWUP_s *blowup = part->carried_blowup;
+    if ((blowup->secondary_flags & 4) != 0)
+        SuperCarry_TurnBlowupBackOn(blowup, &part->position, part->rotation_y, 0);
+    else
+        GizmoBlowUp_AddEffects(&part->position, blowup, 0, 15, NULL);
+}
+
+// Original 0x4fad90, 673 bytes.
+void SuperCarry_DrawObject(GameObject_s *object) {
+    if (static_cast<i8>(object->field_0xe22) >= 0) {
+        if (LEGOCONTEXT_SUPERCARRY == -1 || object->character_context != LEGOCONTEXT_SUPERCARRY)
+            return;
+        switch (object->field_0x7a3) {
+            case 0:
+                if ((object->context_flags & 0x40) == 0)
+                    return;
+                break;
+            case 1:
+            case 4:
+            case 5:
+                if ((object->context_flags & 0x40) != 0)
+                    return;
+                break;
+            case 2:
+            case 3:
+            case 6:
+            case 7:
+                break;
+            default:
+                return;
+        }
+    }
+    NUMTX matrix;
+    NUVEC offset;
+    NUVEC *translation = NULL;
+    if (SuperCarry_AlignObject != 0) {
+        NuVecRotateY(&offset, &object->carried_object_basis[0], object->apiobj.field_0x276);
+        NuMtxSetRotationY(&matrix, object->carried_object_angle);
+        translation = &offset;
+    } else {
+        matrix = numtx_identity;
+        *NUMTX_GET_ROW_VEC(&matrix, 0) = object->carried_object_basis[0];
+        *NUMTX_GET_ROW_VEC(&matrix, 1) = object->carried_object_basis[1];
+        *NUMTX_GET_ROW_VEC(&matrix, 2) = object->carried_object_basis[2];
+    }
+    if (SuperCarry_KeepObjectLevel != 0) {
+        NuMtxRotateY(&matrix, object->apiobj.field_0x276);
+        dco_locatorposonly = 1;
+    }
+    PLAYERCHARACTERCONFIG_s *config = object->apiobj.character_data->player_config;
+    GIZMOBLOWUP_s *blowup = static_cast<GIZMOBLOWUP_s *>(object->field_0x788);
+    DrawObjectOnCharacter(WORLD, object, -1, &blowup->type->special, config->hand_joints[0], config->hand_joints[1],
+                          object->joint_matrices, object->field_0x1088, object->field_0x1054, &matrix, translation,
+                          1.0f, 1.0f);
+}
+
+// Original 0x4fb040, 410 bytes. Aligned carry uses the vector storage as offsets.
+void SuperCarry_GetObjectPos(GameObject_s *object, NUVEC *position, NUVEC *secondary_position) {
+    *position = object->apiobj.collision_position;
+    PLAYERCHARACTERCONFIG_s *config = object->apiobj.character_data->player_config;
+    const i32 first = config->hand_joints[0];
+    if (first != -1 && object->apiobj.character_model->points_of_interest[first] != NULL) {
+        const i32 second = config->hand_joints[1];
+        if (second != -1 && object->apiobj.character_model->points_of_interest[second] != NULL) {
+            *position = *NUMTX_GET_ROW_VEC(&object->joint_matrices[first], 3);
+            NUVEC *other = NUMTX_GET_ROW_VEC(&object->joint_matrices[second], 3);
+            position->x += (other->x - position->x) * 0.5f;
+            position->y += (other->y - position->y) * 0.5f;
+            position->z += (other->z - position->z) * 0.5f;
+        }
+    }
+    if (SuperCarry_AlignObject != 0) {
+        NUVEC offset;
+        if (secondary_position != NULL) {
+            NuVecRotateY(&offset, &object->carried_object_basis[1], object->apiobj.field_0x276);
+            NuVecAdd(secondary_position, position, &offset);
+        }
+        NuVecRotateY(&offset, &object->carried_object_basis[0], object->apiobj.field_0x276);
+        NuVecAdd(position, position, &offset);
+    }
+}
+
+// Original 0x4fb1e0, 2147 bytes.
+void SuperCarry_Throw(GameObject_s *object, i32 mode) {
+    PLAYERCHARACTERCONFIG_s *config = object->apiobj.character_data->player_config;
+    const i32 first = config->hand_joints[0];
+    if (first == -1 || object->apiobj.character_model->points_of_interest[first] == NULL)
+        return;
+    NUMTX matrix;
+    if (SuperCarry_KeepObjectLevel != 0) {
+        if (SuperCarry_AlignObject != 0) {
+            NuMtxSetRotationY(&matrix, object->carried_object_angle);
+        } else {
+            matrix = numtx_identity;
+            *NUMTX_GET_ROW_VEC(&matrix, 0) = object->carried_object_basis[0];
+            *NUMTX_GET_ROW_VEC(&matrix, 1) = object->carried_object_basis[1];
+            *NUMTX_GET_ROW_VEC(&matrix, 2) = object->carried_object_basis[2];
+        }
+        NuMtxRotateY(&matrix, object->apiobj.field_0x276);
+        NuMtxTranslate(&matrix, NUMTX_GET_ROW_VEC(&object->joint_matrices[first], 3));
+    } else {
+        matrix = object->joint_matrices[first];
+    }
+    const i32 second = object->apiobj.character_data->player_config->hand_joints[1];
+    if (second != -1 && object->apiobj.character_model->points_of_interest[second] != NULL) {
+        NUVEC position = *NUMTX_GET_ROW_VEC(&matrix, 3);
+        if (SuperCarry_KeepObjectLevel == 0) {
+            NUMTX left = matrix;
+            NUMTX right = object->joint_matrices[second];
+            left.m30 = left.m31 = left.m32 = 0.0f;
+            right.m30 = right.m31 = right.m32 = 0.0f;
+            QuatInterpolateRotationMatrix(&matrix, &left, &right, 0.5f);
+        }
+        matrix.m30 = (position.x + object->joint_matrices[second].m30) * 0.5f;
+        matrix.m31 = (position.y + object->joint_matrices[second].m31) * 0.5f;
+        matrix.m32 = (position.z + object->joint_matrices[second].m32) * 0.5f;
+    }
+    if (SuperCarry_KeepObjectLevel == 0) {
+        NUVEC position = *NUMTX_GET_ROW_VEC(&matrix, 3);
+        NUMTX basis = numtx_identity;
+        *NUMTX_GET_ROW_VEC(&basis, 0) = object->carried_object_basis[0];
+        *NUMTX_GET_ROW_VEC(&basis, 1) = object->carried_object_basis[1];
+        *NUMTX_GET_ROW_VEC(&basis, 2) = object->carried_object_basis[2];
+        NuMtxMulR(&matrix, &basis, &matrix);
+        *NUMTX_GET_ROW_VEC(&matrix, 3) = position;
+    } else if (SuperCarry_AlignObject != 0) {
+        NUVEC offset;
+        NuVecRotateY(&offset, &object->carried_object_basis[0], object->apiobj.field_0x276);
+        NuMtxTranslate(&matrix, &offset);
+    }
+    ADDPART_s params = Default_ADDPART;
+    params.matrix = &matrix;
+    NUVEC velocity;
+    f32 speed;
+    if (mode == 0)
+        speed = SUPERCARRY_THROWSPEED_XZ;
+    else if (mode == 1)
+        speed = SUPERCARRY_RELEASESPEED_XZ;
+    else
+        speed = SUPERCARRY_DROPSPEED_XZ;
+    velocity.x = NU_SIN_LUT(object->apiobj.facing_angle) * speed;
+    velocity.z = NU_COS_LUT(object->apiobj.facing_angle) * speed;
+    velocity.y = mode == 2 ? SUPERCARRY_DROPSPEED_Y : SUPERCARRY_THROWSPEED_Y;
+    params.velocity = &velocity;
+    GIZMOBLOWUP_s *blowup = static_cast<GIZMOBLOWUP_s *>(object->field_0x788);
+    params.field_14 = params.field_18 = 0.5f * blowup->target_scale;
+    params.special = &blowup->type->special;
+    params.flags = (blowup->secondary_flags & 4) != 0 ? 0x8011 : 0x8111;
+    params.owner = object;
+    params.time_step = FRAMETIME;
+    params.gravity = SUPERCARRY_OBJGRAVITY;
+    params.field_3c = SuperCarry_PartImpact;
+    params.field_a4 = 3.0f;
+    params.field_44 = SuperCarry_PartKill;
+    params.lighting = reinterpret_cast<PARTLIGHTSOURCE_s *>(&object->light_data);
+    PART_s *part = AddPart(&params);
+    if (part != NULL) {
+        part->force_flags = static_cast<u16>(ObjHitObj_Flags(object));
+        part->carried_blowup = static_cast<GIZMOBLOWUP_s *>(object->field_0x788);
+        part->rotation_y = object->carried_object_angle + object->apiobj.movement_facing_angle;
+    }
+}

--- a/src/legoapi/actions/movement/supercarry.cpp
+++ b/src/legoapi/actions/movement/supercarry.cpp
@@ -32,7 +32,7 @@ i32 SuperCarry_KeepObjectLevel = 1;
 i16 LEGOACT_SUPERCARRY_PICKUP = -1;
 i16 LEGOACT_SUPERCARRY_IDLE = -1;
 extern "C" f32 AnimDuration(i32, i32, f32, f32, i32);
-void GizmoBlowupBlowup(GIZMOBLOWUP_s *, i32, i32, i32, GameObject_s *, i32);
+i32 GizmoBlowupBlowup(GIZMOBLOWUP_s *, i32, i32, i32, GameObject_s *, i32);
 u32 (*CanSuperCarryFn)(GameObject_s *) = NULL;
 i32 SuperCarry_Carrying(GameObject_s *);
 

--- a/src/legoapi/gizmos/door/plugs.cpp
+++ b/src/legoapi/gizmos/door/plugs.cpp
@@ -5,6 +5,7 @@
 #include "legoapi/world/level.h"
 #include "legoapi/world/world.h"
 #include "nu2api/nucore/nustring.h"
+#include "nu2api/numath/numtx.h"
 
 struct PLUGPROGRESS {
     i32 visible_mask;
@@ -13,6 +14,36 @@ struct PLUGPROGRESS {
 };
 
 i32 plug_gizmotype_id = -1;
+
+// Original 0x5000f0, 342 bytes; part of the optimized plug module.
+PLUG *Plug_FindNearest(PLUGSYS *system, NUVEC *position, f32 *distance_squared, i32 only_unplugged) {
+    PLUG *nearest = NULL;
+    f32 nearest_distance = 1000000000.0f;
+    if (system != NULL) {
+        PLUG *plug = system->plugs;
+        for (i32 index = 0; index < system->count; ++index, ++plug) {
+            if (only_unplugged == 0 || (plug->flags & PLUG_FLAG_PLUGGED) == 0) {
+                const f32 distance = NuVecDistSqr(position, &plug->position, NULL);
+                if (distance < nearest_distance) {
+                    nearest_distance = distance;
+                    nearest = plug;
+                }
+            }
+        }
+    }
+    if (distance_squared != NULL) {
+        *distance_squared = nearest_distance;
+    }
+    return nearest;
+}
+
+// Original 0x500250, 115 bytes.
+void Plug_MakeDrawMtx(PLUG *plug, NUMTX *matrix) {
+    NuMtxSetRotationY(matrix, plug->y_rotation);
+    NuMtxRotateZ(matrix, plug->z_rotation);
+    NuMtxRotateX(matrix, plug->x_rotation);
+    NuMtxTranslate(matrix, &plug->position);
+}
 
 static i32 Plugs_GetMaxGizmos(void *world_ptr) {
     WORLDINFO *world = static_cast<WORLDINFO *>(world_ptr);
@@ -185,7 +216,7 @@ static i32 Plugs_Load(void *world_ptr, void *) {
         plug.x_rotation = EdFileReadUnsignedShort();
         plug.y_rotation = EdFileReadUnsignedShort();
         plug.enabled = EdFileReadUnsignedChar();
-        plug.target_id = version <= 1 ? 0 : EdFileReadUnsignedShort();
+        plug.z_rotation = version <= 1 ? 0 : EdFileReadUnsignedShort();
     }
     return 1;
 }

--- a/src/legoapi/gizmos/door/plugs.h
+++ b/src/legoapi/gizmos/door/plugs.h
@@ -3,6 +3,7 @@
 #include "decomp_assert.h"
 #include "legoapi/gizmo/base/gizmo.h"
 #include "nu2api/numath/nuvec.h"
+#include "nu2api/numath/numtx.h"
 
 extern i32 plug_gizmotype_id;
 
@@ -19,7 +20,7 @@ typedef struct PLUG_s {
     NUVEC position;
     u16 x_rotation;
     u16 y_rotation;
-    u16 target_id;
+    u16 z_rotation;
     u8 enabled;
     union {
         u8 flags;
@@ -40,9 +41,12 @@ typedef struct PLUGSYS_s {
 DECOMP_ASSERT(sizeof(PLUG) == 0x34, "PLUG size");
 DECOMP_ASSERT(offsetof(PLUG, position) == 0x10, "PLUG position offset");
 DECOMP_ASSERT(offsetof(PLUG, flags) == 0x23, "PLUG flags offset");
+DECOMP_ASSERT(offsetof(PLUG, z_rotation) == 0x20, "PLUG Z rotation offset");
 DECOMP_ASSERT(sizeof(PLUGSYS) == 8, "PLUGSYS size");
 
 ADDGIZMOTYPE *Plugs_RegisterGizmo(i32 type_id);
+PLUG *Plug_FindNearest(PLUGSYS *system, NUVEC *position, f32 *distance_squared, i32 only_unplugged);
+void Plug_MakeDrawMtx(PLUG *plug, NUMTX *matrix);
 
 extern "C" {
 #endif

--- a/src/legoapi/items/base/apiobject.h
+++ b/src/legoapi/items/base/apiobject.h
@@ -655,9 +655,12 @@ typedef struct GameObject_s {
                 u8 pad_744[0x768 - 0x744];
                 NUVEC launch_origin; // 0x744, saved on entering launch context
                 struct {
-                    NUVEC zipup_start_position;   // 0x744, selected endpoint
-                    NUVEC zipup_swing_position;   // 0x750, end of the swing animation
-                    NUVEC zipup_landing_position; // 0x75c, opposite endpoint with ground height
+                    NUVEC zipup_start_position; // 0x744, selected endpoint
+                    NUVEC zipup_swing_position; // 0x750, end of the swing animation
+                    union {
+                        NUVEC zipup_landing_position;       // 0x75c, opposite endpoint with ground height
+                        NUVEC carried_object_drop_position; // 0x75c, carry put-down position
+                    };
                 };
             };
             f32 field_0x768; // 0x0768
@@ -1419,3 +1422,5 @@ DECOMP_ASSERT(offsetof(GameObject_s, saved_position) == 0x10c8, "GameObject save
 
 DECOMP_ASSERT(offsetof(GameObject_s, run_speed_override) == 0xee0, "GameObject run speed override offset");
 DECOMP_ASSERT(offsetof(GameObject_s, walk_speed_override) == 0xee4, "GameObject walk speed override offset");
+
+DECOMP_ASSERT(offsetof(GameObject_s, carried_object_drop_position) == 0x75c, "GameObject carry drop position offset");

--- a/src/legoapi/items/base/apiobject.h
+++ b/src/legoapi/items/base/apiobject.h
@@ -633,6 +633,10 @@ typedef struct GameObject_s {
     u8 pad_6b1[0x6b4 - 0x6b1]; // 0x06b1 .. 0x06b4
     union {
         u8 player_packet[0x780 - 0x6b4]; // 0x06b4, PLAYERPACKET_s begins here
+        struct {
+            u8 carry_prefix[0x738 - 0x6b4];
+            NUVEC carried_object_basis[3]; // 0x738: rotation rows, or offsets for aligned carrying
+        };
         CHARACTER_SHADOW_s character_shadows[5];
         struct {
             u8 suspension_prefix[0x718 - 0x6b4];
@@ -678,9 +682,12 @@ typedef struct GameObject_s {
     GIZMOBLOWUP_s *blowup_target; // 0x0784
     void *field_0x788;            // 0x0788
     u8 pad_78c[0x790 - 0x78c];
-    void *big_jump_data;          // 0x0790
-    u16 magnet_surface_angle;     // 0x794
-    u16 takeover_start_angle;     // 0x796
+    void *big_jump_data;      // 0x0790
+    u16 magnet_surface_angle; // 0x794
+    union {
+        u16 takeover_start_angle;
+        u16 carried_object_angle;
+    }; // 0x796
     u16 grapple_swing_phase;      // 0x798
     i16 context_animation;        // 0x079a, action-owned animation index
     i16 queued_context_animation; // 0x079c, base action used by combo branches
@@ -1271,6 +1278,8 @@ DECOMP_ASSERT(offsetof(GameObject_s, build_context) == 0x7a5, "GameObject Build-
 DECOMP_ASSERT(offsetof(GameObject_s, character_context) == 0x7a5, "GameObject character context offset");
 DECOMP_ASSERT(offsetof(GameObject_s, action_movement_state) == 0x7a8, "GameObject action movement state offset");
 DECOMP_ASSERT(offsetof(GameObject_s, external_force) == 0x738, "GameObject external force offset");
+DECOMP_ASSERT(offsetof(GameObject_s, carried_object_basis) == 0x738, "GameObject carried basis offset");
+DECOMP_ASSERT(offsetof(GameObject_s, carried_object_angle) == 0x796, "GameObject carried angle offset");
 DECOMP_ASSERT(offsetof(GameObject_s, hit_variant) == 0x7ab, "GameObject hit variant offset");
 DECOMP_ASSERT(offsetof(GameObject_s, context_flags) == 0x7ac, "GameObject context flags offset");
 DECOMP_ASSERT(offsetof(GameObject_s, context_variant_flags) == 0x7ad, "GameObject context variant flags offset");

--- a/src/legoapi/items/objects/plugs.cpp
+++ b/src/legoapi/items/objects/plugs.cpp
@@ -6,9 +6,3 @@ struct AIROW_s;
 struct nuqthdr_s;
 struct nunativegscene_s;
 struct SHOPINPUT;
-
-void Plug_FindNearest(PLUGSYS_s *, nuvec_s *, float *, i32) {
-}
-
-void Plug_MakeDrawMtx(PLUG_s *, numtx_s *) {
-}

--- a/src/legoapi/legoapi_types.h
+++ b/src/legoapi/legoapi_types.h
@@ -4445,7 +4445,10 @@ struct PART_s {
     i8 field_20b;
     u32 field_20c;
     f32 field_210, field_214;
-    u32 force_flags;
+    union {
+        u32 force_flags;
+        GIZMOBLOWUP_s *carried_blowup; // 0x218, thrown-object callback data
+    };
     u32 field_21c, field_220;
     void ClearMechObjectInterface();
     void GetMechObjectInterface();
@@ -4462,6 +4465,7 @@ DECOMP_ASSERT(offsetof(PART_s, gravity) == 0xe8, "PART gravity offset");
 DECOMP_ASSERT(offsetof(PART_s, move_callback) == 0x1b0, "PART move callback offset");
 DECOMP_ASSERT(offsetof(PART_s, force_player_mask) == 0x206, "PART Force player mask offset");
 DECOMP_ASSERT(offsetof(PART_s, force_flags) == 0x218, "PART Force flags offset");
+DECOMP_ASSERT(offsetof(PART_s, carried_blowup) == 0x218, "PART carried blowup offset");
 struct PartObjectInterface {
     void GetPos(VuVec &, i32) const;
     void GetRadius() const;

--- a/src/legoapi/render/fx/parts.cpp
+++ b/src/legoapi/render/fx/parts.cpp
@@ -456,7 +456,18 @@ static __used__ void PartExtra_BlueCoin(PART_s *part) {
         AddVariableShotDebrisEffect(effect, &part->position, count, 0, 0);
 }
 
-static __used__ void PartExtra_PurpleCoin(PART_s *) {
+static __used__ void PartExtra_PurpleCoin(PART_s *part) {
+    if ((part->render_flags & 2) == 0)
+        return;
+    i32 effect = WORLD->debris_sys->entries[57].effect;
+    if (effect == -1)
+        return;
+    f32 rate = 5.0f;
+    if (WORLD->area != NULL && (WORLD->area->flags & 0x104) == 4)
+        rate = 2.5f;
+    i32 count = ParticlesPerSecond(rate, FRAMETIME);
+    if (count > 0)
+        AddVariableShotDebrisEffect(effect, &part->position, count, 0, 0);
 }
 
 static __used__ void PowerUp_DrawPart(PART_s *) {

--- a/src/legoapi/render/fx/parts.cpp
+++ b/src/legoapi/render/fx/parts.cpp
@@ -494,15 +494,6 @@ static __used__ void SpeederPart_Kill(PART_s *, i32) {
 static __used__ void SpeederPart_Update(PART_s *) {
 }
 
-static __used__ void SuperCarry_PartKill(PART_s *, i32) {
-}
-
-static __used__ void SuperCarry_PartImpact(PART_s *) {
-}
-
-static __used__ void SuperCarry_TurnBlowupBackOn(GIZMOBLOWUP_s *, nuvec_s *, u16, i32) {
-}
-
 extern WORLDINFO_s *WORLD;
 extern AREADATA_s *PODRACE_ADATA;
 extern AREADATA_s *BONUS_GUNSHIP_ADATA;


### PR DESCRIPTION
Restore original carry state handling, carried-object transforms, thrown-part callbacks, plug lookup, and the purple-coin callback from the Android x86 binary. The replacements cover the original branches rather than leaving partial bodies. Original carry defaults and return types are restored, and overlapping data fields have target ABI offset assertions.

The carry code uses a separate target `-O3` translation unit based on the original module's generated code. This PR adds no host-specific gameplay paths. Full in-game carry behavior still depends on other existing incomplete routines and initialization; gameplay has not been verified in WebAssembly.

Validation:

- Bazel pre-commit passed: target/native/WebAssembly clang-tidy, repository checks, target build, symbol checks, and regenerated matching report.
- Original-symbol comparison against main: 13,459 symbols, no regressions above 0.1 percentage points, no losses from exactly 100%, and no large-function regressions (at least 512 bytes and 5 percentage points).
- Raw byte-weighted fuzzy match: 29.77539% on main to 29.89861% (+0.12321 percentage points).

- All 10 GitHub checks passed on corrected commit 3798462b35ec892fb5230531ec10540be55c41be. Bazel pre-commit also passed after correcting the carry caller return declaration; target matching is unchanged.


