### PR TITLE
Document the new branch of objdiff fork

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,8 +347,10 @@ The matching scripts also require an external `objdiff-cli` executable on
 `PATH`. Install the known-compatible revision with Rust's Cargo:
 
 ```sh
-cargo install --git https://github.com/ttdecomp/objdiff.git objdiff-cli
+cargo install --git https://github.com/opensagadev/objdiff.git --branch codex/i386-linked-got objdiff-cli
 ```
+
+(note the `codex/i386-linked-got` branch; we are currently using this experimental branch for the decomp, but are undecided how to reconcile it with the changes we would like to contribute to upstream objdiff. In the future, we may return to installing the fork from main, or even the upstream `encounter/objdiff`)
 
 To compare one function, build `target` and give its mangled symbol name to the
 compact diff wrapper:
@@ -367,7 +369,7 @@ for browsing differences; building, matching reports, pre-commit, and CI do
 not need it. Install the known-compatible revision with Rust's Cargo:
 
 ```sh
-cargo install --git https://github.com/ttdecomp/objdiff.git objdiff-gui
+cargo install --git https://github.com/opensagadev/objdiff.git --branch codex/i386-linked-got objdiff-gui
 # Generate its local project file and open the repository root:
 bazel run //scripts:generate_objdiff_gui_config
 # Then run the GUI:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # _saga_
 
-![Progress](https://img.shields.io/badge/matching-39.40%25-orange)
+![Progress](https://img.shields.io/badge/matching-39.18%25-orange)
 [![Bazel build](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml/badge.svg)](https://github.com/ttdecomp/saga/actions/workflows/build-bazel.yaml)
 [![Discord](https://img.shields.io/discord/1467775700894224555?color=%235865F2&logo=discord&logoColor=%23FFFFFF)](https://discord.gg/2HJuMtzA7q)
 [![status & wasm build](https://img.shields.io/badge/status%20%26%20wasm%20build-click%20here-orange?style=flat)](https://opensaga.dev/)
@@ -58,28 +58,28 @@ See https://ttdecomp.github.io/saga/
 
 | Directory | Fuzzy % | Funcs % |
 |---|---:|---:|
-| `(root)` | 62.0% | 50.0% |
+| `(root)` | 61.7% | 50.0% |
 | `MechInputTouch` | 17.7% | 26.3% |
 | `editor` | 3.5% | 5.7% |
 | `gameapi` | 29.5% | 18.1% |
 | `gameframework` | 100.0% | 52.9% |
 | `gamelib` | 24.4% | 24.0% |
 | `java` | 96.1% | 73.1% |
-| `legoapi` | 36.9% | 29.3% |
+| `legoapi` | 36.5% | 29.3% |
 | `legoapi/actions` | 32.5% | 6.8% |
 | `legoapi/ai` | 48.0% | 24.1% |
-| `legoapi/audio` | 54.5% | 45.5% |
-| `legoapi/characters` | 33.2% | 18.7% |
+| `legoapi/audio` | 53.8% | 45.5% |
+| `legoapi/characters` | 32.4% | 18.7% |
 | `legoapi/core` | 30.9% | 20.6% |
 | `legoapi/cutscenes` | 36.6% | 15.7% |
 | `legoapi/gizmo` | 43.4% | 37.0% |
-| `legoapi/gizmos` | 50.4% | 47.3% |
-| `legoapi/items` | 40.3% | 38.0% |
-| `legoapi/menus` | 27.1% | 27.8% |
+| `legoapi/gizmos` | 50.3% | 47.3% |
+| `legoapi/items` | 40.1% | 38.0% |
+| `legoapi/menus` | 27.0% | 27.8% |
 | `legoapi/misc` | 27.5% | 12.5% |
-| `legoapi/props` | 52.2% | 13.9% |
-| `legoapi/render` | 37.4% | 26.5% |
-| `legoapi/world` | 28.3% | 30.4% |
+| `legoapi/props` | 51.1% | 13.9% |
+| `legoapi/render` | 36.5% | 26.5% |
+| `legoapi/world` | 27.9% | 30.4% |
 | `legogame` | 50.8% | 60.0% |
 | `nu2api` | 58.2% | 55.4% |
 

--- a/matching.json
+++ b/matching.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "measures": {
-    "fuzzy_match_percent": 39.402073,
+    "fuzzy_match_percent": 39.17659,
     "total_code": "4722419",
     "matched_code": "370312",
     "matched_code_percent": 7.841574,
@@ -14347,7 +14347,7 @@
     {
       "name": "MechInputTouch/MechAutoJumpManager.cpp.o",
       "source": "src/MechInputTouch/MechAutoJumpManager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutoJumpManager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutoJumpManager.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechAutoJumpManager.cpp",
@@ -14474,7 +14474,7 @@
     {
       "name": "MechInputTouch/MechAutofireAddon.cpp.o",
       "source": "src/MechInputTouch/MechAutofireAddon.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutofireAddon.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechAutofireAddon.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechAutofireAddon.cpp",
@@ -14537,7 +14537,7 @@
     {
       "name": "MechInputTouch/MechEdgeStopAddon.cpp.o",
       "source": "src/MechInputTouch/MechEdgeStopAddon.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechEdgeStopAddon.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechEdgeStopAddon.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechEdgeStopAddon.cpp",
@@ -14600,7 +14600,7 @@
     {
       "name": "MechInputTouch/MechInputTouch.cpp.o",
       "source": "src/MechInputTouch/MechInputTouch.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouch.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouch.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouch.cpp",
@@ -14863,7 +14863,7 @@
     {
       "name": "MechInputTouch/MechInputTouchBonusCavalryController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchBonusCavalryController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchBonusCavalryController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchBonusCavalryController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchBonusCavalryController.cpp",
@@ -14958,7 +14958,7 @@
     {
       "name": "MechInputTouch/MechInputTouchButton.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchButton.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchButton.cpp",
@@ -15237,7 +15237,7 @@
     {
       "name": "MechInputTouch/MechInputTouchButton_stubs.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchButton_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchButton_stubs.o",
       "functions": [
         {
           "name": "_ZNK29MechInputTouchMainDummyButton9IsPressedEv",
@@ -15252,7 +15252,7 @@
     {
       "name": "MechInputTouch/MechInputTouchContextTasks.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchContextTasks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchContextTasks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchContextTasks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchContextTasks.cpp",
@@ -16171,7 +16171,7 @@
     {
       "name": "MechInputTouch/MechInputTouchDeathStarTurretController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchDeathStarTurretController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchDeathStarTurretController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchDeathStarTurretController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchDeathStarTurretController.cpp",
@@ -16274,7 +16274,7 @@
     {
       "name": "MechInputTouch/MechInputTouchGestureBasedController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchGestureBasedController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureBasedController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureBasedController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchGestureBasedController.cpp",
@@ -16529,7 +16529,7 @@
     {
       "name": "MechInputTouch/MechInputTouchGestureTracker.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchGestureTracker.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureTracker.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchGestureTracker.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchGestureTracker.cpp",
@@ -16680,7 +16680,7 @@
     {
       "name": "MechInputTouch/MechInputTouchMainController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchMainController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMainController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMainController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchMainController.cpp",
@@ -16775,7 +16775,7 @@
     {
       "name": "MechInputTouch/MechInputTouchMenuController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchMenuController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMenuController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchMenuController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchMenuController.cpp",
@@ -16918,7 +16918,7 @@
     {
       "name": "MechInputTouch/MechInputTouchPodraceController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchPodraceController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchPodraceController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchPodraceController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchPodraceController.cpp",
@@ -17013,7 +17013,7 @@
     {
       "name": "MechInputTouch/MechInputTouchSpeederChaseBikeController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchSpeederChaseBikeController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchSpeederChaseBikeController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchSpeederChaseBikeController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchSpeederChaseBikeController.cpp",
@@ -17164,7 +17164,7 @@
     {
       "name": "MechInputTouch/MechInputTouchVirtualConsoleController.cpp.o",
       "source": "src/MechInputTouch/MechInputTouchVirtualConsoleController.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchVirtualConsoleController.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechInputTouchVirtualConsoleController.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechInputTouchVirtualConsoleController.cpp",
@@ -17307,7 +17307,7 @@
     {
       "name": "MechInputTouch/MechJumpAutopilotAddon.cpp.o",
       "source": "src/MechInputTouch/MechJumpAutopilotAddon.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechJumpAutopilotAddon.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechJumpAutopilotAddon.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechJumpAutopilotAddon.cpp",
@@ -17442,7 +17442,7 @@
     {
       "name": "MechInputTouch/MechObjectInterface.cpp.o",
       "source": "src/MechInputTouch/MechObjectInterface.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechObjectInterface.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechObjectInterface.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechObjectInterface.cpp",
@@ -17457,7 +17457,7 @@
     {
       "name": "MechInputTouch/MechSystems.cpp.o",
       "source": "src/MechInputTouch/MechSystems.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechSystems.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechSystems.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechSystems.cpp",
@@ -17672,7 +17672,7 @@
     {
       "name": "MechInputTouch/MechTouchUIElements.cpp.o",
       "source": "src/MechInputTouch/MechTouchUIElements.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechTouchUIElements.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_mechinputtouch/MechTouchUIElements.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_MechTouchUIElements.cpp",
@@ -18295,7 +18295,7 @@
     {
       "name": "batman.cpp.o",
       "source": "src/batman.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_root/batman.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_root/batman.o",
       "functions": [
         {
           "name": "_ZL19NuSoundAppTerminatev",
@@ -18311,14 +18311,14 @@
           "address": 1015456,
           "offset": 125488,
           "size": 13465,
-          "match_percent": 61.869213
+          "match_percent": 61.620914
         }
       ]
     },
     {
       "name": "editor/aieditor.cpp.o",
       "source": "src/editor/aieditor.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/aieditor.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/aieditor.o",
       "functions": [
         {
           "name": "aieditor_cbDrawAllToggle",
@@ -18573,7 +18573,7 @@
     {
       "name": "editor/area_editor.cpp.o",
       "source": "src/editor/area_editor.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/area_editor.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/area_editor.o",
       "functions": [
         {
           "name": "_ZL31areaEditor_cbAreaCylinderToggleP10eduimenu_sP10eduiitem_sj",
@@ -18636,7 +18636,7 @@
     {
       "name": "editor/creature_editor.cpp.o",
       "source": "src/editor/creature_editor.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/creature_editor.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/creature_editor.o",
       "functions": [
         {
           "name": "_ZL30creatureEditor_cbSetActivationP10eduimenu_sP10eduiitem_sj",
@@ -19011,7 +19011,7 @@
     {
       "name": "editor/edlevelall.cpp.o",
       "source": "src/editor/edlevelall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/edlevelall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edlevelall.o",
       "functions": [
         {
           "name": "_Z16areaEditor_Enterv",
@@ -20290,7 +20290,7 @@
     {
       "name": "editor/edlevelall_stubs.cpp.o",
       "source": "src/editor/edlevelall_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/edlevelall_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edlevelall_stubs.o",
       "functions": [
         {
           "name": "_ZN10BaseEditor10InitialiseER9variptr_uS1_i",
@@ -20401,7 +20401,7 @@
     {
       "name": "editor/edpath.cpp.o",
       "source": "src/editor/edpath.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/edpath.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edpath.o",
       "functions": [
         {
           "name": "_ZL34pathEditor_cbDrawWallsplinesToggleP10eduimenu_sP10eduiitem_sj",
@@ -20792,7 +20792,7 @@
     {
       "name": "editor/edtoolsall.cpp.o",
       "source": "src/editor/edtoolsall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/edtoolsall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/edtoolsall.o",
       "functions": [
         {
           "name": "_Z21DumpAttributeBindingsv",
@@ -20927,7 +20927,7 @@
     {
       "name": "editor/locator_editor.cpp.o",
       "source": "src/editor/locator_editor.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_editor/locator_editor.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_editor/locator_editor.o",
       "functions": [
         {
           "name": "_ZL14CreateCreatureiP7nuvec_si",
@@ -21166,7 +21166,7 @@
     {
       "name": "gameapi/ai/aisys/aiscript.cpp.o",
       "source": "src/gameapi/ai/aisys/aiscript.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/aiscript.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/aiscript.o",
       "functions": [
         {
           "name": "_ZL27AiParseExpressionNameLoopupPcPfPi",
@@ -21421,7 +21421,7 @@
     {
       "name": "gameapi/ai/aisys/aistate.cpp.o",
       "source": "src/gameapi/ai/aisys/aistate.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/aistate.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/aistate.o",
       "functions": [
         {
           "name": "AIStateFind",
@@ -21436,7 +21436,7 @@
     {
       "name": "gameapi/ai/aisys/aisys.cpp.o",
       "source": "src/gameapi/ai/aisys/aisys.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/aisys.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/aisys.o",
       "functions": [
         {
           "name": "_ZL18Condition_GlynTestP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPcPv",
@@ -23316,7 +23316,7 @@
           "address": 1677344,
           "offset": 787376,
           "size": 4428,
-          "match_percent": 22.354292
+          "match_percent": 20.223553
         },
         {
           "name": "_ZL16Action_ForcePushP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPPciif",
@@ -24404,7 +24404,7 @@
           "address": 4128912,
           "offset": 3238944,
           "size": 509,
-          "match_percent": 74.73505
+          "match_percent": 74.393166
         },
         {
           "name": "AIFormationFollow",
@@ -24659,7 +24659,7 @@
     {
       "name": "gameapi/ai/aisys/gameai_actions.cpp.o",
       "source": "src/gameapi/ai/aisys/gameai_actions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_actions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_actions.o",
       "functions": [
         {
           "name": "_ZL24Condition_NumBaddiesInitP7AISYS_sPcP10AISCRIPT_s",
@@ -24714,7 +24714,7 @@
     {
       "name": "gameapi/ai/gameai_bt.cpp.o",
       "source": "src/gameapi/ai/gameai_bt.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_bt.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_bt.o",
       "functions": [
         {
           "name": "_ZL12BT_nodeflectP8nufpar_s",
@@ -24921,13 +24921,13 @@
     {
       "name": "gameapi/ai/gameai_cs.cpp.o",
       "source": "src/gameapi/ai/gameai_cs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_cs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_cs.o",
       "functions": []
     },
     {
       "name": "gameapi/ai/gameai_d.cpp.o",
       "source": "src/gameapi/ai/gameai_d.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_d.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_d.o",
       "functions": [
         {
           "name": "_ZL19D_cam_lookatplayersP8nufpar_s",
@@ -25046,7 +25046,7 @@
     {
       "name": "gameapi/ai/gameai_grab.cpp.o",
       "source": "src/gameapi/ai/gameai_grab.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_grab.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_grab.o",
       "functions": [
         {
           "name": "_ZL13Grab_invert_xP8nufpar_s",
@@ -25125,7 +25125,7 @@
     {
       "name": "gameapi/ai/gameai_sockpar.cpp.o",
       "source": "src/gameapi/ai/gameai_sockpar.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_sockpar.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_sockpar.o",
       "functions": [
         {
           "name": "_ZL14SockParCircuitP8nufpar_sPv",
@@ -25500,7 +25500,7 @@
     {
       "name": "gameapi/ai/gameai_tel.cpp.o",
       "source": "src/gameapi/ai/gameai_tel.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_tel.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/gameai_tel.o",
       "functions": [
         {
           "name": "_ZL9Tel_1_wayP8nufpar_s",
@@ -25595,7 +25595,7 @@
     {
       "name": "gameapi/edtools/edanimall.cpp.o",
       "source": "src/gameapi/edtools/edanimall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edanimall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edanimall.o",
       "functions": [
         {
           "name": "_ZL19edanimcbSetSwitchIdP10eduimenu_sP10eduiitem_sj",
@@ -25810,7 +25810,7 @@
     {
       "name": "gameapi/edtools/edanimcallbacks.cpp.o",
       "source": "src/gameapi/edtools/edanimcallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edanimcallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edanimcallbacks.o",
       "functions": [
         {
           "name": "_ZL26edgizforce_ReadAnimSetDataP13GAMEANIMOBJ_sh",
@@ -26097,7 +26097,7 @@
     {
       "name": "gameapi/edtools/edbriall.cpp.o",
       "source": "src/gameapi/edtools/edbriall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edbriall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edbriall.o",
       "functions": [
         {
           "name": "_ZL20edbricbSetPlankCountP10eduimenu_sP10eduiitem_sj",
@@ -26216,7 +26216,7 @@
     {
       "name": "gameapi/edtools/edbricallbacks.cpp.o",
       "source": "src/gameapi/edtools/edbricallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edbricallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edbricallbacks.o",
       "functions": [
         {
           "name": "_ZL26edbricbSetPostInstanceTypeP10eduimenu_sP10eduiitem_sj",
@@ -26367,7 +26367,7 @@
     {
       "name": "gameapi/edtools/edfile.cpp.o",
       "source": "src/gameapi/edtools/edfile.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edfile.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edfile.o",
       "functions": [
         {
           "name": "EdFileSwapEndianess16",
@@ -26622,7 +26622,7 @@
     {
       "name": "gameapi/edtools/edgra.cpp.o",
       "source": "src/gameapi/edtools/edgra.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edgra.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edgra.o",
       "functions": [
         {
           "name": "edgraStartPage",
@@ -26653,7 +26653,7 @@
     {
       "name": "gameapi/edtools/edgraall.cpp.o",
       "source": "src/gameapi/edtools/edgraall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edgraall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edgraall.o",
       "functions": [
         {
           "name": "_ZL22edgracbSetInstanceTypeP10eduimenu_sP10eduiitem_sj",
@@ -26916,7 +26916,7 @@
     {
       "name": "gameapi/edtools/edgracallbacks.cpp.o",
       "source": "src/gameapi/edtools/edgracallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edgracallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edgracallbacks.o",
       "functions": [
         {
           "name": "_ZL26edgracbToggleClumpReactiveP10eduimenu_sP10eduiitem_sj",
@@ -27115,7 +27115,7 @@
     {
       "name": "gameapi/edtools/edlevelall.cpp.o",
       "source": "src/gameapi/edtools/edlevelall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edlevelall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edlevelall.o",
       "functions": [
         {
           "name": "_ZN7EdClass15SerialiseObjectER8EdStreamPv",
@@ -27242,7 +27242,7 @@
     {
       "name": "gameapi/edtools/edmenucallbacks.cpp.o",
       "source": "src/gameapi/edtools/edmenucallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edmenucallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edmenucallbacks.o",
       "functions": [
         {
           "name": "_ZL18cbPtlChangeEmitVelP10eduimenu_sP10eduiitem_sj",
@@ -28713,7 +28713,7 @@
     {
       "name": "gameapi/edtools/edpartall.cpp.o",
       "source": "src/gameapi/edtools/edpartall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edpartall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edpartall.o",
       "functions": [
         {
           "name": "_ZL10edppRenderv",
@@ -29296,7 +29296,7 @@
     {
       "name": "gameapi/edtools/edpartcallbacks.cpp.o",
       "source": "src/gameapi/edtools/edpartcallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edpartcallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edpartcallbacks.o",
       "functions": [
         {
           "name": "_ZL24edptlcbApplyBounceOffsetP10eduimenu_sP10eduiitem_sj",
@@ -30127,7 +30127,7 @@
     {
       "name": "gameapi/edtools/edptlall.cpp.o",
       "source": "src/gameapi/edtools/edptlall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edptlall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edptlall.o",
       "functions": [
         {
           "name": "_ZL21edptlcbChangeDistortXP10eduimenu_sP10eduiitem_sj",
@@ -30542,7 +30542,7 @@
     {
       "name": "gameapi/edtools/edrtl.cpp.o",
       "source": "src/gameapi/edtools/edrtl.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edrtl.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edrtl.o",
       "functions": [
         {
           "name": "_Z16edrtlInitBurnsetP9burnset_s",
@@ -30621,7 +30621,7 @@
     {
       "name": "gameapi/edtools/edrtlall.cpp.o",
       "source": "src/gameapi/edtools/edrtlall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlall.o",
       "functions": [
         {
           "name": "_ZL13edrtlSaveUndov",
@@ -30876,7 +30876,7 @@
     {
       "name": "gameapi/edtools/edrtlcallbacks.cpp.o",
       "source": "src/gameapi/edtools/edrtlcallbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlcallbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edrtlcallbacks.o",
       "functions": [
         {
           "name": "_ZL9edrtlUndov",
@@ -31171,7 +31171,7 @@
     {
       "name": "gameapi/edtools/edsplines.cpp.o",
       "source": "src/gameapi/edtools/edsplines.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edsplines.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edsplines.o",
       "functions": [
         {
           "name": "_Z12SplineLengthP11nugspline_si",
@@ -31602,7 +31602,7 @@
     {
       "name": "gameapi/edtools/edstubs.cpp.o",
       "source": "src/gameapi/edtools/edstubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edstubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edstubs.o",
       "functions": [
         {
           "name": "edanimRegisterBaseScene",
@@ -31649,7 +31649,7 @@
     {
       "name": "gameapi/edtools/edtoolsall.cpp.o",
       "source": "src/gameapi/edtools/edtoolsall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall.o",
       "functions": [
         {
           "name": "_Z24edanimPlayerAnimDistancei",
@@ -33848,7 +33848,7 @@
     {
       "name": "gameapi/edtools/edtoolsall_plain.cpp.o",
       "source": "src/gameapi/edtools/edtoolsall_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_plain.o",
       "functions": [
         {
           "name": "edanimParticleDestroy",
@@ -35687,7 +35687,7 @@
     {
       "name": "gameapi/edtools/edtoolsall_stubs.cpp.o",
       "source": "src/gameapi/edtools/edtoolsall_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edtoolsall_stubs.o",
       "functions": [
         {
           "name": "_ZN14EdInputContext10GetReleaseEi",
@@ -35766,7 +35766,7 @@
     {
       "name": "gameapi/edtools/edui.c.o",
       "source": "src/gameapi/edtools/edui.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/0/edui.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/0/edui.o",
       "functions": [
         {
           "name": "eduicbInteractSel",
@@ -36165,7 +36165,7 @@
     {
       "name": "gameapi/edtools/edui.cpp.o",
       "source": "src/gameapi/edtools/edui.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/1/edui.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/1/edui.o",
       "functions": [
         {
           "name": "eduicbItemExpanderClose",
@@ -36204,7 +36204,7 @@
     {
       "name": "gameapi/edtools/edui_fnt.cpp.o",
       "source": "src/gameapi/edtools/edui_fnt.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/edui_fnt.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/edui_fnt.o",
       "functions": [
         {
           "name": "_ZL14eduiFntPrintExPviiiPcz",
@@ -36227,7 +36227,7 @@
     {
       "name": "gameapi/gui/apimenu.cpp.o",
       "source": "src/gameapi/gui/apimenu.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameapi/apimenu.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameapi/apimenu.o",
       "functions": [
         {
           "name": "_ZL17MenuInitHowToPlayP6MENU_s",
@@ -36522,7 +36522,7 @@
     {
       "name": "gameframework/saveload.cpp.o",
       "source": "src/gameframework/saveload.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameframework/saveload.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameframework/saveload.o",
       "functions": [
         {
           "name": "_Z8slotnamei",
@@ -36633,7 +36633,7 @@
     {
       "name": "gameframework/savesystem.cpp.o",
       "source": "src/gameframework/savesystem.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gameframework/savesystem.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gameframework/savesystem.o",
       "functions": [
         {
           "name": "SaveSystemInitialise",
@@ -36672,7 +36672,7 @@
     {
       "name": "gamelib/NewTerrain.cpp.o",
       "source": "src/gamelib/NewTerrain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/NewTerrain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/NewTerrain.o",
       "functions": [
         {
           "name": "_Z18NuVecCheckForSNANsP7nuvec_s",
@@ -36687,7 +36687,7 @@
     {
       "name": "gamelib/crc/crc.cpp.o",
       "source": "src/gamelib/crc/crc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/crc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/crc.o",
       "functions": [
         {
           "name": "CRC_Init",
@@ -36742,7 +36742,7 @@
     {
       "name": "gamelib/nuwind/nuwind.cpp.o",
       "source": "src/gamelib/nuwind/nuwind.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/nuwind.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/nuwind.o",
       "functions": [
         {
           "name": "NuWindInitialise",
@@ -36765,7 +36765,7 @@
     {
       "name": "gamelib/nuwind/nuwind_groups.cpp.o",
       "source": "src/gamelib/nuwind/nuwind_groups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/nuwind_groups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/nuwind_groups.o",
       "functions": [
         {
           "name": "NuWindRand",
@@ -36836,7 +36836,7 @@
     {
       "name": "gamelib/util/AndroidOBBUtils.cpp.o",
       "source": "src/gamelib/util/AndroidOBBUtils.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/AndroidOBBUtils.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/AndroidOBBUtils.o",
       "functions": [
         {
           "name": "_ZN15AndroidOBBUtils17LookupPackagePathEPcN26NuFileDeviceAndroidOBBType1TE",
@@ -36867,7 +36867,7 @@
     {
       "name": "gamelib/util/CRC16.cpp.o",
       "source": "src/gamelib/util/CRC16.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16.o",
       "functions": [
         {
           "name": "_ZN5CRC16C1Ev",
@@ -36906,13 +36906,13 @@
     {
       "name": "gamelib/util/CRC16_plain.cpp.o",
       "source": "src/gamelib/util/CRC16_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/CRC16_plain.o",
       "functions": []
     },
     {
       "name": "gamelib/util/Ftp.cpp.o",
       "source": "src/gamelib/util/Ftp.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp.o",
       "functions": [
         {
           "name": "_ZN13NetFtpManager7ReceiveE10NetMessagehRK10NetAddress",
@@ -37111,7 +37111,7 @@
     {
       "name": "gamelib/util/Ftp_stubs.cpp.o",
       "source": "src/gamelib/util/Ftp_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Ftp_stubs.o",
       "functions": [
         {
           "name": "_ZN7FtpFile6AcceptEv",
@@ -37126,7 +37126,7 @@
     {
       "name": "gamelib/util/Network.cpp.o",
       "source": "src/gamelib/util/Network.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/Network.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Network.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_Network.cpp",
@@ -37957,7 +37957,7 @@
     {
       "name": "gamelib/util/Network_stubs.cpp.o",
       "source": "src/gamelib/util/Network_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/Network_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Network_stubs.o",
       "functions": [
         {
           "name": "_ZN10NetMessage10RaiseErrorEv",
@@ -37996,7 +37996,7 @@
     {
       "name": "gamelib/util/TouchHacks.cpp.o",
       "source": "src/gamelib/util/TouchHacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/TouchHacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/TouchHacks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_TouchHacks.cpp",
@@ -38363,7 +38363,7 @@
     {
       "name": "gamelib/util/Transporter.cpp.o",
       "source": "src/gamelib/util/Transporter.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/Transporter.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/Transporter.o",
       "functions": [
         {
           "name": "_ZN14NetTransporter11AddListenerEP20NetListenerInterfacehPc",
@@ -38490,7 +38490,7 @@
     {
       "name": "gamelib/util/V2SessionManager.cpp.o",
       "source": "src/gamelib/util/V2SessionManager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/V2SessionManager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/V2SessionManager.o",
       "functions": [
         {
           "name": "_ZN16V2SessionManager13VerifyStringsEPPcS1_iS0_",
@@ -38569,7 +38569,7 @@
     {
       "name": "gamelib/util/VirtualStackAllocator.cpp.o",
       "source": "src/gamelib/util/VirtualStackAllocator.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/VirtualStackAllocator.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/VirtualStackAllocator.o",
       "functions": [
         {
           "name": "_ZN21VirtualStackAllocatorC1Ev",
@@ -38664,7 +38664,7 @@
     {
       "name": "gamelib/util/gamelib_util_misc.cpp.o",
       "source": "src/gamelib/util/gamelib_util_misc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_gamelib/gamelib_util_misc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_gamelib/gamelib_util_misc.o",
       "functions": [
         {
           "name": "_ZN10TouchHacks9TintStackC1Ev",
@@ -38751,13 +38751,13 @@
     {
       "name": "globals.cpp.o",
       "source": "src/globals.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_root/globals.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_root/globals.o",
       "functions": []
     },
     {
       "name": "java/android.cpp.o",
       "source": "src/java/android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_root/android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_root/android.o",
       "functions": [
         {
           "name": "Java_com_tt_tech_TTActivity_nativeSetScreenDimesions",
@@ -38972,13 +38972,13 @@
     {
       "name": "java/android_state.cpp.o",
       "source": "src/java/android_state.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_root/android_state.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_root/android_state.o",
       "functions": []
     },
     {
       "name": "legoapi/actions/character/simpletons.cpp.o",
       "source": "src/legoapi/actions/character/simpletons.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/simpletons.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/simpletons.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_simpletons.cpp",
@@ -39081,7 +39081,7 @@
     {
       "name": "legoapi/actions/character/snake.cpp.o",
       "source": "src/legoapi/actions/character/snake.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/snake.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/snake.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_snake.cpp",
@@ -39160,7 +39160,7 @@
     {
       "name": "legoapi/actions/character/specialmoves.cpp.o",
       "source": "src/legoapi/actions/character/specialmoves.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/specialmoves.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/specialmoves.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_specialmoves.cpp",
@@ -39271,7 +39271,7 @@
     {
       "name": "legoapi/actions/character/speederchase.cpp.o",
       "source": "src/legoapi/actions/character/speederchase.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_speederchase.cpp",
@@ -39486,7 +39486,7 @@
     {
       "name": "legoapi/actions/character/speederchase_stubs.cpp.o",
       "source": "src/legoapi/actions/character/speederchase_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/speederchase_stubs.o",
       "functions": [
         {
           "name": "_Z10getPodRolli",
@@ -39501,7 +39501,7 @@
     {
       "name": "legoapi/actions/character/starwars.cpp.o",
       "source": "src/legoapi/actions/character/starwars.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/starwars.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/starwars.o",
       "functions": [
         {
           "name": "InitFn_PreparingForSpecialMove",
@@ -39532,7 +39532,7 @@
     {
       "name": "legoapi/actions/character/streaks.cpp.o",
       "source": "src/legoapi/actions/character/streaks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/streaks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/streaks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_streaks.cpp",
@@ -39579,7 +39579,7 @@
     {
       "name": "legoapi/actions/character/suit.cpp.o",
       "source": "src/legoapi/actions/character/suit.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/suit.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/suit.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_suit.cpp",
@@ -39658,7 +39658,7 @@
     {
       "name": "legoapi/actions/character/tagging.cpp.o",
       "source": "src/legoapi/actions/character/tagging.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/tagging.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tagging.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_tagging.cpp",
@@ -39729,7 +39729,7 @@
     {
       "name": "legoapi/actions/character/transform.cpp.o",
       "source": "src/legoapi/actions/character/transform.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/transform.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/transform.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_transform.cpp",
@@ -39816,7 +39816,7 @@
     {
       "name": "legoapi/actions/combat/fighting.cpp.o",
       "source": "src/legoapi/actions/combat/fighting.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/fighting.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/fighting.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_fighting.cpp",
@@ -39927,7 +39927,7 @@
     {
       "name": "legoapi/actions/combat/hits.cpp.o",
       "source": "src/legoapi/actions/combat/hits.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/hits.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hits.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_hits.cpp",
@@ -40118,7 +40118,7 @@
     {
       "name": "legoapi/actions/combat/rope.cpp.o",
       "source": "src/legoapi/actions/combat/rope.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/rope.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/rope.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_rope.cpp",
@@ -40141,7 +40141,7 @@
     {
       "name": "legoapi/actions/combat/shovesys.cpp.o",
       "source": "src/legoapi/actions/combat/shovesys.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shovesys.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shovesys.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shovesys.cpp",
@@ -40180,7 +40180,7 @@
     {
       "name": "legoapi/actions/combat/whip.cpp.o",
       "source": "src/legoapi/actions/combat/whip.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/whip.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/whip.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_whip.cpp",
@@ -40211,7 +40211,7 @@
     {
       "name": "legoapi/actions/movement/carrying.cpp.o",
       "source": "src/legoapi/actions/movement/carrying.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/carrying.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/carrying.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_carrying.cpp",
@@ -40266,7 +40266,7 @@
     {
       "name": "legoapi/actions/movement/climbing.cpp.o",
       "source": "src/legoapi/actions/movement/climbing.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/climbing.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/climbing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_climbing.cpp",
@@ -40353,7 +40353,7 @@
     {
       "name": "legoapi/actions/movement/dropinout.cpp.o",
       "source": "src/legoapi/actions/movement/dropinout.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/dropinout.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/dropinout.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_dropinout.cpp",
@@ -40416,7 +40416,7 @@
     {
       "name": "legoapi/actions/movement/jumping.cpp.o",
       "source": "src/legoapi/actions/movement/jumping.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/jumping.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/jumping.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_jumping.cpp",
@@ -40511,7 +40511,7 @@
     {
       "name": "legoapi/actions/movement/pushblocks.cpp.o",
       "source": "src/legoapi/actions/movement/pushblocks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/pushblocks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/pushblocks.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_pushblocks.cpp",
@@ -40614,7 +40614,7 @@
     {
       "name": "legoapi/actions/movement/pushing.cpp.o",
       "source": "src/legoapi/actions/movement/pushing.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/pushing.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/pushing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_pushing.cpp",
@@ -40701,7 +40701,7 @@
     {
       "name": "legoapi/actions/movement/supercarry.cpp.o",
       "source": "src/legoapi/actions/movement/supercarry.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/supercarry.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/supercarry.o",
       "functions": [
         {
           "name": "_ZL21SuperCarry_PartImpactP6PART_s",
@@ -40788,7 +40788,7 @@
     {
       "name": "legoapi/ai/core/ai_sys.cpp.o",
       "source": "src/legoapi/ai/core/ai_sys.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys.o",
       "functions": [
         {
           "name": "_Z25AIPathCnxControlSysCreateP9variptr_uS0_i",
@@ -40851,7 +40851,7 @@
     {
       "name": "legoapi/ai/core/ai_sys_stubs.cpp.o",
       "source": "src/legoapi/ai/core/ai_sys_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ai_sys_stubs.o",
       "functions": [
         {
           "name": "_ZL13FormationMoveP9AIGROUP_sPFiS0_P7AIROW_sS2_P11APIOBJECT_sE",
@@ -41043,7 +41043,7 @@
           "address": 4099904,
           "offset": 3209936,
           "size": 6313,
-          "match_percent": 13.840412
+          "match_percent": 12.699485
         },
         {
           "name": "AISysProcess",
@@ -41314,7 +41314,7 @@
     {
       "name": "legoapi/ai/core/aisysall.cpp.o",
       "source": "src/legoapi/ai/core/aisysall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/aisysall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aisysall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_aisysall.cpp",
@@ -41449,7 +41449,7 @@
     {
       "name": "legoapi/ai/core/gameai.cpp.o",
       "source": "src/legoapi/ai/core/gameai.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameai.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameai.cpp",
@@ -41488,7 +41488,7 @@
     {
       "name": "legoapi/ai/core/legoai.cpp.o",
       "source": "src/legoapi/ai/core/legoai.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/legoai.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_legoai.cpp",
@@ -41503,7 +41503,7 @@
     {
       "name": "legoapi/ai/game/aipathcnxhelper.cpp.o",
       "source": "src/legoapi/ai/game/aipathcnxhelper.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/aipathcnxhelper.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aipathcnxhelper.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_aipathcnxhelper.cpp",
@@ -41622,7 +41622,7 @@
     {
       "name": "legoapi/ai/game/aitrigger.cpp.o",
       "source": "src/legoapi/ai/game/aitrigger.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_aitrigger.cpp",
@@ -41693,13 +41693,13 @@
     {
       "name": "legoapi/ai/game/aitrigger_stubs.cpp.o",
       "source": "src/legoapi/ai/game/aitrigger_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/aitrigger_stubs.o",
       "functions": []
     },
     {
       "name": "legoapi/ai/game/creature.cpp.o",
       "source": "src/legoapi/ai/game/creature.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/creature.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/creature.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_creature.cpp",
@@ -41810,7 +41810,7 @@
     {
       "name": "legoapi/ai/game/gameantinode.cpp.o",
       "source": "src/legoapi/ai/game/gameantinode.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameantinode.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameantinode.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameantinode.cpp",
@@ -42009,7 +42009,7 @@
     {
       "name": "legoapi/ai/game/lsw_hub_ai.cpp.o",
       "source": "src/legoapi/ai/game/lsw_hub_ai.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_lsw_hub_ai.cpp",
@@ -42096,7 +42096,7 @@
     {
       "name": "legoapi/ai/game/lsw_hub_ai_stubs.cpp.o",
       "source": "src/legoapi/ai/game/lsw_hub_ai_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lsw_hub_ai_stubs.o",
       "functions": [
         {
           "name": "_Z23Condition_InHubAreaInitP7AISYS_sPcP10AISCRIPT_s",
@@ -42111,7 +42111,7 @@
     {
       "name": "legoapi/ai/game/misc_a_game.cpp.o",
       "source": "src/legoapi/ai/game/misc_a_game.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/misc_a_game.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/misc_a_game.o",
       "functions": [
         {
           "name": "_ZL17CreatePodRaceMineP7nuvec_s",
@@ -42134,7 +42134,7 @@
     {
       "name": "legoapi/ai/game/starwars_gameai.cpp.o",
       "source": "src/legoapi/ai/game/starwars_gameai.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/starwars_gameai.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/starwars_gameai.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_starwars_gameai.cpp",
@@ -42277,7 +42277,7 @@
     {
       "name": "legoapi/audio/audio.cpp.o",
       "source": "src/legoapi/audio/audio.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/audio.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/audio.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_audio.cpp",
@@ -42476,7 +42476,7 @@
     {
       "name": "legoapi/audio/gamelib_ogg.cpp.o",
       "source": "src/legoapi/audio/gamelib_ogg.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_ogg.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_ogg.o",
       "functions": [
         {
           "name": "_ZL10RemoveDataP9nuqthdr_sPci",
@@ -42539,7 +42539,7 @@
     {
       "name": "legoapi/audio/radio.cpp.o",
       "source": "src/legoapi/audio/radio.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/radio.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/radio.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_radio.cpp",
@@ -42578,7 +42578,7 @@
     {
       "name": "legoapi/audio/sfx.cpp.o",
       "source": "src/legoapi/audio/sfx.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/sfx.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/sfx.o",
       "functions": [
         {
           "name": "_Z15SetLevelSfxBitsP11WORLDINFO_s",
@@ -43265,7 +43265,7 @@
     {
       "name": "legoapi/audio/sfx_callbacks.cpp.o",
       "source": "src/legoapi/audio/sfx_callbacks.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/sfx_callbacks.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/sfx_callbacks.o",
       "functions": [
         {
           "name": "SetAPIObjPlaySfxByIdFn",
@@ -43280,7 +43280,7 @@
     {
       "name": "legoapi/audio/specialsfx.cpp.o",
       "source": "src/legoapi/audio/specialsfx.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/specialsfx.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/specialsfx.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_specialsfx.cpp",
@@ -43328,7 +43328,7 @@
           "address": 3584336,
           "offset": 2694368,
           "size": 5342,
-          "match_percent": 24.843689
+          "match_percent": 18.641748
         },
         {
           "name": "_Z14SpecialSfxLoadPcP11WORLDINFO_s",
@@ -43375,7 +43375,7 @@
     {
       "name": "legoapi/characters/core/character.cpp.o",
       "source": "src/legoapi/characters/core/character.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/character.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/character.o",
       "functions": [
         {
           "name": "_ZL15ExtraDieSfx_LSWP12GameObject_s",
@@ -43471,7 +43471,7 @@
           "address": 3999075,
           "offset": 3109107,
           "size": 5289,
-          "match_percent": 24.581024
+          "match_percent": 12.878809
         },
         {
           "name": "ConfigureCharacterList",
@@ -43614,7 +43614,7 @@
     {
       "name": "legoapi/characters/core/character_plain.cpp.o",
       "source": "src/legoapi/characters/core/character_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/character_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/character_plain.o",
       "functions": [
         {
           "name": "APIResetCharacterRemap",
@@ -43645,7 +43645,7 @@
     {
       "name": "legoapi/characters/core/characters.cpp.o",
       "source": "src/legoapi/characters/core/characters.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/characters.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/characters.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_characters.cpp",
@@ -44020,7 +44020,7 @@
     {
       "name": "legoapi/characters/core/charconfig.cpp.o",
       "source": "src/legoapi/characters/core/charconfig.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/charconfig.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charconfig.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charconfig.cpp",
@@ -44036,7 +44036,7 @@
           "address": 1031168,
           "offset": 141200,
           "size": 1761,
-          "match_percent": 98.23009
+          "match_percent": 97.84661
         },
         {
           "name": "_ZL10CC_variantP8nufpar_s",
@@ -45739,7 +45739,7 @@
     {
       "name": "legoapi/characters/core/playeritems.cpp.o",
       "source": "src/legoapi/characters/core/playeritems.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/playeritems.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/playeritems.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_playeritems.cpp",
@@ -45882,7 +45882,7 @@
     {
       "name": "legoapi/characters/core/players.cpp.o",
       "source": "src/legoapi/characters/core/players.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/players.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/players.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_players.cpp",
@@ -46377,7 +46377,7 @@
     {
       "name": "legoapi/characters/motion/animation.cpp.o",
       "source": "src/legoapi/characters/motion/animation.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/animation.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/animation.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_animation.cpp",
@@ -46440,7 +46440,7 @@
     {
       "name": "legoapi/characters/motion/camera.cpp.o",
       "source": "src/legoapi/characters/motion/camera.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/camera.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/camera.o",
       "functions": [
         {
           "name": "_Z12KeepOnScreenP12GameObject_s",
@@ -46719,7 +46719,7 @@
     {
       "name": "legoapi/characters/motion/charpivot.cpp.o",
       "source": "src/legoapi/characters/motion/charpivot.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/charpivot.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charpivot.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charpivot.cpp",
@@ -46750,7 +46750,7 @@
     {
       "name": "legoapi/characters/motion/charplatforms.cpp.o",
       "source": "src/legoapi/characters/motion/charplatforms.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/charplatforms.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charplatforms.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charplatforms.cpp",
@@ -46845,7 +46845,7 @@
     {
       "name": "legoapi/characters/motion/charshadows.cpp.o",
       "source": "src/legoapi/characters/motion/charshadows.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/charshadows.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/charshadows.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_charshadows.cpp",
@@ -46884,7 +46884,7 @@
     {
       "name": "legoapi/characters/motion/chris.cpp.o",
       "source": "src/legoapi/characters/motion/chris.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/chris.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/chris.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_chris.cpp",
@@ -47075,7 +47075,7 @@
     {
       "name": "legoapi/characters/motion/chris_stubs.cpp.o",
       "source": "src/legoapi/characters/motion/chris_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/chris_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/chris_stubs.o",
       "functions": [
         {
           "name": "_Z18ChrisAnakinAUpdateP11WORLDINFO_s",
@@ -47114,7 +47114,7 @@
     {
       "name": "legoapi/characters/motion/gameanim.cpp.o",
       "source": "src/legoapi/characters/motion/gameanim.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameanim.cpp",
@@ -48049,7 +48049,7 @@
     {
       "name": "legoapi/characters/motion/gameanim_modes.cpp.o",
       "source": "src/legoapi/characters/motion/gameanim_modes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim_modes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameanim_modes.o",
       "functions": [
         {
           "name": "SetAnimBlendMode",
@@ -48072,7 +48072,7 @@
     {
       "name": "legoapi/characters/motion/move.cpp.o",
       "source": "src/legoapi/characters/motion/move.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/move.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/move.o",
       "functions": [
         {
           "name": "_ZL11IsAFallAnimi",
@@ -48112,7 +48112,7 @@
           "address": 1110000,
           "offset": 220032,
           "size": 23545,
-          "match_percent": 8.625641
+          "match_percent": 0.0
         },
         {
           "name": "_ZL13AtatPart_StopP6PART_s",
@@ -48536,7 +48536,7 @@
           "address": 1470672,
           "offset": 580704,
           "size": 14602,
-          "match_percent": 34.726665
+          "match_percent": 33.673653
         },
         {
           "name": "_Z9FloatCodeP12GameObject_s",
@@ -48944,7 +48944,7 @@
           "address": 5171920,
           "offset": 4281952,
           "size": 8829,
-          "match_percent": 41.477875
+          "match_percent": 40.981747
         },
         {
           "name": "_Z13Hang_MoveCodeP12GameObject_s",
@@ -49039,7 +49039,7 @@
     {
       "name": "legoapi/core/config/cheat.cpp.o",
       "source": "src/legoapi/core/config/cheat.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cheat.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cheat.o",
       "functions": [
         {
           "name": "_Z16Cheat_FindByNamePc",
@@ -49086,7 +49086,7 @@
     {
       "name": "legoapi/core/config/cheats.cpp.o",
       "source": "src/legoapi/core/config/cheats.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cheats.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cheats.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_cheats.cpp",
@@ -49197,7 +49197,7 @@
     {
       "name": "legoapi/core/config/config.cpp.o",
       "source": "src/legoapi/core/config/config.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/config.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/config.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_config.cpp",
@@ -49220,7 +49220,7 @@
     {
       "name": "legoapi/core/config/saveload.cpp.o",
       "source": "src/legoapi/core/config/saveload.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/saveload.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/saveload.o",
       "functions": [
         {
           "name": "_Z11InitMemCardv",
@@ -49635,7 +49635,7 @@
     {
       "name": "legoapi/core/input/gamepads.cpp.o",
       "source": "src/legoapi/core/input/gamepads.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamepads.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamepads.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamepads.cpp",
@@ -49922,7 +49922,7 @@
     {
       "name": "legoapi/core/input/input.cpp.o",
       "source": "src/legoapi/core/input/input.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/input.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/input.o",
       "functions": [
         {
           "name": "_ZN31ClickToPressStartGestureTracker7OnClickER12GameObject_sR11TouchHolder",
@@ -49937,7 +49937,7 @@
     {
       "name": "legoapi/core/input/qrand.cpp.o",
       "source": "src/legoapi/core/input/qrand.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/qrand.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/qrand.o",
       "functions": [
         {
           "name": "_Z5qrandv",
@@ -49952,7 +49952,7 @@
     {
       "name": "legoapi/core/input/timer.cpp.o",
       "source": "src/legoapi/core/input/timer.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/timer.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/timer.o",
       "functions": [
         {
           "name": "_Z10ResetTimerP7TIMER_sf",
@@ -49975,7 +49975,7 @@
     {
       "name": "legoapi/core/input/timing.cpp.o",
       "source": "src/legoapi/core/input/timing.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/timing.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/timing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_timing.cpp",
@@ -50030,7 +50030,7 @@
     {
       "name": "legoapi/core/net/netplay.cpp.o",
       "source": "src/legoapi/core/net/netplay.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/netplay.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/netplay.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_netplay.cpp",
@@ -50093,7 +50093,7 @@
     {
       "name": "legoapi/core/net/network.cpp.o",
       "source": "src/legoapi/core/net/network.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/network.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/network.o",
       "functions": [
         {
           "name": "_ZN9TTNetwork7DisplayEP15ThingRenderData",
@@ -50268,7 +50268,7 @@
     {
       "name": "legoapi/core/startup/game.cpp.o",
       "source": "src/legoapi/core/startup/game.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/game.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/game.o",
       "functions": [
         {
           "name": "_Z7NewGamev",
@@ -50331,7 +50331,7 @@
     {
       "name": "legoapi/core/startup/main.cpp.o",
       "source": "src/legoapi/core/startup/main.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/main.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/main.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_main.cpp",
@@ -50378,7 +50378,7 @@
     {
       "name": "legoapi/core/startup/startup.cpp.o",
       "source": "src/legoapi/core/startup/startup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/startup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/startup.o",
       "functions": [
         {
           "name": "_Z16ParseCommandLinev",
@@ -50393,7 +50393,7 @@
     {
       "name": "legoapi/core/startup/virtual.cpp.o",
       "source": "src/legoapi/core/startup/virtual.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/virtual.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/virtual.o",
       "functions": [
         {
           "name": "_ZN29VirtualControlDPad_LockButton7ProcessEf",
@@ -50544,7 +50544,7 @@
     {
       "name": "legoapi/cutscenes/cutscene.cpp.o",
       "source": "src/legoapi/cutscenes/cutscene.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene.o",
       "functions": [
         {
           "name": "_ZL35CutScene_OverrideConfigFileName_LSWPcii",
@@ -51135,7 +51135,7 @@
     {
       "name": "legoapi/cutscenes/cutscene_find.cpp.o",
       "source": "src/legoapi/cutscenes/cutscene_find.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_find.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_find.o",
       "functions": [
         {
           "name": "_Z13CutScene_FindP6CUTSYSPc",
@@ -51150,7 +51150,7 @@
     {
       "name": "legoapi/cutscenes/cutscene_stubs.cpp.o",
       "source": "src/legoapi/cutscenes/cutscene_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscene_stubs.o",
       "functions": [
         {
           "name": "SetForceScenePlayBack",
@@ -51429,7 +51429,7 @@
     {
       "name": "legoapi/cutscenes/cutscenes.cpp.o",
       "source": "src/legoapi/cutscenes/cutscenes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cutscenes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cutscenes.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_cutscenes.cpp",
@@ -51772,7 +51772,7 @@
     {
       "name": "legoapi/cutscenes/gcutscn.cpp.o",
       "source": "src/legoapi/cutscenes/gcutscn.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gcutscn.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gcutscn.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gcutscn.cpp",
@@ -51923,7 +51923,7 @@
     {
       "name": "legoapi/cutscenes/minicamcut.cpp.o",
       "source": "src/legoapi/cutscenes/minicamcut.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/minicamcut.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/minicamcut.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_minicamcut.cpp",
@@ -52010,7 +52010,7 @@
     {
       "name": "legoapi/gizmo/base/gizactions.cpp.o",
       "source": "src/legoapi/gizmo/base/gizactions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizactions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizactions.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizactions.cpp",
@@ -52057,7 +52057,7 @@
     {
       "name": "legoapi/gizmo/base/gizflow.cpp.o",
       "source": "src/legoapi/gizmo/base/gizflow.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizflow.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizflow.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizflow.cpp",
@@ -52408,7 +52408,7 @@
     {
       "name": "legoapi/gizmo/base/gizmessage.cpp.o",
       "source": "src/legoapi/gizmo/base/gizmessage.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmessage.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmessage.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmessage.cpp",
@@ -52487,7 +52487,7 @@
     {
       "name": "legoapi/gizmo/base/gizmo.cpp.o",
       "source": "src/legoapi/gizmo/base/gizmo.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmo.cpp",
@@ -54006,7 +54006,7 @@
     {
       "name": "legoapi/gizmo/base/gizmo_sys.cpp.o",
       "source": "src/legoapi/gizmo/base/gizmo_sys.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo_sys.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmo_sys.o",
       "functions": [
         {
           "name": "_Z24Hub_LoadAndFixUpMiniKitsP11WORLDINFO_sP9variptr_uS2_",
@@ -54077,7 +54077,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizactions.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizactions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizactions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizactions.o",
       "functions": [
         {
           "name": "_Z23Action_GameFollowPlayerP7AISYS_sP17AISCRIPTPROCESS_sP10AIPACKET_sPPciif",
@@ -54460,7 +54460,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizbuildits.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizbuildits.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizbuildits.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizbuildits.o",
       "functions": [
         {
           "name": "_Z15GizBuildIt_FindP11WORLDINFO_sPc",
@@ -54611,7 +54611,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizforce.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizforce.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizforce.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizforce.o",
       "functions": [
         {
           "name": "_Z17GizForce_ResetLOSP12GameObject_s",
@@ -54730,7 +54730,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizmopickups.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizmopickups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizmopickups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizmopickups.o",
       "functions": [
         {
           "name": "_ZL22GizmoPickups_Collide2DP12GameObject_s",
@@ -54873,7 +54873,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizobstacles.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizobstacles.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizobstacles.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizobstacles.o",
       "functions": [
         {
           "name": "_Z31GizObstacle_SetDefaultSFXFn_LSWPvP13GIZOBSTACLE_s",
@@ -55032,7 +55032,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizpanel.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizpanel.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizpanel.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizpanel.o",
       "functions": [
         {
           "name": "_Z24GizPanel_GetAbsTargetPosP10GIZPANEL_sP7nuvec_si",
@@ -55143,7 +55143,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_gizturrets.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_gizturrets.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizturrets.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_gizturrets.o",
       "functions": [
         {
           "name": "_Z16GizTurret_GetTgtP11GIZTURRET_sP7numtx_s",
@@ -55230,7 +55230,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_grabber.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_grabber.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grabber.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grabber.o",
       "functions": [
         {
           "name": "_Z18Grabber_GetGrabPosP9GRABBER_sP7numtx_s",
@@ -55285,7 +55285,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_grapples.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_grapples.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grapples.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_grapples.o",
       "functions": [
         {
           "name": "_ZL25Grapple_FindNearestInListP7nuvec_sP9GRAPPLE_siP12GameObject_sPS2_Pf",
@@ -55372,7 +55372,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_hatmachine.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_hatmachine.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_hatmachine.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_hatmachine.o",
       "functions": [
         {
           "name": "_Z23HatMachines_InitTerrainP11WORLDINFO_s",
@@ -55427,13 +55427,13 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_lever.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_lever.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_lever.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_lever.o",
       "functions": []
     },
     {
       "name": "legoapi/gizmo/gizmos/gizmos_newblowup.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_newblowup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_newblowup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_newblowup.o",
       "functions": [
         {
           "name": "_ZN13GIZMOBLOWUP_s22GetMechObjectInterfaceEv",
@@ -55496,7 +55496,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_spinner.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_spinner.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_spinner.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_spinner.o",
       "functions": [
         {
           "name": "_Z23GizSpinners_InitTerrainP11WORLDINFO_s",
@@ -55591,7 +55591,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_teleport.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_teleport.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_teleport.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_teleport.o",
       "functions": [
         {
           "name": "_ZN10TELEPORT_s22GetMechObjectInterfaceEv",
@@ -55670,7 +55670,7 @@
     {
       "name": "legoapi/gizmo/gizmos/gizmos_tubes.cpp.o",
       "source": "src/legoapi/gizmo/gizmos/gizmos_tubes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_tubes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmos_tubes.o",
       "functions": [
         {
           "name": "_Z21Torpedo_UpdateJobbiesP12GameObject_s",
@@ -55837,7 +55837,7 @@
     {
       "name": "legoapi/gizmo/object/gizbombgen.cpp.o",
       "source": "src/legoapi/gizmo/object/gizbombgen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizbombgen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizbombgen.o",
       "functions": [
         {
           "name": "_Z9Mine_KillP6PART_si",
@@ -55860,7 +55860,7 @@
     {
       "name": "legoapi/gizmo/object/gizbuildit.cpp.o",
       "source": "src/legoapi/gizmo/object/gizbuildit.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildit.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildit.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizbuildit.cpp",
@@ -55939,7 +55939,7 @@
     {
       "name": "legoapi/gizmo/object/gizforce.cpp.o",
       "source": "src/legoapi/gizmo/object/gizforce.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizforce.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizforce.o",
       "functions": [
         {
           "name": "_Z8EndForceP12GameObject_si",
@@ -55986,7 +55986,7 @@
     {
       "name": "legoapi/gizmo/object/gizminicut.cpp.o",
       "source": "src/legoapi/gizmo/object/gizminicut.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizminicut.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizminicut.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizminicut.cpp",
@@ -56009,7 +56009,7 @@
     {
       "name": "legoapi/gizmo/object/gizmoblowups.cpp.o",
       "source": "src/legoapi/gizmo/object/gizmoblowups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmoblowups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmoblowups.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmoblowups.cpp",
@@ -56328,7 +56328,7 @@
     {
       "name": "legoapi/gizmo/object/gizmopickup.cpp.o",
       "source": "src/legoapi/gizmo/object/gizmopickup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizmopickup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizmopickup.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizmopickup.cpp",
@@ -56447,7 +56447,7 @@
     {
       "name": "legoapi/gizmo/object/gizmopickups.cpp.o",
       "source": "src/legoapi/gizmo/object/gizmopickups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizmopickups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizmopickups.o",
       "functions": [
         {
           "name": "_Z17InDoubleScoreZoneP12GameObject_s",
@@ -56494,7 +56494,7 @@
     {
       "name": "legoapi/gizmo/object/gizobstacle.cpp.o",
       "source": "src/legoapi/gizmo/object/gizobstacle.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacle.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacle.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gizobstacle.cpp",
@@ -56517,7 +56517,7 @@
     {
       "name": "legoapi/gizmo/object/gizpanel.cpp.o",
       "source": "src/legoapi/gizmo/object/gizpanel.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizpanel.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizpanel.o",
       "functions": [
         {
           "name": "_Z14SetPanelLightsf",
@@ -56532,7 +56532,7 @@
     {
       "name": "legoapi/gizmo/object/gizportal.cpp.o",
       "source": "src/legoapi/gizmo/object/gizportal.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizportal.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizportal.o",
       "functions": [
         {
           "name": "_Z16PortalGameObjectP12GameObject_siisP8nugscn_s",
@@ -56555,7 +56555,7 @@
     {
       "name": "legoapi/gizmo/object/gizrandom.cpp.o",
       "source": "src/legoapi/gizmo/object/gizrandom.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizrandom.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizrandom.o",
       "functions": [
         {
           "name": "_Z10randyfloatv",
@@ -56586,7 +56586,7 @@
     {
       "name": "legoapi/gizmo/object/gizspecial.cpp.o",
       "source": "src/legoapi/gizmo/object/gizspecial.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizspecial.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/gizspecial.o",
       "functions": [
         {
           "name": "_Z19ReleaseAllTakeOversv",
@@ -56641,7 +56641,7 @@
     {
       "name": "legoapi/gizmo/object/giztimers.cpp.o",
       "source": "src/legoapi/gizmo/object/giztimers.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/giztimers.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztimers.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_giztimers.cpp",
@@ -56664,7 +56664,7 @@
     {
       "name": "legoapi/gizmo/object/giztorpedo.cpp.o",
       "source": "src/legoapi/gizmo/object/giztorpedo.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpedo.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpedo.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_giztorpedo.cpp",
@@ -56679,7 +56679,7 @@
     {
       "name": "legoapi/gizmos/door/door.cpp.o",
       "source": "src/legoapi/gizmos/door/door.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/door.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/door.o",
       "functions": [
         {
           "name": "_ZL17Door_GetMaxGizmosPv",
@@ -56750,7 +56750,7 @@
     {
       "name": "legoapi/gizmos/door/plugs.cpp.o",
       "source": "src/legoapi/gizmos/door/plugs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/plugs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/plugs.o",
       "functions": [
         {
           "name": "_ZL13Plug_ActivateP7GIZMO_si",
@@ -56917,7 +56917,7 @@
     {
       "name": "legoapi/gizmos/door/push.cpp.o",
       "source": "src/legoapi/gizmos/door/push.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/push.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/push.o",
       "functions": [
         {
           "name": "_ZL29PushBlocks_ReserveBufferSpacePv",
@@ -57060,7 +57060,7 @@
     {
       "name": "legoapi/gizmos/door/securitydoors.cpp.o",
       "source": "src/legoapi/gizmos/door/securitydoors.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoors.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoors.o",
       "functions": [
         {
           "name": "_ZL32SecurityDoors_ReserveBufferSpacePv",
@@ -57211,7 +57211,7 @@
     {
       "name": "legoapi/gizmos/door/spinner.cpp.o",
       "source": "src/legoapi/gizmos/door/spinner.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/spinner.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/spinner.o",
       "functions": [
         {
           "name": "_ZL20GizSpinner_PanelDrawPvS_f",
@@ -57410,7 +57410,7 @@
     {
       "name": "legoapi/gizmos/door/zipups.cpp.o",
       "source": "src/legoapi/gizmos/door/zipups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/zipups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/zipups.o",
       "functions": [
         {
           "name": "_ZL17ZipUp_ActivateRevP7GIZMO_sii",
@@ -57561,7 +57561,7 @@
     {
       "name": "legoapi/gizmos/fx/edgizshadowmachine.cpp.o",
       "source": "src/legoapi/gizmos/fx/edgizshadowmachine.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/edgizshadowmachine.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/edgizshadowmachine.o",
       "functions": [
         {
           "name": "_ZL24edGizShadow_GetMaxGizmosPv",
@@ -57640,7 +57640,7 @@
     {
       "name": "legoapi/gizmos/fx/gizmopickups.cpp.o",
       "source": "src/legoapi/gizmos/fx/gizmopickups.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizmopickups.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizmopickups.o",
       "functions": [
         {
           "name": "_ZL25GizmoPickups_GetMaxGizmosPv",
@@ -57823,7 +57823,7 @@
     {
       "name": "legoapi/gizmos/fx/guidelines.cpp.o",
       "source": "src/legoapi/gizmos/fx/guidelines.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/guidelines.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/guidelines.o",
       "functions": [
         {
           "name": "_ZL29GuideLines_ReserveBufferSpacePv",
@@ -57958,7 +57958,7 @@
     {
       "name": "legoapi/gizmos/object/gizbuildits.cpp.o",
       "source": "src/legoapi/gizmos/object/gizbuildits.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildits.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizbuildits.o",
       "functions": [
         {
           "name": "_ZL19GizmoBuildit_GetPosP7GIZMO_s",
@@ -58078,7 +58078,7 @@
           "address": 5043648,
           "offset": 4153680,
           "size": 6532,
-          "match_percent": 20.48465
+          "match_percent": 18.173977
         },
         {
           "name": "_ZL26GizmoBuildit_SetVisibilityP7GIZMO_si",
@@ -58133,7 +58133,7 @@
     {
       "name": "legoapi/gizmos/object/gizobstacles.cpp.o",
       "source": "src/legoapi/gizmos/object/gizobstacles.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacles.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizobstacles.o",
       "functions": [
         {
           "name": "_ZL20GizmoObstacle_GetPosP7GIZMO_s",
@@ -58364,7 +58364,7 @@
     {
       "name": "legoapi/gizmos/object/gizpanel.cpp.o",
       "source": "src/legoapi/gizmos/object/gizpanel.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizpanel.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizpanel.o",
       "functions": [
         {
           "name": "_ZL21GizPanel_GetMaxGizmosPv",
@@ -58523,7 +58523,7 @@
     {
       "name": "legoapi/gizmos/object/hatmachine.cpp.o",
       "source": "src/legoapi/gizmos/object/hatmachine.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/hatmachine.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/hatmachine.o",
       "functions": [
         {
           "name": "_ZL23HatMachine_GetMaxGizmosPv",
@@ -58674,7 +58674,7 @@
     {
       "name": "legoapi/gizmos/object/lever.cpp.o",
       "source": "src/legoapi/gizmos/object/lever.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/lever.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/lever.o",
       "functions": [
         {
           "name": "_ZL25Levers_ReserveBufferSpacePv",
@@ -58834,7 +58834,7 @@
           "address": 1901104,
           "offset": 1011136,
           "size": 2379,
-          "match_percent": 66.34156
+          "match_percent": 66.3107
         },
         {
           "name": "_ZN7LEVER_s22GetMechObjectInterfaceEv",
@@ -58905,7 +58905,7 @@
     {
       "name": "legoapi/gizmos/object/newblowup.cpp.o",
       "source": "src/legoapi/gizmos/object/newblowup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/newblowup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/newblowup.o",
       "functions": [
         {
           "name": "_ZL19Blowup_GetMaxGizmosPv",
@@ -59072,7 +59072,7 @@
     {
       "name": "legoapi/gizmos/object/technos.cpp.o",
       "source": "src/legoapi/gizmos/object/technos.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/technos.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/technos.o",
       "functions": [
         {
           "name": "_ZL26Technos_ReserveBufferSpacePv",
@@ -59247,7 +59247,7 @@
     {
       "name": "legoapi/gizmos/transport/gizportal.cpp.o",
       "source": "src/legoapi/gizmos/transport/gizportal.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizportal.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizportal.o",
       "functions": [
         {
           "name": "_Z17PortalDoors_ResetP11WORLDINFO_s",
@@ -59366,7 +59366,7 @@
     {
       "name": "legoapi/gizmos/transport/grapples.cpp.o",
       "source": "src/legoapi/gizmos/transport/grapples.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/grapples.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/grapples.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_grapples.cpp",
@@ -59549,7 +59549,7 @@
     {
       "name": "legoapi/gizmos/transport/ledges.cpp.o",
       "source": "src/legoapi/gizmos/transport/ledges.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ledges.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ledges.o",
       "functions": [
         {
           "name": "_ZL25Ledges_ReserveBufferSpacePv",
@@ -59700,7 +59700,7 @@
     {
       "name": "legoapi/gizmos/transport/teleport.cpp.o",
       "source": "src/legoapi/gizmos/transport/teleport.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/teleport.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/teleport.o",
       "functions": [
         {
           "name": "_ZL20Teleport_ActivateRevP7GIZMO_sii",
@@ -59779,7 +59779,7 @@
     {
       "name": "legoapi/gizmos/transport/tightropes.cpp.o",
       "source": "src/legoapi/gizmos/transport/tightropes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/tightropes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tightropes.o",
       "functions": [
         {
           "name": "_ZL29TightRopes_ReserveBufferSpacePv",
@@ -59970,7 +59970,7 @@
     {
       "name": "legoapi/gizmos/transport/tubes.cpp.o",
       "source": "src/legoapi/gizmos/transport/tubes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/0/tubes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/0/tubes.o",
       "functions": [
         {
           "name": "_ZL24Tubes_ReserveBufferSpacePv",
@@ -60137,7 +60137,7 @@
     {
       "name": "legoapi/gizmos/traps/attractos.cpp.o",
       "source": "src/legoapi/gizmos/traps/attractos.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/attractos.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/attractos.o",
       "functions": [
         {
           "name": "_ZL28Attractos_ReserveBufferSpacePv",
@@ -60288,7 +60288,7 @@
     {
       "name": "legoapi/gizmos/traps/gizbombgen.cpp.o",
       "source": "src/legoapi/gizmos/traps/gizbombgen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizbombgen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizbombgen.o",
       "functions": [
         {
           "name": "_ZL21GizmoBombGen_ActivateP7GIZMO_si",
@@ -60431,7 +60431,7 @@
     {
       "name": "legoapi/gizmos/traps/gizforce.cpp.o",
       "source": "src/legoapi/gizmos/traps/gizforce.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizforce.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizforce.o",
       "functions": [
         {
           "name": "_ZL17GizmoForce_GetPosP7GIZMO_s",
@@ -60694,7 +60694,7 @@
     {
       "name": "legoapi/gizmos/traps/giztorpmachine.cpp.o",
       "source": "src/legoapi/gizmos/traps/giztorpmachine.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpmachine.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztorpmachine.o",
       "functions": [
         {
           "name": "_Z13PartDraw_TorpP6PART_s",
@@ -60821,7 +60821,7 @@
     {
       "name": "legoapi/gizmos/traps/gizturrets.cpp.o",
       "source": "src/legoapi/gizmos/traps/gizturrets.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizturrets.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizturrets.o",
       "functions": [
         {
           "name": "_ZL20GizmoTurret_ActivateP7GIZMO_si",
@@ -61028,7 +61028,7 @@
     {
       "name": "legoapi/gizmos/traps/shards.cpp.o",
       "source": "src/legoapi/gizmos/traps/shards.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shards.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shards.o",
       "functions": [
         {
           "name": "_ZL25Shards_ReserveBufferSpacePv",
@@ -61179,7 +61179,7 @@
     {
       "name": "legoapi/gizmos/trigger/ai.cpp.o",
       "source": "src/legoapi/gizmos/trigger/ai.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ai.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ai.o",
       "functions": [
         {
           "name": "_ZL15AI_GetMaxGizmosPv",
@@ -61250,7 +61250,7 @@
     {
       "name": "legoapi/gizmos/trigger/gizaimessage.cpp.o",
       "source": "src/legoapi/gizmos/trigger/gizaimessage.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gizaimessage.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gizaimessage.o",
       "functions": [
         {
           "name": "_ZL25GizAIMessage_GetMaxGizmosPv",
@@ -61313,7 +61313,7 @@
     {
       "name": "legoapi/gizmos/trigger/gizrandom.cpp.o",
       "source": "src/legoapi/gizmos/trigger/gizrandom.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizrandom.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizrandom.o",
       "functions": [
         {
           "name": "_Z22GizRandom_GetMaxGizmosPv",
@@ -61392,7 +61392,7 @@
     {
       "name": "legoapi/gizmos/trigger/gizspecial.cpp.o",
       "source": "src/legoapi/gizmos/trigger/gizspecial.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizspecial.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/gizspecial.o",
       "functions": [
         {
           "name": "_ZL23GizSpecial_GetMaxGizmosPv",
@@ -61535,7 +61535,7 @@
     {
       "name": "legoapi/gizmos/trigger/giztimer.cpp.o",
       "source": "src/legoapi/gizmos/trigger/giztimer.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/giztimer.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/giztimer.o",
       "functions": [
         {
           "name": "_Z21GizTimer_GetMaxGizmosPv",
@@ -61630,7 +61630,7 @@
     {
       "name": "legoapi/gizmos/trigger/minicut.cpp.o",
       "source": "src/legoapi/gizmos/trigger/minicut.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/minicut.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/minicut.o",
       "functions": [
         {
           "name": "_ZL23GizMiniCut_GetGizmoNameP7GIZMO_s",
@@ -61741,7 +61741,7 @@
     {
       "name": "legoapi/gizmos/trigger/signals.cpp.o",
       "source": "src/legoapi/gizmos/trigger/signals.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/signals.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/signals.o",
       "functions": [
         {
           "name": "_ZL26Signals_ReserveBufferSpacePv",
@@ -61900,7 +61900,7 @@
     {
       "name": "legoapi/items/base/animpacket.cpp.o",
       "source": "src/legoapi/items/base/animpacket.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/animpacket.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/animpacket.o",
       "functions": [
         {
           "name": "ResetMiniAnimPacket",
@@ -61947,7 +61947,7 @@
     {
       "name": "legoapi/items/base/apiobject.cpp.o",
       "source": "src/legoapi/items/base/apiobject.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/apiobject.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/apiobject.o",
       "functions": [
         {
           "name": "WindShear",
@@ -62082,7 +62082,7 @@
     {
       "name": "legoapi/items/base/collection.cpp.o",
       "source": "src/legoapi/items/base/collection.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/collection.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/collection.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_collection.cpp",
@@ -62273,7 +62273,7 @@
     {
       "name": "legoapi/items/base/game_object.cpp.o",
       "source": "src/legoapi/items/base/game_object.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/game_object.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/game_object.o",
       "functions": [
         {
           "name": "_ZL19PauseGame_ExtraCodev",
@@ -62384,7 +62384,7 @@
     {
       "name": "legoapi/items/base/scene.cpp.o",
       "source": "src/legoapi/items/base/scene.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/scene.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/scene.o",
       "functions": [
         {
           "name": "_ZNK13SceneInstance13GetVisibilityEv",
@@ -62495,7 +62495,7 @@
     {
       "name": "legoapi/items/base/sceneobject.cpp.o",
       "source": "src/legoapi/items/base/sceneobject.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/sceneobject.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/sceneobject.o",
       "functions": [
         {
           "name": "_ZN17SceneObjectHelper10ClearLevelEi",
@@ -62654,7 +62654,7 @@
     {
       "name": "legoapi/items/collect/attracto.cpp.o",
       "source": "src/legoapi/items/collect/attracto.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/attracto.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/attracto.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_attracto.cpp",
@@ -62709,7 +62709,7 @@
     {
       "name": "legoapi/items/collect/batarang.cpp.o",
       "source": "src/legoapi/items/collect/batarang.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/batarang.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/batarang.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_batarang.cpp",
@@ -62836,7 +62836,7 @@
     {
       "name": "legoapi/items/collect/bolt.cpp.o",
       "source": "src/legoapi/items/collect/bolt.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/bolt.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/bolt.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_bolt.cpp",
@@ -62923,7 +62923,7 @@
     {
       "name": "legoapi/items/collect/bolts.cpp.o",
       "source": "src/legoapi/items/collect/bolts.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/bolts.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/bolts.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_bolts.cpp",
@@ -63298,13 +63298,13 @@
     {
       "name": "legoapi/items/collect/bolts_stubs.cpp.o",
       "source": "src/legoapi/items/collect/bolts_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/bolts_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/bolts_stubs.o",
       "functions": []
     },
     {
       "name": "legoapi/items/collect/detonator.cpp.o",
       "source": "src/legoapi/items/collect/detonator.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/detonator.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/detonator.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_detonator.cpp",
@@ -63367,7 +63367,7 @@
     {
       "name": "legoapi/items/collect/minikits.cpp.o",
       "source": "src/legoapi/items/collect/minikits.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/minikits.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/minikits.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_minikits.cpp",
@@ -63582,7 +63582,7 @@
     {
       "name": "legoapi/items/collect/shard.cpp.o",
       "source": "src/legoapi/items/collect/shard.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shard.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shard.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shard.cpp",
@@ -63621,7 +63621,7 @@
     {
       "name": "legoapi/items/collect/thermaldetonators.cpp.o",
       "source": "src/legoapi/items/collect/thermaldetonators.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/thermaldetonators.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/thermaldetonators.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_thermaldetonators.cpp",
@@ -63700,7 +63700,7 @@
     {
       "name": "legoapi/items/collect/torpedo.cpp.o",
       "source": "src/legoapi/items/collect/torpedo.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/torpedo.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/torpedo.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_torpedo.cpp",
@@ -63779,7 +63779,7 @@
     {
       "name": "legoapi/items/fx/explosions.cpp.o",
       "source": "src/legoapi/items/fx/explosions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/explosions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/explosions.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_explosions.cpp",
@@ -63834,7 +63834,7 @@
     {
       "name": "legoapi/items/fx/pulses.cpp.o",
       "source": "src/legoapi/items/fx/pulses.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/pulses.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/pulses.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_pulses.cpp",
@@ -63881,7 +63881,7 @@
     {
       "name": "legoapi/items/fx/ripples.cpp.o",
       "source": "src/legoapi/items/fx/ripples.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ripples.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ripples.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_ripples.cpp",
@@ -64040,7 +64040,7 @@
     {
       "name": "legoapi/items/objects/cable.cpp.o",
       "source": "src/legoapi/items/objects/cable.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/cable.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/cable.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_cable.cpp",
@@ -64111,7 +64111,7 @@
     {
       "name": "legoapi/items/objects/gameobjects.cpp.o",
       "source": "src/legoapi/items/objects/gameobjects.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameobjects.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameobjects.o",
       "functions": [
         {
           "name": "_ZL27Tag_FindGameObject_TRANSFERP12GameObject_s",
@@ -64143,7 +64143,7 @@
           "address": 1079344,
           "offset": 189376,
           "size": 3212,
-          "match_percent": 7.633083
+          "match_percent": 7.476692
         },
         {
           "name": "_ZL20LEGO_AllGoldBricksFnv",
@@ -64231,7 +64231,7 @@
           "address": 1266080,
           "offset": 376112,
           "size": 10082,
-          "match_percent": 29.025106
+          "match_percent": 28.619139
         },
         {
           "name": "_Z14KillGameObjectP12GameObject_sii",
@@ -64239,7 +64239,7 @@
           "address": 1282256,
           "offset": 392288,
           "size": 5214,
-          "match_percent": 6.951598
+          "match_percent": 5.07306
         },
         {
           "name": "_Z16TargetGameObjectP12GameObject_sP7nuvec_sS2_ffjiii",
@@ -64279,7 +64279,7 @@
           "address": 1455728,
           "offset": 565760,
           "size": 8481,
-          "match_percent": 44.078632
+          "match_percent": 43.437576
         },
         {
           "name": "_ZL18LevelCharacterNameh",
@@ -64551,7 +64551,7 @@
           "address": 1560992,
           "offset": 671024,
           "size": 14477,
-          "match_percent": 24.413433
+          "match_percent": 21.739584
         },
         {
           "name": "_Z18AddDynamicCreatureiP7nuvec_siPcP12AIPATHINFO_sP9AIGROUP_siP11nugspline_sS0_ii",
@@ -67062,7 +67062,7 @@
     {
       "name": "legoapi/items/objects/grabber.cpp.o",
       "source": "src/legoapi/items/objects/grabber.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/grabber.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/grabber.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_grabber.cpp",
@@ -67085,7 +67085,7 @@
     {
       "name": "legoapi/items/objects/objectsall.cpp.o",
       "source": "src/legoapi/items/objects/objectsall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/objectsall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/objectsall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_objectsall.cpp",
@@ -67220,7 +67220,7 @@
     {
       "name": "legoapi/items/objects/placeable.cpp.o",
       "source": "src/legoapi/items/objects/placeable.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/placeable.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/placeable.o",
       "functions": [
         {
           "name": "_ZNK9Placeable18GetInitialPositionEv",
@@ -67435,13 +67435,13 @@
     {
       "name": "legoapi/items/objects/plugs.cpp.o",
       "source": "src/legoapi/items/objects/plugs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/plugs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/plugs.o",
       "functions": []
     },
     {
       "name": "legoapi/items/objects/things.cpp.o",
       "source": "src/legoapi/items/objects/things.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/things.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/things.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_things.cpp",
@@ -67480,7 +67480,7 @@
     {
       "name": "legoapi/items/objects/traffic.cpp.o",
       "source": "src/legoapi/items/objects/traffic.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/traffic.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/traffic.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_traffic.cpp",
@@ -67575,7 +67575,7 @@
     {
       "name": "legoapi/menus/core/gamehint.cpp.o",
       "source": "src/legoapi/menus/core/gamehint.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamehint.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamehint.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamehint.cpp",
@@ -67862,7 +67862,7 @@
     {
       "name": "legoapi/menus/core/gamemessages.cpp.o",
       "source": "src/legoapi/menus/core/gamemessages.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamemessages.cpp",
@@ -67957,7 +67957,7 @@
     {
       "name": "legoapi/menus/core/gamemessages_stubs.cpp.o",
       "source": "src/legoapi/menus/core/gamemessages_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamemessages_stubs.o",
       "functions": [
         {
           "name": "_Z9numeminitv",
@@ -67972,7 +67972,7 @@
     {
       "name": "legoapi/menus/core/hint.cpp.o",
       "source": "src/legoapi/menus/core/hint.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/hint.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hint.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_hint.cpp",
@@ -68195,7 +68195,7 @@
     {
       "name": "legoapi/menus/core/hud.cpp.o",
       "source": "src/legoapi/menus/core/hud.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/hud.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hud.o",
       "functions": [
         {
           "name": "_ZL13DrawCoinTotalii",
@@ -68282,7 +68282,7 @@
     {
       "name": "legoapi/menus/core/panel.cpp.o",
       "source": "src/legoapi/menus/core/panel.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/panel.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/panel.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_panel.cpp",
@@ -68337,7 +68337,7 @@
     {
       "name": "legoapi/menus/core/text.cpp.o",
       "source": "src/legoapi/menus/core/text.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/text.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/text.o",
       "functions": [
         {
           "name": "_Z18Text_DecodeButtonsPcS_",
@@ -68489,7 +68489,7 @@
           "address": 4371936,
           "offset": 3481968,
           "size": 3480,
-          "match_percent": 11.325707
+          "match_percent": 8.519515
         },
         {
           "name": "Text3D",
@@ -68521,7 +68521,7 @@
           "address": 4381664,
           "offset": 3491696,
           "size": 4373,
-          "match_percent": 18.753813
+          "match_percent": 13.139434
         },
         {
           "name": "SmartText",
@@ -68840,7 +68840,7 @@
     {
       "name": "legoapi/menus/screens/arcade.cpp.o",
       "source": "src/legoapi/menus/screens/arcade.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/arcade.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/arcade.o",
       "functions": [
         {
           "name": "_Z24Arcade_BothPlayersActivev",
@@ -68943,7 +68943,7 @@
     {
       "name": "legoapi/menus/screens/credits.cpp.o",
       "source": "src/legoapi/menus/screens/credits.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/credits.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/credits.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_credits.cpp",
@@ -68998,7 +68998,7 @@
     {
       "name": "legoapi/menus/screens/customise.cpp.o",
       "source": "src/legoapi/menus/screens/customise.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/customise.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/customise.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_customise.cpp",
@@ -69285,7 +69285,7 @@
     {
       "name": "legoapi/menus/screens/gamemenuall.cpp.o",
       "source": "src/legoapi/menus/screens/gamemenuall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamemenuall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamemenuall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamemenuall.cpp",
@@ -70740,7 +70740,7 @@
     {
       "name": "legoapi/menus/screens/gamestatus_lsw.cpp.o",
       "source": "src/legoapi/menus/screens/gamestatus_lsw.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamestatus_lsw.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamestatus_lsw.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gamestatus_lsw.cpp",
@@ -71179,7 +71179,7 @@
     {
       "name": "legoapi/menus/screens/menus.cpp.o",
       "source": "src/legoapi/menus/screens/menus.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/menus.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/menus.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_menus.cpp",
@@ -71282,7 +71282,7 @@
     {
       "name": "legoapi/menus/screens/movies.cpp.o",
       "source": "src/legoapi/menus/screens/movies.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/movies.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/movies.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_movies.cpp",
@@ -71321,7 +71321,7 @@
     {
       "name": "legoapi/menus/screens/shop.cpp.o",
       "source": "src/legoapi/menus/screens/shop.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shop.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shop.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shop.cpp",
@@ -71440,7 +71440,7 @@
     {
       "name": "legoapi/menus/screens/store.cpp.o",
       "source": "src/legoapi/menus/screens/store.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/store.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/store.o",
       "functions": [
         {
           "name": "_Z24StoreProgressAICharacterP16LEVEL_PROGRESS_s",
@@ -71631,7 +71631,7 @@
     {
       "name": "legoapi/misc/androidbatman.cpp.o",
       "source": "src/legoapi/misc/androidbatman.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/androidbatman.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/androidbatman.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_androidbatman.cpp",
@@ -71694,7 +71694,7 @@
     {
       "name": "legoapi/misc/buffers.cpp.o",
       "source": "src/legoapi/misc/buffers.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/buffers.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/buffers.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_buffers.cpp",
@@ -71725,7 +71725,7 @@
     {
       "name": "legoapi/misc/gamelib_utilities.cpp.o",
       "source": "src/legoapi/misc/gamelib_utilities.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_utilities.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gamelib_utilities.o",
       "functions": [
         {
           "name": "VuQuatSlerpFast",
@@ -71844,13 +71844,13 @@
     {
       "name": "legoapi/misc/legoapi_helpers.cpp.o",
       "source": "src/legoapi/misc/legoapi_helpers.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_helpers.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_helpers.o",
       "functions": []
     },
     {
       "name": "legoapi/misc/legoapi_misc.cpp.o",
       "source": "src/legoapi/misc/legoapi_misc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc.o",
       "functions": [
         {
           "name": "_Z21ClearLastSafeTakeOverP12GameObject_s",
@@ -71977,7 +71977,7 @@
     {
       "name": "legoapi/misc/legoapi_misc_c.c.o",
       "source": "src/legoapi/misc/legoapi_misc_c.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc_c.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_misc_c.o",
       "functions": [
         {
           "name": "tpentPropOnEnter",
@@ -72000,7 +72000,7 @@
     {
       "name": "legoapi/misc/legoapi_status.cpp.o",
       "source": "src/legoapi/misc/legoapi_status.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_status.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/legoapi_status.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_legoapi_status.cpp",
@@ -72047,7 +72047,7 @@
     {
       "name": "legoapi/misc/memory.cpp.o",
       "source": "src/legoapi/misc/memory.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/memory.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/memory.o",
       "functions": [
         {
           "name": "DebAlloc",
@@ -72134,7 +72134,7 @@
     {
       "name": "legoapi/misc/stream.cpp.o",
       "source": "src/legoapi/misc/stream.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/stream.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/stream.o",
       "functions": [
         {
           "name": "StreamRead",
@@ -72173,7 +72173,7 @@
     {
       "name": "legoapi/misc/supportall.cpp.o",
       "source": "src/legoapi/misc/supportall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/supportall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/supportall.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_supportall.cpp",
@@ -72636,7 +72636,7 @@
     {
       "name": "legoapi/misc/supportall_stubs.cpp.o",
       "source": "src/legoapi/misc/supportall_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/supportall_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/supportall_stubs.o",
       "functions": [
         {
           "name": "_Z14bgprocIsFrozenv",
@@ -72699,7 +72699,7 @@
     {
       "name": "legoapi/misc/tm.cpp.o",
       "source": "src/legoapi/misc/tm.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/tm.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tm.o",
       "functions": [
         {
           "name": "_ZN8TMClient11AllocHandleEv",
@@ -72818,7 +72818,7 @@
     {
       "name": "legoapi/misc/utilities.cpp.o",
       "source": "src/legoapi/misc/utilities.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/utilities.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/utilities.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_utilities.cpp",
@@ -73257,7 +73257,7 @@
     {
       "name": "legoapi/props/doors/door.cpp.o",
       "source": "src/legoapi/props/doors/door.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/door.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/door.o",
       "functions": [
         {
           "name": "_ZL23GoThroughDoor_ExtraCodeP11WORLDINFO_sP6DOOR_s",
@@ -73296,7 +73296,7 @@
     {
       "name": "legoapi/props/doors/doors.cpp.o",
       "source": "src/legoapi/props/doors/doors.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/doors.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/doors.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_doors.cpp",
@@ -73375,7 +73375,7 @@
     {
       "name": "legoapi/props/doors/securitydoor.cpp.o",
       "source": "src/legoapi/props/doors/securitydoor.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoor.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/securitydoor.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_securitydoor.cpp",
@@ -73414,7 +73414,7 @@
     {
       "name": "legoapi/props/objects/guidelines.cpp.o",
       "source": "src/legoapi/props/objects/guidelines.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/guidelines.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/guidelines.o",
       "functions": [
         {
           "name": "_Z21GuideLine_FindNearestP7nuvec_sP11WORLDINFO_sPiPf",
@@ -73429,7 +73429,7 @@
     {
       "name": "legoapi/props/objects/hatmachine.cpp.o",
       "source": "src/legoapi/props/objects/hatmachine.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/hatmachine.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/hatmachine.o",
       "functions": [
         {
           "name": "_Z19Hat_GetAbsTargetPosP12HATMACHINE_sP7nuvec_s",
@@ -73444,7 +73444,7 @@
     {
       "name": "legoapi/props/objects/ledge.cpp.o",
       "source": "src/legoapi/props/objects/ledge.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/ledge.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/ledge.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_ledge.cpp",
@@ -73491,13 +73491,13 @@
     {
       "name": "legoapi/props/objects/lever.cpp.o",
       "source": "src/legoapi/props/objects/lever.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/lever.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/lever.o",
       "functions": []
     },
     {
       "name": "legoapi/props/objects/signal.cpp.o",
       "source": "src/legoapi/props/objects/signal.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/signal.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/signal.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_signal.cpp",
@@ -73544,7 +73544,7 @@
     {
       "name": "legoapi/props/objects/techno.cpp.o",
       "source": "src/legoapi/props/objects/techno.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/techno.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/techno.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_techno.cpp",
@@ -73615,13 +73615,13 @@
     {
       "name": "legoapi/props/objects/teleport.cpp.o",
       "source": "src/legoapi/props/objects/teleport.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/teleport.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/teleport.o",
       "functions": []
     },
     {
       "name": "legoapi/props/objects/tightrope.cpp.o",
       "source": "src/legoapi/props/objects/tightrope.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/tightrope.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/tightrope.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_tightrope.cpp",
@@ -73636,7 +73636,7 @@
     {
       "name": "legoapi/props/objects/tubes.cpp.o",
       "source": "src/legoapi/props/objects/tubes.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/1/tubes.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/1/tubes.o",
       "functions": [
         {
           "name": "_Z15TractorBeamCodeP12GameObject_s",
@@ -73651,7 +73651,7 @@
     {
       "name": "legoapi/props/objects/zipup.cpp.o",
       "source": "src/legoapi/props/objects/zipup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/zipup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/zipup.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_zipup.cpp",
@@ -73706,7 +73706,7 @@
     {
       "name": "legoapi/props/system/socksysall.cpp.o",
       "source": "src/legoapi/props/system/socksysall.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall.o",
       "functions": [
         {
           "name": "_Z28GoingForwardsAlongNarrowSockP12GameObject_s",
@@ -73770,7 +73770,7 @@
           "address": 3921467,
           "offset": 3031499,
           "size": 3611,
-          "match_percent": 47.026203
+          "match_percent": 29.213018
         },
         {
           "name": "SockSysPointAlongSpline",
@@ -73969,7 +73969,7 @@
     {
       "name": "legoapi/props/system/socksysall_stubs.cpp.o",
       "source": "src/legoapi/props/system/socksysall_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/socksysall_stubs.o",
       "functions": [
         {
           "name": "_Z21TurnOffAllSocksExceptP7SOCKSYSi",
@@ -73992,7 +73992,7 @@
     {
       "name": "legoapi/render/core/gameliball.cpp.o",
       "source": "src/legoapi/render/core/gameliball.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/gameliball.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/gameliball.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_gameliball.cpp",
@@ -74031,7 +74031,7 @@
     {
       "name": "legoapi/render/core/nugraph.cpp.o",
       "source": "src/legoapi/render/core/nugraph.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/nugraph.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/nugraph.o",
       "functions": [
         {
           "name": "nugraphInit",
@@ -74254,7 +74254,7 @@
     {
       "name": "legoapi/render/core/render.cpp.o",
       "source": "src/legoapi/render/core/render.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/render.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/render.o",
       "functions": [
         {
           "name": "_ZL26DrawWeapon_SetSabreObjectsP12GameObject_siiiiPiS1_",
@@ -74270,7 +74270,7 @@
           "address": 1071808,
           "offset": 181840,
           "size": 7204,
-          "match_percent": 6.705883
+          "match_percent": 6.157617
         },
         {
           "name": "_ZL24DrawCharacterAttachmentsP12GameObject_sP7numtx_s",
@@ -74294,7 +74294,7 @@
           "address": 1095536,
           "offset": 205568,
           "size": 12138,
-          "match_percent": 36.956745
+          "match_percent": 36.401283
         },
         {
           "name": "_Z19DrawGameObjectsDrawi",
@@ -74454,7 +74454,7 @@
           "address": 1316752,
           "offset": 426784,
           "size": 12845,
-          "match_percent": 11.4881
+          "match_percent": 6.296451
         },
         {
           "name": "_Z19DrawForceGlowSpriteP7nuvec_sfifP12GameObject_s",
@@ -75405,7 +75405,7 @@
     {
       "name": "legoapi/render/core/render_stubs.cpp.o",
       "source": "src/legoapi/render/core/render_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/render_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/render_stubs.o",
       "functions": [
         {
           "name": "CreateDmaParticleSet",
@@ -75445,7 +75445,7 @@
           "address": 2724356,
           "offset": 1834388,
           "size": 5724,
-          "match_percent": 40.023384
+          "match_percent": 32.84663
         },
         {
           "name": "DisplayListDebugPS",
@@ -75780,7 +75780,7 @@
     {
       "name": "legoapi/render/core/rtl.cpp.o",
       "source": "src/legoapi/render/core/rtl.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/rtl.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/rtl.o",
       "functions": [
         {
           "name": "_ZL10ElOverlapsP9nuqtdim_sS0_",
@@ -76076,7 +76076,7 @@
           "address": 3851389,
           "offset": 2961421,
           "size": 4488,
-          "match_percent": 16.8888
+          "match_percent": 9.8632
         },
         {
           "name": "_ZL13rtlCalcShadowP10rtlidata_s",
@@ -76275,7 +76275,7 @@
     {
       "name": "legoapi/render/core/screen.cpp.o",
       "source": "src/legoapi/render/core/screen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/screen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/screen.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_screen.cpp",
@@ -76426,7 +76426,7 @@
     {
       "name": "legoapi/render/core/shader.cpp.o",
       "source": "src/legoapi/render/core/shader.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shader.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shader.o",
       "functions": [
         {
           "name": "NuShaderManagerSetfv",
@@ -76625,7 +76625,7 @@
     {
       "name": "legoapi/render/core/terrain.cpp.o",
       "source": "src/legoapi/render/core/terrain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/terrain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/terrain.o",
       "functions": [
         {
           "name": "_ZL17TerrainKillPlayerP12GameObject_siP7nuvec_s.isra.4",
@@ -76641,7 +76641,7 @@
           "address": 1058464,
           "offset": 168496,
           "size": 12323,
-          "match_percent": 14.295684
+          "match_percent": 9.021379
         },
         {
           "name": "DebrisSetThinningLevel",
@@ -76801,7 +76801,7 @@
           "address": 3641264,
           "offset": 2751296,
           "size": 6787,
-          "match_percent": 22.103987
+          "match_percent": 16.046793
         },
         {
           "name": "_Z7NewCastP7nuvec_sff",
@@ -76833,7 +76833,7 @@
           "address": 3665328,
           "offset": 2775360,
           "size": 8732,
-          "match_percent": 13.344371
+          "match_percent": 2.593267
         },
         {
           "name": "_Z15FullDeflectTestP7nuvec_sS0_S0_",
@@ -76913,7 +76913,7 @@
           "address": 3680432,
           "offset": 2790464,
           "size": 5421,
-          "match_percent": 15.159935
+          "match_percent": 6.215671
         },
         {
           "name": "_Z15StorePlatImpactv",
@@ -77096,7 +77096,7 @@
     {
       "name": "legoapi/render/core/terrain_runtime.cpp.o",
       "source": "src/legoapi/render/core/terrain_runtime.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_runtime.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_runtime.o",
       "functions": [
         {
           "name": "DebrisSetTimeIncrement",
@@ -77119,7 +77119,7 @@
     {
       "name": "legoapi/render/core/terrain_stubs.cpp.o",
       "source": "src/legoapi/render/core/terrain_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/terrain_stubs.o",
       "functions": [
         {
           "name": "DebrisReserveTrashableSpace",
@@ -78358,7 +78358,7 @@
     {
       "name": "legoapi/render/fx/edsplines.cpp.o",
       "source": "src/legoapi/render/fx/edsplines.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/edsplines.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/edsplines.o",
       "functions": [
         {
           "name": "_Z15CalcSplinePointP14flightspline_sP6_vuv_sf",
@@ -78509,7 +78509,7 @@
     {
       "name": "legoapi/render/fx/game_deb.cpp.o",
       "source": "src/legoapi/render/fx/game_deb.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/game_deb.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/game_deb.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_game_deb.cpp",
@@ -78692,7 +78692,7 @@
     {
       "name": "legoapi/render/fx/game_debris_api.cpp.o",
       "source": "src/legoapi/render/fx/game_debris_api.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/game_debris_api.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/game_debris_api.o",
       "functions": [
         {
           "name": "FindGameDebris",
@@ -78763,7 +78763,7 @@
     {
       "name": "legoapi/render/fx/inflate.cpp.o",
       "source": "src/legoapi/render/fx/inflate.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/inflate.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/inflate.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_inflate.cpp",
@@ -78826,7 +78826,7 @@
     {
       "name": "legoapi/render/fx/particles.cpp.o",
       "source": "src/legoapi/render/fx/particles.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/particles.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/particles.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_particles.cpp",
@@ -78905,7 +78905,7 @@
     {
       "name": "legoapi/render/fx/parts.cpp.o",
       "source": "src/legoapi/render/fx/parts.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/parts.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/parts.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_parts.cpp",
@@ -79241,7 +79241,7 @@
           "address": 3477408,
           "offset": 2587440,
           "size": 6320,
-          "match_percent": 4.973473
+          "match_percent": 1.245177
         },
         {
           "name": "AddVariableShotDebrisEffectMtx4",
@@ -79960,7 +79960,7 @@
     {
       "name": "legoapi/render/fx/parts_control.cpp.o",
       "source": "src/legoapi/render/fx/parts_control.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/parts_control.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/parts_control.o",
       "functions": [
         {
           "name": "_Z11Parts_StartP11WORLDINFO_s",
@@ -79983,7 +79983,7 @@
     {
       "name": "legoapi/render/fx/parts_stubs.cpp.o",
       "source": "src/legoapi/render/fx/parts_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/parts_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/parts_stubs.o",
       "functions": [
         {
           "name": "ParticlesPerFrame",
@@ -80014,7 +80014,7 @@
     {
       "name": "legoapi/render/light/fade.cpp.o",
       "source": "src/legoapi/render/light/fade.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/fade.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/fade.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_fade.cpp",
@@ -80397,7 +80397,7 @@
     {
       "name": "legoapi/render/light/faders.cpp.o",
       "source": "src/legoapi/render/light/faders.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/faders.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/faders.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_faders.cpp",
@@ -80436,7 +80436,7 @@
     {
       "name": "legoapi/render/light/lighting.cpp.o",
       "source": "src/legoapi/render/light/lighting.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/lighting.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lighting.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_lighting.cpp",
@@ -80579,7 +80579,7 @@
     {
       "name": "legoapi/render/light/occlusion.cpp.o",
       "source": "src/legoapi/render/light/occlusion.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/occlusion.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/occlusion.o",
       "functions": [
         {
           "name": "_ZN11OccluderSet11SortByDepthEPKvS1_",
@@ -80826,7 +80826,7 @@
     {
       "name": "legoapi/render/light/shadow.cpp.o",
       "source": "src/legoapi/render/light/shadow.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/shadow.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/shadow.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_shadow.cpp",
@@ -80937,7 +80937,7 @@
     {
       "name": "legoapi/render/light/surfaces.cpp.o",
       "source": "src/legoapi/render/light/surfaces.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/surfaces.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/surfaces.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_surfaces.cpp",
@@ -81056,7 +81056,7 @@
     {
       "name": "legoapi/world/area.cpp.o",
       "source": "src/legoapi/world/area.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/area.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/area.o",
       "functions": [
         {
           "name": "_ZL12LoadAreaDataP12bgprocinfo_s",
@@ -81072,7 +81072,7 @@
           "address": 1213776,
           "offset": 323808,
           "size": 5414,
-          "match_percent": 35.945168
+          "match_percent": 37.067844
         },
         {
           "name": "_Z10FixUpAreasv",
@@ -81143,7 +81143,7 @@
     {
       "name": "legoapi/world/areas.cpp.o",
       "source": "src/legoapi/world/areas.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/areas.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/areas.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_areas.cpp",
@@ -81207,7 +81207,7 @@
           "address": 4683968,
           "offset": 3794000,
           "size": 5236,
-          "match_percent": 17.38191
+          "match_percent": 12.506701
         },
         {
           "name": "_Z25Areas_CompleteAllBuildUpsP10AREASAVE_s",
@@ -81222,7 +81222,7 @@
     {
       "name": "legoapi/world/boss.cpp.o",
       "source": "src/legoapi/world/boss.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/boss.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/boss.o",
       "functions": [
         {
           "name": "_Z8KillBossiif",
@@ -81261,7 +81261,7 @@
     {
       "name": "legoapi/world/level.cpp.o",
       "source": "src/legoapi/world/level.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/level.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/level.o",
       "functions": [
         {
           "name": "_Z18ClearLevelProgressiP11WORLDINFO_s",
@@ -81436,7 +81436,7 @@
     {
       "name": "legoapi/world/levelconfig.cpp.o",
       "source": "src/legoapi/world/levelconfig.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/levelconfig.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levelconfig.o",
       "functions": [
         {
           "name": "_ZL15LC_BL_wind_sizeP8nufpar_s",
@@ -82275,7 +82275,7 @@
     {
       "name": "legoapi/world/leveldata.cpp.o",
       "source": "src/legoapi/world/leveldata.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/leveldata.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/leveldata.o",
       "functions": [
         {
           "name": "_Z12ClearLevDatav",
@@ -82306,7 +82306,7 @@
     {
       "name": "legoapi/world/levelobjects.cpp.o",
       "source": "src/legoapi/world/levelobjects.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/levelobjects.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levelobjects.o",
       "functions": [
         {
           "name": "_Z24LevelObjects_InitForGameP11LEVELOBJECTP9variptr_uS2_ii",
@@ -82337,7 +82337,7 @@
     {
       "name": "legoapi/world/levels.cpp.o",
       "source": "src/legoapi/world/levels.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/levels.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levels.o",
       "functions": [
         {
           "name": "_Z15getSpawnLocatorfPc",
@@ -82384,7 +82384,7 @@
     {
       "name": "legoapi/world/levels/episode.cpp.o",
       "source": "src/legoapi/world/levels/episode.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episode.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episode.o",
       "functions": [
         {
           "name": "_Z32Episodes_CompleteAllSuperStoriesv",
@@ -82575,7 +82575,7 @@
     {
       "name": "legoapi/world/levels/episodeI.cpp.o",
       "source": "src/legoapi/world/levels/episodeI.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeI.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeI.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeI.cpp",
@@ -83078,7 +83078,7 @@
     {
       "name": "legoapi/world/levels/episodeII.cpp.o",
       "source": "src/legoapi/world/levels/episodeII.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeII.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeII.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeII.cpp",
@@ -83533,7 +83533,7 @@
     {
       "name": "legoapi/world/levels/episodeIII.cpp.o",
       "source": "src/legoapi/world/levels/episodeIII.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIII.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIII.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeIII.cpp",
@@ -83924,7 +83924,7 @@
     {
       "name": "legoapi/world/levels/episodeIV.cpp.o",
       "source": "src/legoapi/world/levels/episodeIV.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIV.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeIV.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeIV.cpp",
@@ -84275,7 +84275,7 @@
     {
       "name": "legoapi/world/levels/episodeV.cpp.o",
       "source": "src/legoapi/world/levels/episodeV.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeV.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeV.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeV.cpp",
@@ -84882,7 +84882,7 @@
     {
       "name": "legoapi/world/levels/episodeVI.cpp.o",
       "source": "src/legoapi/world/levels/episodeVI.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/episodeVI.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/episodeVI.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_episodeVI.cpp",
@@ -85193,7 +85193,7 @@
     {
       "name": "legoapi/world/levels/hub.cpp.o",
       "source": "src/legoapi/world/levels/hub.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/hub.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/hub.o",
       "functions": [
         {
           "name": "_ZL21Hub_DrawBonusModeMenuif",
@@ -85425,7 +85425,7 @@
           "address": 1766272,
           "offset": 876304,
           "size": 10455,
-          "match_percent": 36.80809
+          "match_percent": 32.989147
         },
         {
           "name": "_Z14Hub_ResetPanelv",
@@ -85465,7 +85465,7 @@
           "address": 1795760,
           "offset": 905792,
           "size": 9054,
-          "match_percent": 9.532188
+          "match_percent": 1.845017
         },
         {
           "name": "_Z17Hub_MakeModelListv",
@@ -85496,7 +85496,7 @@
     {
       "name": "legoapi/world/levels/lego_city.cpp.o",
       "source": "src/legoapi/world/levels/lego_city.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/lego_city.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/lego_city.o",
       "functions": [
         {
           "name": "_Z13LegoCity_InitP11WORLDINFO_s",
@@ -85527,7 +85527,7 @@
     {
       "name": "legoapi/world/levels/new_town.cpp.o",
       "source": "src/legoapi/world/levels/new_town.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/new_town.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/new_town.o",
       "functions": [
         {
           "name": "_Z12NewTown_InitP11WORLDINFO_s",
@@ -85558,7 +85558,7 @@
     {
       "name": "legoapi/world/levels/podsprint.cpp.o",
       "source": "src/legoapi/world/levels/podsprint.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/podsprint.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/podsprint.o",
       "functions": [
         {
           "name": "_Z17PodSprint_RollMulP12GameObject_s",
@@ -85573,7 +85573,7 @@
     {
       "name": "legoapi/world/levels/senate.cpp.o",
       "source": "src/legoapi/world/levels/senate.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/senate.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/senate.o",
       "functions": [
         {
           "name": "_Z12SenateA_InitP11WORLDINFO_s",
@@ -85588,7 +85588,7 @@
     {
       "name": "legoapi/world/levelstreaming.cpp.o",
       "source": "src/legoapi/world/levelstreaming.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/levelstreaming.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/levelstreaming.o",
       "functions": [
         {
           "name": "_Z32LevelProgress_ReserveBufferSpaceP9variptr_uS_",
@@ -85619,7 +85619,7 @@
     {
       "name": "legoapi/world/mission.cpp.o",
       "source": "src/legoapi/world/mission.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/mission.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/mission.o",
       "functions": [
         {
           "name": "_Z18Missions_ConfigurePcP9variptr_uS1_P13MISSIONSAVE_s",
@@ -85634,7 +85634,7 @@
     {
       "name": "legoapi/world/missions.cpp.o",
       "source": "src/legoapi/world/missions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/missions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/missions.o",
       "functions": [
         {
           "name": "_Z13InitChallengei",
@@ -85737,7 +85737,7 @@
     {
       "name": "legoapi/world/world.cpp.o",
       "source": "src/legoapi/world/world.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legoapi/world.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legoapi/world.o",
       "functions": [
         {
           "name": "_Z21MakeFreePlayModelListiiiii",
@@ -85745,7 +85745,7 @@
           "address": 1201040,
           "offset": 311072,
           "size": 3556,
-          "match_percent": 9.693764
+          "match_percent": 8.906459
         },
         {
           "name": "_Z18StoreSceneProgressP8nugscn_sP15SCENEPROGRESS_si",
@@ -85912,7 +85912,7 @@
     {
       "name": "legogame/game.cpp.o",
       "source": "src/legogame/game.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legogame/game.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legogame/game.o",
       "functions": [
         {
           "name": "_Z12MakeSaveHashv",
@@ -86215,7 +86215,7 @@
     {
       "name": "legogame/startup.cpp.o",
       "source": "src/legogame/startup.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legogame/startup.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legogame/startup.o",
       "functions": [
         {
           "name": "_ZL12LoadPermDataP12bgprocinfo_s",
@@ -86254,7 +86254,7 @@
     {
       "name": "legogame/target_android.cpp.o",
       "source": "src/legogame/target_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_legogame/target_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_legogame/target_android.o",
       "functions": [
         {
           "name": "_ZL29SystemDidBecomeActiveCallbackPK20NuPhoneOSMessageData",
@@ -86293,7 +86293,7 @@
     {
       "name": "nu2api/nu3d/NuRenderDevice.cpp.o",
       "source": "src/nu2api/nu3d/NuRenderDevice.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuRenderDevice.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuRenderDevice.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_NuRenderDevice.cpp",
@@ -86604,7 +86604,7 @@
     {
       "name": "nu2api/nu3d/android/gles_extensions.cpp.o",
       "source": "src/nu2api/nu3d/android/gles_extensions.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/gles_extensions.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/gles_extensions.o",
       "functions": [
         {
           "name": "_Z21NuGLES2ExtensionsInitv",
@@ -86635,7 +86635,7 @@
     {
       "name": "nu2api/nu3d/android/nugscn_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nugscn_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn_android.o",
       "functions": [
         {
           "name": "_ZL5NuMaxii",
@@ -86690,7 +86690,7 @@
     {
       "name": "nu2api/nu3d/android/nuiosdl_gl.cpp.o",
       "source": "src/nu2api/nu3d/android/nuiosdl_gl.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuiosdl_gl.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuiosdl_gl.o",
       "functions": [
         {
           "name": "NuRenderContextSetWorld",
@@ -86937,7 +86937,7 @@
     {
       "name": "nu2api/nu3d/android/numtl_android.cpp.o",
       "source": "src/nu2api/nu3d/android/numtl_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numtl_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numtl_android.o",
       "functions": [
         {
           "name": "_Z13NuMtlCreatePSP7numtl_si",
@@ -86968,7 +86968,7 @@
     {
       "name": "nu2api/nu3d/android/nuposteffect_plain.cpp.o",
       "source": "src/nu2api/nu3d/android/nuposteffect_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuposteffect_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuposteffect_plain.o",
       "functions": [
         {
           "name": "NuFramebufferSwapBuffers",
@@ -87159,7 +87159,7 @@
     {
       "name": "nu2api/nu3d/android/nuptl_flush.cpp.o",
       "source": "src/nu2api/nu3d/android/nuptl_flush.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuptl_flush.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuptl_flush.o",
       "functions": [
         {
           "name": "NuInitDebrisRenderer",
@@ -87190,7 +87190,7 @@
     {
       "name": "nu2api/nu3d/android/nuqfnt_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nuqfnt_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt_android.o",
       "functions": [
         {
           "name": "NuQFntSetMtxRS",
@@ -87213,7 +87213,7 @@
     {
       "name": "nu2api/nu3d/android/nurain_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nurain_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurain_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurain_android.o",
       "functions": [
         {
           "name": "NuRainProcess",
@@ -87236,7 +87236,7 @@
     {
       "name": "nu2api/nu3d/android/nurenderthread.cpp.o",
       "source": "src/nu2api/nu3d/android/nurenderthread.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurenderthread.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurenderthread.o",
       "functions": [
         {
           "name": "NuRenderThreadCreate",
@@ -87331,7 +87331,7 @@
     {
       "name": "nu2api/nu3d/android/nurndr_android.c.o",
       "source": "src/nu2api/nu3d/android/nurndr_android.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_android.o",
       "functions": [
         {
           "name": "NuRndrPspDraw",
@@ -87402,7 +87402,7 @@
     {
       "name": "nu2api/nu3d/android/nurndr_android_cpp.cpp.o",
       "source": "src/nu2api/nu3d/android/nurndr_android_cpp.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_android_cpp.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_android_cpp.o",
       "functions": [
         {
           "name": "_Z11NuRndrFlushi",
@@ -87417,7 +87417,7 @@
     {
       "name": "nu2api/nu3d/android/nutex_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nutex_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_android.o",
       "functions": [
         {
           "name": "_Z15NuTexReadBitmapPc",
@@ -87560,7 +87560,7 @@
     {
       "name": "nu2api/nu3d/android/nutex_ios_ex.cpp.o",
       "source": "src/nu2api/nu3d/android/nutex_ios_ex.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_ios_ex.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutex_ios_ex.o",
       "functions": [
         {
           "name": "_Z20GetTextureFormatInfo11NUTEXFORMATRjS0_",
@@ -87687,7 +87687,7 @@
     {
       "name": "nu2api/nu3d/android/nutimebar_plain.cpp.o",
       "source": "src/nu2api/nu3d/android/nutimebar_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutimebar_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutimebar_plain.o",
       "functions": [
         {
           "name": "NuTimeBarCreateSetEx",
@@ -87750,7 +87750,7 @@
     {
       "name": "nu2api/nu3d/android/nuvertexformat_android.cpp.o",
       "source": "src/nu2api/nu3d/android/nuvertexformat_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvertexformat_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvertexformat_android.o",
       "functions": [
         {
           "name": "NuGetVertexDeclaration",
@@ -87765,7 +87765,7 @@
     {
       "name": "nu2api/nu3d/generic/nucamera_gen.cpp.o",
       "source": "src/nu2api/nu3d/generic/nucamera_gen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera_gen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera_gen.o",
       "functions": [
         {
           "name": "NuCameraCreate",
@@ -87980,7 +87980,7 @@
     {
       "name": "nu2api/nu3d/nubridge.cpp.o",
       "source": "src/nu2api/nu3d/nubridge.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nubridge.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nubridge.o",
       "functions": [
         {
           "name": "_Z13NuBridgeAllocv",
@@ -88051,7 +88051,7 @@
     {
       "name": "nu2api/nu3d/nucamera.cpp.o",
       "source": "src/nu2api/nu3d/nucamera.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucamera.o",
       "functions": [
         {
           "name": "NuCameraSetProjectionMtx",
@@ -88090,7 +88090,7 @@
     {
       "name": "nu2api/nu3d/nucamvu0.c.o",
       "source": "src/nu2api/nu3d/nucamvu0.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucamvu0.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucamvu0.o",
       "functions": [
         {
           "name": "NuCameraInitClipTestVU0",
@@ -88105,7 +88105,7 @@
     {
       "name": "nu2api/nu3d/nudlist.cpp.o",
       "source": "src/nu2api/nu3d/nudlist.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist.o",
       "functions": [
         {
           "name": "NuDisplayListDrawItems",
@@ -88264,7 +88264,7 @@
     {
       "name": "nu2api/nu3d/nudlist_stubs.cpp.o",
       "source": "src/nu2api/nu3d/nudlist_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudlist_stubs.o",
       "functions": [
         {
           "name": "NuDisplayListCheckBuffer",
@@ -88351,7 +88351,7 @@
     {
       "name": "nu2api/nu3d/nufadeobj.cpp.o",
       "source": "src/nu2api/nu3d/nufadeobj.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufadeobj.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufadeobj.o",
       "functions": [
         {
           "name": "NuFadeObjInit",
@@ -88470,7 +88470,7 @@
     {
       "name": "nu2api/nu3d/nufogstate.cpp.o",
       "source": "src/nu2api/nu3d/nufogstate.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufogstate.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufogstate.o",
       "functions": [
         {
           "name": "NuRndrStateUpdateCameraState",
@@ -88517,7 +88517,7 @@
     {
       "name": "nu2api/nu3d/nugscn.cpp.o",
       "source": "src/nu2api/nu3d/nugscn.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nugscn.o",
       "functions": [
         {
           "name": "_Z18NuGScnMtlLayerMaskP8nugscn_sh",
@@ -88596,7 +88596,7 @@
     {
       "name": "nu2api/nu3d/numtl.cpp.o",
       "source": "src/nu2api/nu3d/numtl.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numtl.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numtl.o",
       "functions": [
         {
           "name": "_Z13NuMtlUpdatePSP7numtl_s",
@@ -88739,7 +88739,7 @@
     {
       "name": "nu2api/nu3d/nuocclusion.cpp.o",
       "source": "src/nu2api/nu3d/nuocclusion.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuocclusion.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuocclusion.o",
       "functions": [
         {
           "name": "NuOcclusionManagerBeginFrame",
@@ -88754,7 +88754,7 @@
     {
       "name": "nu2api/nu3d/nuportal.cpp.o",
       "source": "src/nu2api/nu3d/nuportal.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuportal.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuportal.o",
       "functions": [
         {
           "name": "_ZL19transposeClipPlanesP10NUFRUSTRUM",
@@ -88865,7 +88865,7 @@
     {
       "name": "nu2api/nu3d/nuprim.cpp.o",
       "source": "src/nu2api/nu3d/nuprim.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuprim.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuprim.o",
       "functions": [
         {
           "name": "NuPrimPushCoordSystem",
@@ -88904,7 +88904,7 @@
     {
       "name": "nu2api/nu3d/nuqfnt.cpp.o",
       "source": "src/nu2api/nu3d/nuqfnt.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuqfnt.o",
       "functions": [
         {
           "name": "NuQFntPushPrintMode",
@@ -89167,7 +89167,7 @@
     {
       "name": "nu2api/nu3d/nurndr.cpp.o",
       "source": "src/nu2api/nu3d/nurndr.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr.o",
       "functions": [
         {
           "name": "_Z23NuRndrParticleSetRepeatP7nuvec_s",
@@ -89302,7 +89302,7 @@
     {
       "name": "nu2api/nu3d/nurndr_alloc.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_alloc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_alloc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_alloc.o",
       "functions": [
         {
           "name": "NuRndrCreateBlendShapeDeformerWeightsArray",
@@ -89325,7 +89325,7 @@
     {
       "name": "nu2api/nu3d/nurndr_grad.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_grad.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_grad.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_grad.o",
       "functions": [
         {
           "name": "NuRndrGradClear",
@@ -89340,7 +89340,7 @@
     {
       "name": "nu2api/nu3d/nurndr_noops.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_noops.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_noops.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_noops.o",
       "functions": [
         {
           "name": "NuRndrSetBlendData",
@@ -89411,7 +89411,7 @@
     {
       "name": "nu2api/nu3d/nurndr_plain.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_plain.o",
       "functions": [
         {
           "name": "NuRndrShadPolys",
@@ -90162,7 +90162,7 @@
     {
       "name": "nu2api/nu3d/nurndr_shadow.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_shadow.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_shadow.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_shadow.o",
       "functions": [
         {
           "name": "NuRndrAddShadow",
@@ -90177,7 +90177,7 @@
     {
       "name": "nu2api/nu3d/nurndr_specular.cpp.o",
       "source": "src/nu2api/nu3d/nurndr_specular.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_specular.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurndr_specular.o",
       "functions": [
         {
           "name": "NuRndrSetSpecularLightPS",
@@ -90192,7 +90192,7 @@
     {
       "name": "nu2api/nu3d/nuscreen.cpp.o",
       "source": "src/nu2api/nu3d/nuscreen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuscreen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuscreen.o",
       "functions": [
         {
           "name": "_ZN8NuScreen6CreateEv",
@@ -90263,7 +90263,7 @@
     {
       "name": "nu2api/nu3d/nushader.cpp.o",
       "source": "src/nu2api/nu3d/nushader.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nushader.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nushader.o",
       "functions": [
         {
           "name": "_Z17LinkShaderProgramj",
@@ -90542,7 +90542,7 @@
     {
       "name": "nu2api/nu3d/nushadermanager_plain.cpp.o",
       "source": "src/nu2api/nu3d/nushadermanager_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nushadermanager_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nushadermanager_plain.o",
       "functions": [
         {
           "name": "NuShaderManagerInit",
@@ -90645,7 +90645,7 @@
     {
       "name": "nu2api/nu3d/nuspecial.cpp.o",
       "source": "src/nu2api/nu3d/nuspecial.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuspecial.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuspecial.o",
       "functions": [
         {
           "name": "NuSpecialTestAnim",
@@ -90884,7 +90884,7 @@
     {
       "name": "nu2api/nu3d/nuspline.c.o",
       "source": "src/nu2api/nu3d/nuspline.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuspline.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuspline.o",
       "functions": [
         {
           "name": "NuSplineFind",
@@ -90931,7 +90931,7 @@
     {
       "name": "nu2api/nu3d/nutex.cpp.o",
       "source": "src/nu2api/nu3d/nutex.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutex.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutex.o",
       "functions": [
         {
           "name": "_Z30NuTexGetUnresolvedTextureTIDPSv",
@@ -91138,13 +91138,13 @@
     {
       "name": "nu2api/nu3d/nutexanm.c.o",
       "source": "src/nu2api/nu3d/nutexanm.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanm.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanm.o",
       "functions": []
     },
     {
       "name": "nu2api/nu3d/nuvport.cpp.o",
       "source": "src/nu2api/nu3d/nuvport.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport.o",
       "functions": [
         {
           "name": "NuVpInit",
@@ -91351,7 +91351,7 @@
     {
       "name": "nu2api/nu3d/nuvport_ps2.cpp.o",
       "source": "src/nu2api/nu3d/nuvport_ps2.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport_ps2.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvport_ps2.o",
       "functions": [
         {
           "name": "_Z16NuPs2GetViewportP12nuviewport_s",
@@ -91398,7 +91398,7 @@
     {
       "name": "nu2api/nu3d/nuwater.cpp.o",
       "source": "src/nu2api/nu3d/nuwater.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater.o",
       "functions": [
         {
           "name": "NuWaterReset",
@@ -91413,7 +91413,7 @@
     {
       "name": "nu2api/nu3d/nuwater_speed.cpp.o",
       "source": "src/nu2api/nu3d/nuwater_speed.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater_speed.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuwater_speed.o",
       "functions": [
         {
           "name": "NuWaterSpeed",
@@ -91428,7 +91428,7 @@
     {
       "name": "nu2api/nuandroid/ios_graphics.cpp.o",
       "source": "src/nu2api/nuandroid/ios_graphics.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/ios_graphics.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/ios_graphics.o",
       "functions": [
         {
           "name": "NuIOS_ShouldUseMSAA",
@@ -91547,7 +91547,7 @@
     {
       "name": "nu2api/nuandroid/ios_graphics_stubs.cpp.o",
       "source": "src/nu2api/nuandroid/ios_graphics_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/ios_graphics_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/ios_graphics_stubs.o",
       "functions": [
         {
           "name": "_Z17NuCheckGLErrorsFLPKci",
@@ -91562,7 +91562,7 @@
     {
       "name": "nu2api/nuandroid/nuphoneos.cpp.o",
       "source": "src/nu2api/nuandroid/nuphoneos.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuphoneos.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuphoneos.o",
       "functions": [
         {
           "name": "NuPhoneOSRegisterEventCallback",
@@ -91577,7 +91577,7 @@
     {
       "name": "nu2api/nucore/NuInputDevice.cpp.o",
       "source": "src/nu2api/nucore/NuInputDevice.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice.o",
       "functions": [
         {
           "name": "_ZN18NuTouchInputButton6UpdateEPK16NuInputTouchData",
@@ -91720,7 +91720,7 @@
     {
       "name": "nu2api/nucore/NuInputManager.cpp.o",
       "source": "src/nu2api/nucore/NuInputManager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputManager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputManager.o",
       "functions": [
         {
           "name": "_ZN14NuInputManagerD1Ev",
@@ -91799,7 +91799,7 @@
     {
       "name": "nu2api/nucore/NuMemoryManager.cpp.o",
       "source": "src/nu2api/nucore/NuMemoryManager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryManager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryManager.o",
       "functions": [
         {
           "name": "_ZN15NuMemoryManager13IErrorHandler11HandleErrorEPS_NS_9ErrorCodeEPKc",
@@ -92150,7 +92150,7 @@
     {
       "name": "nu2api/nucore/NuMemoryPool.cpp.o",
       "source": "src/nu2api/nucore/NuMemoryPool.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryPool.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuMemoryPool.o",
       "functions": [
         {
           "name": "_ZN12NuMemoryPool14InterlockedAddEPVjj",
@@ -92181,7 +92181,7 @@
     {
       "name": "nu2api/nucore/NuThreadManager.cpp.o",
       "source": "src/nu2api/nucore/NuThreadManager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuThreadManager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuThreadManager.o",
       "functions": [
         {
           "name": "_ZN15NuThreadManagerC1Ev",
@@ -92252,7 +92252,7 @@
     {
       "name": "nu2api/nucore/NuVirtualTouchDevice.cpp.o",
       "source": "src/nu2api/nucore/NuVirtualTouchDevice.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuVirtualTouchDevice.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuVirtualTouchDevice.o",
       "functions": [
         {
           "name": "_ZN20NuVirtualTouchDeviceC1Ej",
@@ -92363,7 +92363,7 @@
     {
       "name": "nu2api/nucore/android/NuInputDevice_android.cpp.o",
       "source": "src/nu2api/nucore/android/NuInputDevice_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuInputDevice_android.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_NuInputDevice_android.cpp",
@@ -92562,7 +92562,7 @@
     {
       "name": "nu2api/nucore/android/NuThread_android.cpp.o",
       "source": "src/nu2api/nucore/android/NuThread_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuThread_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuThread_android.o",
       "functions": [
         {
           "name": "_ZN8NuThreadD1Ev",
@@ -92761,7 +92761,7 @@
     {
       "name": "nu2api/nucore/android/bgproc_android.cpp.o",
       "source": "src/nu2api/nucore/android/bgproc_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/bgproc_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/bgproc_android.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_bgproc_android.cpp",
@@ -92816,7 +92816,7 @@
     {
       "name": "nu2api/nucore/android/nuapi_android.cpp.o",
       "source": "src/nu2api/nucore/android/nuapi_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuapi_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuapi_android.o",
       "functions": [
         {
           "name": "_Z14NuXboxLiveInitv",
@@ -92879,7 +92879,7 @@
     {
       "name": "nu2api/nucore/android/numemory_android.cpp.o",
       "source": "src/nu2api/nucore/android/numemory_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numemory_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numemory_android.o",
       "functions": [
         {
           "name": "_ZN10NuMemoryPS16Mem2EventHandler12AllocatePageEP15NuMemoryManagerjj",
@@ -92950,7 +92950,7 @@
     {
       "name": "nu2api/nucore/android/nupad_android.cpp.o",
       "source": "src/nu2api/nucore/android/nupad_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_android.o",
       "functions": [
         {
           "name": "_Z18NuPadGetDeadzonePSP7nupad_s",
@@ -93021,7 +93021,7 @@
     {
       "name": "nu2api/nucore/android/nupostresource_create.cpp.o",
       "source": "src/nu2api/nucore/android/nupostresource_create.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nupostresource_create.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nupostresource_create.o",
       "functions": [
         {
           "name": "NuFramebufferCreate",
@@ -93044,7 +93044,7 @@
     {
       "name": "nu2api/nucore/android/nutime_android.cpp.o",
       "source": "src/nu2api/nucore/android/nutime_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutime_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutime_android.o",
       "functions": [
         {
           "name": "_Z29NuGetCurrentTimeMilisecondsPSv",
@@ -93091,7 +93091,7 @@
     {
       "name": "nu2api/nucore/android/nuvideo_android.cpp.o",
       "source": "src/nu2api/nucore/android/nuvideo_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo_android.o",
       "functions": [
         {
           "name": "_Z20NuVideoSetSwapModePS16NUVIDEO_SWAPMODE",
@@ -93122,7 +93122,7 @@
     {
       "name": "nu2api/nucore/android/stubs_android.cpp.o",
       "source": "src/nu2api/nucore/android/stubs_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/stubs_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/stubs_android.o",
       "functions": [
         {
           "name": "NuRndrAddShadowPrims",
@@ -93385,7 +93385,7 @@
     {
       "name": "nu2api/nucore/android/stubvideo.cpp.o",
       "source": "src/nu2api/nucore/android/stubvideo.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/stubvideo.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/stubvideo.o",
       "functions": [
         {
           "name": "_Z18ScreenDumpAviBeginiPciiiiffi",
@@ -93416,7 +93416,7 @@
     {
       "name": "nu2api/nucore/deflate.cpp.o",
       "source": "src/nu2api/nucore/deflate.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/deflate.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/deflate.o",
       "functions": [
         {
           "name": "_Z16BuildHuffmanTreeP10DEFHUFFMANPhi",
@@ -93487,7 +93487,7 @@
     {
       "name": "nu2api/nucore/hashedkey.cpp.o",
       "source": "src/nu2api/nucore/hashedkey.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/hashedkey.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/hashedkey.o",
       "functions": [
         {
           "name": "_ZN9HashedKey3SetEPKc",
@@ -93502,7 +93502,7 @@
     {
       "name": "nu2api/nucore/implode.cpp.o",
       "source": "src/nu2api/nucore/implode.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/implode.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/implode.o",
       "functions": [
         {
           "name": "_ZL7__sputciP7__sFILE",
@@ -93669,7 +93669,7 @@
     {
       "name": "nu2api/nucore/nu2api_nucore_misc.cpp.o",
       "source": "src/nu2api/nucore/nu2api_nucore_misc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc.o",
       "functions": [
         {
           "name": "_Z30NuIOS_CateInAppPurchaseManagerv",
@@ -94460,7 +94460,7 @@
     {
       "name": "nu2api/nucore/nu2api_nucore_misc_stubs.cpp.o",
       "source": "src/nu2api/nucore/nu2api_nucore_misc_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nucore_misc_stubs.o",
       "functions": [
         {
           "name": "_Z19NuTerminateHardwarev",
@@ -94523,7 +94523,7 @@
     {
       "name": "nu2api/nucore/nuanim.cpp.o",
       "source": "src/nu2api/nucore/nuanim.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuanim.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuanim.o",
       "functions": [
         {
           "name": "NuAnimEndFrame",
@@ -94546,7 +94546,7 @@
     {
       "name": "nu2api/nucore/nuapi.c.o",
       "source": "src/nu2api/nucore/nuapi.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/0/nuapi.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nuapi.o",
       "functions": [
         {
           "name": "NuPrimReset",
@@ -94569,7 +94569,7 @@
     {
       "name": "nu2api/nucore/nuapi.cpp.o",
       "source": "src/nu2api/nucore/nuapi.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/1/nuapi.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nuapi.o",
       "functions": [
         {
           "name": "_Z9NuAPIInitv",
@@ -94616,7 +94616,7 @@
     {
       "name": "nu2api/nucore/nucore.cpp.o",
       "source": "src/nu2api/nucore/nucore.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucore.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucore.o",
       "functions": [
         {
           "name": "_ZN6NuCore19GetApplicationStateEv",
@@ -95887,7 +95887,7 @@
     {
       "name": "nu2api/nucore/nucore_frame.cpp.o",
       "source": "src/nu2api/nucore/nucore_frame.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucore_frame.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucore_frame.o",
       "functions": [
         {
           "name": "NuFrameSetMinDelay",
@@ -95910,7 +95910,7 @@
     {
       "name": "nu2api/nucore/nucore_plain.cpp.o",
       "source": "src/nu2api/nucore/nucore_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nucore_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nucore_plain.o",
       "functions": [
         {
           "name": "NuIOS_DeallocateSystemRenderbuffer",
@@ -99573,7 +99573,7 @@
     {
       "name": "nu2api/nucore/nuerror.cpp.o",
       "source": "src/nu2api/nucore/nuerror.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuerror.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuerror.o",
       "functions": [
         {
           "name": "NuSetErrorMsgHandler",
@@ -99716,7 +99716,7 @@
     {
       "name": "nu2api/nucore/nuheap.cpp.o",
       "source": "src/nu2api/nucore/nuheap.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuheap.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuheap.o",
       "functions": [
         {
           "name": "_ZL20NuHeapBlock_SetInUseP11NUHEAPBLOCKj",
@@ -99939,7 +99939,7 @@
     {
       "name": "nu2api/nucore/nuhgobj.cpp.o",
       "source": "src/nu2api/nucore/nuhgobj.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuhgobj.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuhgobj.o",
       "functions": [
         {
           "name": "NuHGobjGetLayerIndex",
@@ -99954,7 +99954,7 @@
     {
       "name": "nu2api/nucore/nuios_metrics.cpp.o",
       "source": "src/nu2api/nucore/nuios_metrics.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuios_metrics.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuios_metrics.o",
       "functions": [
         {
           "name": "NuIOS_GetAspectRatio",
@@ -99977,7 +99977,7 @@
     {
       "name": "nu2api/nucore/nukeyboard.cpp.o",
       "source": "src/nu2api/nucore/nukeyboard.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nukeyboard.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nukeyboard.o",
       "functions": [
         {
           "name": "NuKeyboardRead",
@@ -100048,7 +100048,7 @@
     {
       "name": "nu2api/nucore/nulanguage.cpp.o",
       "source": "src/nu2api/nucore/nulanguage.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nulanguage.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nulanguage.o",
       "functions": [
         {
           "name": "NuLanguageGet",
@@ -100071,7 +100071,7 @@
     {
       "name": "nu2api/nucore/nulist.cpp.o",
       "source": "src/nu2api/nucore/nulist.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nulist.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nulist.o",
       "functions": [
         {
           "name": "NuLinkedListCheck",
@@ -100158,7 +100158,7 @@
     {
       "name": "nu2api/nucore/nulst.cpp.o",
       "source": "src/nu2api/nucore/nulst.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nulst.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nulst.o",
       "functions": [
         {
           "name": "NuLstCreate",
@@ -100309,7 +100309,7 @@
     {
       "name": "nu2api/nucore/numem.c.o",
       "source": "src/nu2api/nucore/numem.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/0/numem.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/numem.o",
       "functions": [
         {
           "name": "NuMemSet128",
@@ -100324,7 +100324,7 @@
     {
       "name": "nu2api/nucore/numem.cpp.o",
       "source": "src/nu2api/nucore/numem.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/1/numem.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/numem.o",
       "functions": [
         {
           "name": "NuMemSetHeap",
@@ -100523,7 +100523,7 @@
     {
       "name": "nu2api/nucore/numemhigh.cpp.o",
       "source": "src/nu2api/nucore/numemhigh.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numemhigh.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numemhigh.o",
       "functions": [
         {
           "name": "NuAllocHighInit",
@@ -100554,7 +100554,7 @@
     {
       "name": "nu2api/nucore/numemory.cpp.o",
       "source": "src/nu2api/nucore/numemory.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numemory.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numemory.o",
       "functions": [
         {
           "name": "_ZN8NuMemory21FixedPoolEventHandler12AllocatePageEP12NuMemoryPooljjPKc",
@@ -101193,7 +101193,7 @@
     {
       "name": "nu2api/nucore/numouse.cpp.o",
       "source": "src/nu2api/nucore/numouse.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numouse.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numouse.o",
       "functions": [
         {
           "name": "NuMouseRead",
@@ -101312,7 +101312,7 @@
     {
       "name": "nu2api/nucore/nunew.cpp.o",
       "source": "src/nu2api/nucore/nunew.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nunew.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nunew.o",
       "functions": [
         {
           "name": "_Znwj",
@@ -101415,7 +101415,7 @@
     {
       "name": "nu2api/nucore/nuonline.cpp.o",
       "source": "src/nu2api/nucore/nuonline.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuonline.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuonline.o",
       "functions": [
         {
           "name": "NuOnlineAchievementAchieved",
@@ -101558,7 +101558,7 @@
     {
       "name": "nu2api/nucore/nupad.cpp.o",
       "source": "src/nu2api/nucore/nupad.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nupad.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nupad.o",
       "functions": [
         {
           "name": "NuPadUseCorrectDeadZoning",
@@ -101837,7 +101837,7 @@
     {
       "name": "nu2api/nucore/nupad_interface.cpp.o",
       "source": "src/nu2api/nucore/nupad_interface.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_interface.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nupad_interface.o",
       "functions": [
         {
           "name": "_ZN15NuInputDevicePS15GetIdentifierPSEj",
@@ -102268,7 +102268,7 @@
     {
       "name": "nu2api/nucore/nuptrblock.cpp.o",
       "source": "src/nu2api/nucore/nuptrblock.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuptrblock.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuptrblock.o",
       "functions": [
         {
           "name": "NuPtrBlockFix",
@@ -102283,7 +102283,7 @@
     {
       "name": "nu2api/nucore/nurdpf.cpp.o",
       "source": "src/nu2api/nucore/nurdpf.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpf.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpf.o",
       "functions": [
         {
           "name": "_ZL10isnumordotc",
@@ -102346,7 +102346,7 @@
     {
       "name": "nu2api/nucore/nurdpi.cpp.o",
       "source": "src/nu2api/nucore/nurdpi.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpi.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurdpi.o",
       "functions": [
         {
           "name": "_ZL5isnumc",
@@ -102425,7 +102425,7 @@
     {
       "name": "nu2api/nucore/nustring.cpp.o",
       "source": "src/nu2api/nucore/nustring.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nustring.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nustring.o",
       "functions": [
         {
           "name": "_Z9NuStrCatCPcc",
@@ -102464,7 +102464,7 @@
     {
       "name": "nu2api/nucore/nustring_c.cpp.o",
       "source": "src/nu2api/nucore/nustring_c.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nustring_c.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nustring_c.o",
       "functions": [
         {
           "name": "NuStrCpyWC",
@@ -103135,7 +103135,7 @@
     {
       "name": "nu2api/nucore/nutexanim.cpp.o",
       "source": "src/nu2api/nucore/nutexanim.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanim.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutexanim.o",
       "functions": [
         {
           "name": "_ZL7pftaRetP8nufpar_s",
@@ -103534,7 +103534,7 @@
     {
       "name": "nu2api/nucore/nuthread.cpp.o",
       "source": "src/nu2api/nucore/nuthread.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuthread.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuthread.o",
       "functions": [
         {
           "name": "_ZN8NuThread12SetDebugNameEPKc",
@@ -103669,7 +103669,7 @@
     {
       "name": "nu2api/nucore/nutime.cpp.o",
       "source": "src/nu2api/nucore/nutime.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutime.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutime.o",
       "functions": [
         {
           "name": "NuTimeWait",
@@ -103748,7 +103748,7 @@
     {
       "name": "nu2api/nucore/nuvideo.cpp.o",
       "source": "src/nu2api/nucore/nuvideo.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvideo.o",
       "functions": [
         {
           "name": "NuVideoGetMode",
@@ -103827,7 +103827,7 @@
     {
       "name": "nu2api/nucore/pending_stubs.cpp.o",
       "source": "src/nu2api/nucore/pending_stubs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/pending_stubs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/pending_stubs.o",
       "functions": [
         {
           "name": "_Z26DisplayListLinkDynamicMtlsv",
@@ -103938,7 +103938,7 @@
     {
       "name": "nu2api/nufile/NuFileDeviceAndroidAPK.cpp.o",
       "source": "src/nu2api/nufile/NuFileDeviceAndroidAPK.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileDeviceAndroidAPK.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileDeviceAndroidAPK.o",
       "functions": [
         {
           "name": "_ZN22NuFileDeviceAndroidAPKD1Ev",
@@ -103993,13 +103993,13 @@
     {
       "name": "nu2api/nufile/android/NuFileAndroidDeviceAPK.cpp.o",
       "source": "src/nu2api/nufile/android/NuFileAndroidDeviceAPK.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileAndroidDeviceAPK.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/NuFileAndroidDeviceAPK.o",
       "functions": []
     },
     {
       "name": "nu2api/nufile/android/nufile_android.cpp.o",
       "source": "src/nu2api/nufile/android/nufile_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile_android.o",
       "functions": [
         {
           "name": "NuGetFileHandlePS",
@@ -104134,7 +104134,7 @@
     {
       "name": "nu2api/nufile/nudatfile.cpp.o",
       "source": "src/nu2api/nufile/nudatfile.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nudatfile.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudatfile.o",
       "functions": [
         {
           "name": "_Z12NuDatCalcPosP10nudathdr_si",
@@ -104181,7 +104181,7 @@
     {
       "name": "nu2api/nufile/nufile.c.o",
       "source": "src/nu2api/nufile/nufile.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nufile.o",
       "functions": [
         {
           "name": "DEVHOST_Interrogate",
@@ -104300,7 +104300,7 @@
     {
       "name": "nu2api/nufile/nufile.cpp.o",
       "source": "src/nu2api/nufile/nufile.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile.o",
       "functions": [
         {
           "name": "_ZL19NuDatFileDecodeInitv",
@@ -104971,7 +104971,7 @@
     {
       "name": "nu2api/nufile/nufile_android.cpp.o",
       "source": "src/nu2api/nufile/nufile_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nufile_android.o",
       "functions": [
         {
           "name": "_ZN16NuFileAndroidAPK4InitEv",
@@ -105010,7 +105010,7 @@
     {
       "name": "nu2api/nufile/nufile_plain.cpp.o",
       "source": "src/nu2api/nufile/nufile_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufile_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufile_plain.o",
       "functions": [
         {
           "name": "NuFileSwapEndianOnWrite",
@@ -105321,7 +105321,7 @@
     {
       "name": "nu2api/nufile/nufilebase.cpp.o",
       "source": "src/nu2api/nufile/nufilebase.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufilebase.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufilebase.o",
       "functions": [
         {
           "name": "_ZN10NuFileBaseD1Ev",
@@ -105520,7 +105520,7 @@
     {
       "name": "nu2api/nufile/nufiledevice.cpp.o",
       "source": "src/nu2api/nufile/nufiledevice.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufiledevice.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufiledevice.o",
       "functions": [
         {
           "name": "_ZN12NuFileDeviceD1Ev",
@@ -105703,7 +105703,7 @@
     {
       "name": "nu2api/nufile/nufilepak.cpp.o",
       "source": "src/nu2api/nufile/nufilepak.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufilepak.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufilepak.o",
       "functions": [
         {
           "name": "_ZL8GetItemsP16nufilepakhdrv2_s",
@@ -105806,7 +105806,7 @@
     {
       "name": "nu2api/nufile/nufpar.cpp.o",
       "source": "src/nu2api/nufile/nufpar.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufpar.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufpar.o",
       "functions": [
         {
           "name": "_Z9NuGetCharP8nufpar_s",
@@ -106165,7 +106165,7 @@
     {
       "name": "nu2api/nufile/numc.cpp.o",
       "source": "src/nu2api/nufile/numc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numc.o",
       "functions": [
         {
           "name": "_Z16NuMcFileOpenSizei",
@@ -106300,7 +106300,7 @@
     {
       "name": "nu2api/nufile/tmclient.cpp.o",
       "source": "src/nu2api/nufile/tmclient.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/tmclient.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/tmclient.o",
       "functions": [
         {
           "name": "_ZN8TMClientC1EiPc",
@@ -106323,7 +106323,7 @@
     {
       "name": "nu2api/numath/nufloat.c.o",
       "source": "src/nu2api/numath/nufloat.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nufloat.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nufloat.o",
       "functions": [
         {
           "name": "NuFsel",
@@ -106466,7 +106466,7 @@
     {
       "name": "nu2api/numath/numaths.cpp.o",
       "source": "src/nu2api/numath/numaths.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numaths.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numaths.o",
       "functions": [
         {
           "name": "_Z21NuVecClipTestPointVU0P7nuvec_sP7numtx_s",
@@ -106497,7 +106497,7 @@
     {
       "name": "nu2api/numath/numaths_plain.cpp.o",
       "source": "src/nu2api/numath/numaths_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numaths_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numaths_plain.o",
       "functions": [
         {
           "name": "NuVecMtxRotateValX",
@@ -107064,7 +107064,7 @@
     {
       "name": "nu2api/numath/numtx.cpp.o",
       "source": "src/nu2api/numath/numtx.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numtx.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numtx.o",
       "functions": [
         {
           "name": "NuMtxSetZero",
@@ -107727,7 +107727,7 @@
     {
       "name": "nu2api/numath/nuplane.cpp.o",
       "source": "src/nu2api/numath/nuplane.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuplane.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuplane.o",
       "functions": [
         {
           "name": "NuPlnEqn",
@@ -107902,7 +107902,7 @@
     {
       "name": "nu2api/numath/nuquat.cpp.o",
       "source": "src/nu2api/numath/nuquat.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuquat.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuquat.o",
       "functions": [
         {
           "name": "_ZL16NuQTUnfixAddressP9nuqthdr_s",
@@ -108093,7 +108093,7 @@
     {
       "name": "nu2api/numath/nurand.cpp.o",
       "source": "src/nu2api/numath/nurand.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nurand.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nurand.o",
       "functions": [
         {
           "name": "NuRandSeed",
@@ -108172,7 +108172,7 @@
     {
       "name": "nu2api/numath/nutrig.c.o",
       "source": "src/nu2api/numath/nutrig.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/0/nutrig.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/0/nutrig.o",
       "functions": [
         {
           "name": "NuASin",
@@ -108219,7 +108219,7 @@
     {
       "name": "nu2api/numath/nutrig.cpp.o",
       "source": "src/nu2api/numath/nutrig.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/1/nutrig.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/1/nutrig.o",
       "functions": [
         {
           "name": "_ZL12NuSinApprox3i",
@@ -108354,7 +108354,7 @@
     {
       "name": "nu2api/numath/nutrig_gen.cpp.o",
       "source": "src/nu2api/numath/nutrig_gen.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nutrig_gen.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nutrig_gen.o",
       "functions": [
         {
           "name": "NuTrigInit",
@@ -108369,7 +108369,7 @@
     {
       "name": "nu2api/numath/nuvec.cpp.o",
       "source": "src/nu2api/numath/nuvec.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec.o",
       "functions": [
         {
           "name": "NuVecMtxTransform",
@@ -108704,7 +108704,7 @@
     {
       "name": "nu2api/numath/nuvec4.c.o",
       "source": "src/nu2api/numath/nuvec4.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec4.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuvec4.o",
       "functions": [
         {
           "name": "NuVec4Add",
@@ -108751,7 +108751,7 @@
     {
       "name": "nu2api/numath/vumath.c.o",
       "source": "src/nu2api/numath/vumath.c",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/vumath.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/vumath.o",
       "functions": [
         {
           "name": "VuQuatBlend",
@@ -108814,7 +108814,7 @@
     {
       "name": "nu2api/numusic/numusic.cpp.o",
       "source": "src/nu2api/numusic/numusic.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/numusic.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/numusic.o",
       "functions": [
         {
           "name": "_ZN7NuMusic18GlobalParseErrorFnEP8nufpar_s",
@@ -109581,7 +109581,7 @@
     {
       "name": "nu2api/numusic/sfx.cpp.o",
       "source": "src/nu2api/numusic/sfx.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/sfx.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/sfx.o",
       "functions": [
         {
           "name": "_ZL12fnAudioAudioP8nufpar_s",
@@ -109660,7 +109660,7 @@
     {
       "name": "nu2api/nuplatform/nudevicespecs.cpp.o",
       "source": "src/nu2api/nuplatform/nudevicespecs.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nudevicespecs.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nudevicespecs.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nudevicespecs.cpp",
@@ -109715,7 +109715,7 @@
     {
       "name": "nu2api/nuplatform/nuplatform.cpp.o",
       "source": "src/nu2api/nuplatform/nuplatform.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nuplatform.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nuplatform.o",
       "functions": [
         {
           "name": "_ZN10NuPlatform6CreateEv",
@@ -109738,7 +109738,7 @@
     {
       "name": "nu2api/nusound/nu2api_nusound_misc.cpp.o",
       "source": "src/nu2api/nusound/nu2api_nusound_misc.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_misc.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_misc.o",
       "functions": [
         {
           "name": "_Z16edanimSoundPlaceiP7nuvec_s",
@@ -109761,7 +109761,7 @@
     {
       "name": "nu2api/nusound/nu2api_nusound_plain.cpp.o",
       "source": "src/nu2api/nusound/nu2api_nusound_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_plain.o",
       "functions": [
         {
           "name": "SetSoundBitsBySingleId",
@@ -109840,19 +109840,19 @@
     {
       "name": "nu2api/nusound/nu2api_nusound_types.cpp.o",
       "source": "src/nu2api/nusound/nu2api_nusound_types.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_types.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nu2api_nusound_types.o",
       "functions": []
     },
     {
       "name": "nu2api/nusound/nusound.cpp.o",
       "source": "src/nu2api/nusound/nusound.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound.o",
       "functions": []
     },
     {
       "name": "nu2api/nusound/nusound3_include.cpp.o",
       "source": "src/nu2api/nusound/nusound3_include.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound3_include.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound3_include.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound3_include.cpp",
@@ -110179,7 +110179,7 @@
     {
       "name": "nu2api/nusound/nusound_android.cpp.o",
       "source": "src/nu2api/nusound/nusound_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_android.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_android.cpp",
@@ -110306,7 +110306,7 @@
     {
       "name": "nu2api/nusound/nusound_buffer.cpp.o",
       "source": "src/nu2api/nusound/nusound_buffer.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_buffer.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_buffer.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_buffer.cpp",
@@ -110473,7 +110473,7 @@
     {
       "name": "nu2api/nusound/nusound_bus.cpp.o",
       "source": "src/nu2api/nusound/nusound_bus.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_bus.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_bus.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_bus.cpp",
@@ -110608,7 +110608,7 @@
     {
       "name": "nu2api/nusound/nusound_clock.cpp.o",
       "source": "src/nu2api/nusound/nusound_clock.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_clock.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_clock.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_clock.cpp",
@@ -110703,7 +110703,7 @@
     {
       "name": "nu2api/nusound/nusound_decoder.cpp.o",
       "source": "src/nu2api/nusound/nusound_decoder.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_decoder.cpp",
@@ -110950,7 +110950,7 @@
     {
       "name": "nu2api/nusound/nusound_decoder_ogg.cpp.o",
       "source": "src/nu2api/nusound/nusound_decoder_ogg.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder_ogg.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_decoder_ogg.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_decoder_ogg.cpp",
@@ -111117,7 +111117,7 @@
     {
       "name": "nu2api/nusound/nusound_effect.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect.cpp",
@@ -111316,7 +111316,7 @@
     {
       "name": "nu2api/nusound/nusound_effect_doppler.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect_doppler.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_doppler.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_doppler.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect_doppler.cpp",
@@ -111387,7 +111387,7 @@
     {
       "name": "nu2api/nusound/nusound_effect_fader.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect_fader.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_fader.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_fader.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect_fader.cpp",
@@ -111514,7 +111514,7 @@
     {
       "name": "nu2api/nusound/nusound_effect_pitchramp.cpp.o",
       "source": "src/nu2api/nusound/nusound_effect_pitchramp.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_pitchramp.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_effect_pitchramp.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_effect_pitchramp.cpp",
@@ -111601,7 +111601,7 @@
     {
       "name": "nu2api/nusound/nusound_handle.cpp.o",
       "source": "src/nu2api/nusound/nusound_handle.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_handle.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_handle.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_handle.cpp",
@@ -111960,7 +111960,7 @@
     {
       "name": "nu2api/nusound/nusound_listener.cpp.o",
       "source": "src/nu2api/nusound/nusound_listener.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_listener.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_listener.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_listener.cpp",
@@ -112175,7 +112175,7 @@
     {
       "name": "nu2api/nusound/nusound_loader.cpp.o",
       "source": "src/nu2api/nusound/nusound_loader.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_loader.cpp",
@@ -112326,7 +112326,7 @@
     {
       "name": "nu2api/nusound/nusound_loader_ogg.cpp.o",
       "source": "src/nu2api/nusound/nusound_loader_ogg.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_ogg.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_ogg.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_loader_ogg.cpp",
@@ -112669,7 +112669,7 @@
     {
       "name": "nu2api/nusound/nusound_loader_wav.cpp.o",
       "source": "src/nu2api/nusound/nusound_loader_wav.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_wav.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_loader_wav.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_loader_wav.cpp",
@@ -112900,7 +112900,7 @@
     {
       "name": "nu2api/nusound/nusound_memorymanager.cpp.o",
       "source": "src/nu2api/nusound/nusound_memorymanager.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_memorymanager.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_memorymanager.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_memorymanager.cpp",
@@ -113323,7 +113323,7 @@
     {
       "name": "nu2api/nusound/nusound_mixer.cpp.o",
       "source": "src/nu2api/nusound/nusound_mixer.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_mixer.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_mixer.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_mixer.cpp",
@@ -113386,7 +113386,7 @@
     {
       "name": "nu2api/nusound/nusound_plain.cpp.o",
       "source": "src/nu2api/nusound/nusound_plain.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_plain.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_plain.o",
       "functions": [
         {
           "name": "NuSound3InitEx",
@@ -113897,7 +113897,7 @@
     {
       "name": "nu2api/nusound/nusound_routing.cpp.o",
       "source": "src/nu2api/nusound/nusound_routing.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_routing.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_routing.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_routing.cpp",
@@ -113984,7 +113984,7 @@
     {
       "name": "nu2api/nusound/nusound_sample.cpp.o",
       "source": "src/nu2api/nusound/nusound_sample.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_sample.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_sample.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_sample.cpp",
@@ -114183,7 +114183,7 @@
     {
       "name": "nu2api/nusound/nusound_source.cpp.o",
       "source": "src/nu2api/nusound/nusound_source.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_source.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_source.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_source.cpp",
@@ -114294,7 +114294,7 @@
     {
       "name": "nu2api/nusound/nusound_streamer.cpp.o",
       "source": "src/nu2api/nusound/nusound_streamer.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_streamer.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_streamer.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_streamer.cpp",
@@ -114517,7 +114517,7 @@
     {
       "name": "nu2api/nusound/nusound_system.cpp.o",
       "source": "src/nu2api/nusound/nusound_system.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_system.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_system.o",
       "functions": [
         {
           "name": "_Z19NuSound3ExitThreadsv",
@@ -115404,7 +115404,7 @@
     {
       "name": "nu2api/nusound/nusound_voice.cpp.o",
       "source": "src/nu2api/nusound/nusound_voice.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_voice.cpp",
@@ -116059,7 +116059,7 @@
     {
       "name": "nu2api/nusound/nusound_voice_android.cpp.o",
       "source": "src/nu2api/nusound/nusound_voice_android.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice_android.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_voice_android.o",
       "functions": [
         {
           "name": "_GLOBAL__sub_I_nusound_voice_android.cpp",
@@ -116290,7 +116290,7 @@
     {
       "name": "nu2api/nusound/nusound_weakptr.cpp.o",
       "source": "src/nu2api/nusound/nusound_weakptr.cpp",
-      "object": "bazel-out/k8-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_weakptr.o",
+      "object": "bazel-out/darwin_arm64-fastbuild/bin/src/_objs/saga_target_nu2api/nusound_weakptr.o",
       "functions": [
         {
           "name": "_ZN17NuSoundWeakPtrObjI21NuSoundBufferCallbackE4LinkEP22NuSoundWeakPtrListNode",


### PR DESCRIPTION
Updated documentation to the fork of objdiff that @Fabus1184 has been using for recent commits.

This helps stability of reports for new contributors.

Curiously, running this on my machine still seems to have some changes to matching reports relative to main. Less than the `main` branch of the fork, though.